### PR TITLE
⚡️ Release 1.15.0

### DIFF
--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -2536,7 +2536,7 @@
 		96FAF7AF1D84441A00EAB299 /* PFDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 96FAF79F1D8443E300EAB299 /* PFDecoder.m */; };
 		96FAF7B81D84461D00EAB299 /* PFEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 96FAF7B61D84461D00EAB299 /* PFEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96FAF7B91D84461D00EAB299 /* PFEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 96FAF7B71D84461D00EAB299 /* PFEncoder.m */; };
-		96FAF7BA1D84462700EAB299 /* PFEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 96FAF7B61D84461D00EAB299 /* PFEncoder.h */; };
+		96FAF7BA1D84462700EAB299 /* PFEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 96FAF7B61D84461D00EAB299 /* PFEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96FAF7BB1D84462700EAB299 /* PFEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 96FAF7B71D84461D00EAB299 /* PFEncoder.m */; };
 		96FAF7BC1D84462700EAB299 /* PFEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 96FAF7B61D84461D00EAB299 /* PFEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96FAF7BD1D84462700EAB299 /* PFEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 96FAF7B71D84461D00EAB299 /* PFEncoder.m */; };

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -13,7 +13,7 @@
 #pragma mark - SDK Version
 ///--------------------------------------
 
-#define PARSE_VERSION @"1.14.5"
+#define PARSE_VERSION @"1.15.0"
 
 ///--------------------------------------
 #pragma mark - Platform

--- a/Parse/Resources/Parse-OSX.Info.plist
+++ b/Parse/Resources/Parse-OSX.Info.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 </dict>
 </plist>

--- a/Parse/Resources/Parse-iOS.Info.plist
+++ b/Parse/Resources/Parse-iOS.Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/Parse/Resources/Parse-tvOS.Info.plist
+++ b/Parse/Resources/Parse-tvOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Resources/Parse-watchOS.Info.plist
+++ b/Parse/Resources/Parse-watchOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.14.5</string>
+	<string>1.15.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
The PFEncoder.h header was missing from the public folder for the iOS Dynamic Scheme. This fixes it as well as bumps to 1.15.0 to maintain backwards compatibility with LiveQuery Client