### PR TITLE
Let the iOS SDK handle Delete ops when sent from the server

### DIFF
--- a/Parse/Internal/Object/State/PFObjectState.m
+++ b/Parse/Internal/Object/State/PFObjectState.m
@@ -15,6 +15,7 @@
 #import "PFMutableObjectState.h"
 #import "PFObjectConstants.h"
 #import "PFObjectUtilities.h"
+#import "PFFieldOperation.h"
 
 @implementation PFObjectState
 
@@ -129,7 +130,11 @@
 #pragma mark Accessors
 
 - (void)setServerDataObject:(id)object forKey:(NSString *)key {
-    _serverData[key] = object;
+    if (!object || [object isKindOfClass:[PFDeleteOperation class]]) {
+        [self removeServerDataObjectForKey:key];
+    } else {
+        _serverData[key] = object;
+    }
 }
 
 - (void)removeServerDataObjectForKey:(NSString *)key {

--- a/Tests/Unit/DecoderTests.m
+++ b/Tests/Unit/DecoderTests.m
@@ -45,6 +45,17 @@
     XCTAssertEqualObjects(operation.amount, @100500);
 }
 
+- (void)testDecodingDeleteOperation {
+    PFDecoder *decoder = [[PFDecoder alloc] init];
+
+    NSDictionary *decoded = [decoder decodeObject:@{ @"key" : @{@"__op" : @"Delete"} }];
+    XCTAssertNotNil(decoded);
+
+    id operation = decoded[@"key"];
+    XCTAssertNotNil(operation);
+    PFAssertIsKindOfClass(operation, [PFDeleteOperation class]);
+}
+
 - (void)testDecodingDates {
     PFDecoder *decoder = [[PFDecoder alloc] init];
 

--- a/Tests/Unit/ObjectStateTests.m
+++ b/Tests/Unit/ObjectStateTests.m
@@ -166,6 +166,17 @@
     XCTAssertEqualObjects(mutableState.serverData, @{ @"foo": @"bar" });
 }
 
+- (void)testDeleteFromServerData {
+    PFMutableObjectState *mutableState = [[PFMutableObjectState alloc] init];
+    XCTAssertEqualObjects(mutableState.serverData, @{});
+
+    [mutableState setServerDataObject:@"foo" forKey:@"bar"];
+    XCTAssertEqualObjects(mutableState.serverData, @{ @"bar": @"foo" });
+
+    [mutableState setServerDataObject:[PFDeleteOperation new] forKey:@"bar"];
+    XCTAssertEqualObjects(mutableState.serverData, @{});
+}
+
 - (void)testEncode {
     PFMutableObjectState *mutableState = [[PFMutableObjectState alloc] init];
     mutableState.objectId = @"objectId";


### PR DESCRIPTION
Related to: https://github.com/ParsePlatform/parse-server/pull/1946
Original Issue: https://github.com/ParsePlatform/parse-server/issues/1840

In a nutshell:

When performing an unset in Cloud Code the client SDKs need to perform a fetch in order the synchronize their state which is redundant and can possibly break the SoC. 

On parse.com, the bug is present, and the deleted key is not part of the response. No way to know what really happened on cloud code. 

In parse-server, the server responds with a Delete op on the key. 
When serializing the JSON response, `undefined` keys are stripped out of the generated string.
We could have replaced with `null` but that would also require updates on both SDK's to properly handle nulls. and we don't really love `NSNull` on iOS do we? 
