### PR TITLE
Removed or replaced the broken links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Join Chat][gitter-svg]][gitter-link]
 
 A library that gives you access to the powerful Parse cloud platform from your iOS or OS X app.
-For more information Parse and its features, see [the blog][blog] and public [documentation][docs].
+For more information about Parse and its features, see [the blog][blog] and public [documentation][docs].
 
 ## Getting Started
 
@@ -90,7 +90,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code. 
 
  [docs]: http://docs.parseplatform.org/ios/guide/
- [blog]: https://blog.parse.com/
+ [blog]: http://blog.parse.com/
 
  [parseui-link]: https://github.com/parse-community/ParseUI-iOS
  [parsefacebookutils-link]: https://github.com/parse-community/ParseFacebookUtils-iOS

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Join Chat][gitter-svg]][gitter-link]
 
 A library that gives you access to the powerful Parse cloud platform from your iOS or OS X app.
-For more information Parse and its features, see [the website][parse.com] and [getting started][docs].
+For more information Parse and its features, see [the blog][blog] and public [documentation][docs].
 
 ## Getting Started
 
@@ -89,8 +89,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code. 
 
- [parse.com]: https://www.parse.com/products/ios
- [docs]: https://www.parse.com/docs/ios/guide
+ [docs]: http://docs.parseplatform.org/ios/guide/
  [blog]: https://blog.parse.com/
 
  [parseui-link]: https://github.com/parse-community/ParseUI-iOS


### PR DESCRIPTION
1. I removed the parse.com link because it redirects to https://parseplatform.github.io which is currently a 404 page.
2. I changed the docs link to the parseplatform.org domain.
3. I changed the blog link from https to http because https doesn't load.