### PR TITLE
Use getter instead accessing instance variable

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -268,7 +268,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             // Recurse into this object's children looking for dirty children.
             // We only need to look at the child object's current estimated data,
             // because that's the only data that might need to be saved now.
-            toSearch = [object->_estimatedData.dictionaryRepresentation copy];
+            toSearch = [object._estimatedData.dictionaryRepresentation copy];
         }
 
         [self collectDirtyChildren:toSearch


### PR DESCRIPTION
Problem:
Using instance variable outside of object methods leads to crashes when using composition patterns like decorator or proxy with PFObject.
It violate liskov substitution principle and encapsulation of object.

Is there any reason for this?
