### PR TITLE
Issue 916:  Deadlock when saving objects with circular references.  L…

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -350,29 +350,31 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 // @param saved A set of objects that we can assume will have been saved.
 // @param error The reason why it can't be serialized.
 - (BOOL)canBeSerializedAfterSaving:(NSMutableArray *)saved withCurrentUser:(PFUser *)user error:(NSError **)error {
+    NSDictionary *dictionaryRepresentationCopy;
     @synchronized (lock) {
-        // This method is only used for batching sets of objects for saveAll
-        // and when saving children automatically. Since it's only used to
-        // determine whether or not save should be called on them, it only
-        // needs to examine their current values, so we use estimatedData.
-        if (![[self class] canBeSerializedAsValue:_estimatedData.dictionaryRepresentation
-                                      afterSaving:saved
-                                            error:error]) {
-            return NO;
-        }
-
-        if ([self isDataAvailableForKey:@"ACL"] &&
-            [[self ACLWithoutCopying] hasUnresolvedUser] &&
-            ![saved containsObject:user]) {
-            if (error) {
-                *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidACL
-                                                 message:@"User associated with ACL must be signed up."];
-            }
-            return NO;
-        }
-
-        return YES;
+        dictionaryRepresentationCopy = _estimatedData.dictionaryRepresentation; // This copies the dictionary representation
     }
+    // This method is only used for batching sets of objects for saveAll
+    // and when saving children automatically. Since it's only used to
+    // determine whether or not save should be called on them, it only
+    // needs to examine their current values, so we use estimatedData.
+    if (![[self class] canBeSerializedAsValue: dictionaryRepresentationCopy
+                                  afterSaving:saved
+                                        error:error]) {
+        return NO;
+    }
+    
+    if ([self isDataAvailableForKey:@"ACL"] &&
+        [[self ACLWithoutCopying] hasUnresolvedUser] &&
+        ![saved containsObject:user]) {
+        if (error) {
+            *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidACL
+                                             message:@"User associated with ACL must be signed up."];
+        }
+        return NO;
+    }
+    
+    return YES;
 }
 
 // This saves all of the objects and files reachable from the given object.

--- a/Parse/Resources/Parse-OSX.Info.plist
+++ b/Parse/Resources/Parse-OSX.Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Parse/Resources/Parse-iOS.Info.plist
+++ b/Parse/Resources/Parse-iOS.Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Parse/Resources/Parse-tvOS.Info.plist
+++ b/Parse/Resources/Parse-tvOS.Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Parse/Resources/Parse-watchOS.Info.plist
+++ b/Parse/Resources/Parse-watchOS.Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
…imited the scope of the lock fixes the issue.

The only relevant change for the fix is the change in PFObject.m.  The PList changes were generated by XCode when I built the project.  
