### PR TITLE
Outputing offending bundle in assert message.

### DIFF
--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
@@ -339,7 +339,7 @@ static NSNumber *PFNumberCreateSafe(const char *typeEncoding, const void *bytes)
 }
 
 - (void)_registerSubclassesInBundle:(NSBundle *)bundle {
-    PFConsistencyAssert(bundle.loaded, @"Cannot register subclasses in a bundle that hasn't been loaded!");
+    PFConsistencyAssert(bundle.loaded, @"Cannot register subclasses in an unloaded bundle: %@", bundle);
 
     const char *executablePath = bundle.executablePath.UTF8String;
     if (executablePath == NULL) {


### PR DESCRIPTION
This will help track down the issue should this assert arrise. See @levigroker’s comments in https://github.com/ParsePlatform/Parse-SDK-iOS-OSX/pull/967
