### PR TITLE
Fix #1162 - PFSubclassing.object() class method unavailable since XCode 9 beta 4

### DIFF
--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -140,6 +140,22 @@
 
 @end
 
+@interface PFObject ()
+
+/**
+ Constructs an object of the most specific class known to implement `+parseClassName`.
+
+ This method takes care to help `PFObject` subclasses be subclassed themselves.
+ For example, `PFUser.+object` returns a `PFUser` by default but will return an
+ object of a registered subclass instead if one is known.
+ A default implementation is provided by `PFObject` which should always be sufficient.
+
+ @return Returns the object that is instantiated.
+ */
++ (instancetype)object;
+
+@end
+
 @interface PFObject (Private)
 
 /**

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -33,18 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 /**
- Constructs an object of the most specific class known to implement `+parseClassName`.
-
- This method takes care to help `PFObject` subclasses be subclassed themselves.
- For example, `PFUser.+object` returns a `PFUser` by default but will return an
- object of a registered subclass instead if one is known.
- A default implementation is provided by `PFObject` which should always be sufficient.
-
- @return Returns the object that is instantiated.
- */
-+ (instancetype)object;
-
-/**
  Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
  Calling `PFObject.dataAvailable` on this object will return `NO`

--- a/Tests/Unit/ProductTests.m
+++ b/Tests/Unit/ProductTests.m
@@ -9,6 +9,7 @@
 
 #import "PFProduct.h"
 #import "PFUnitTestCase.h"
+#import "PFObjectPrivate.h"
 
 @interface ProductTests : PFUnitTestCase
 

--- a/Tests/Unit/PurchaseUnitTests.m
+++ b/Tests/Unit/PurchaseUnitTests.m
@@ -19,6 +19,7 @@
 #import "PFTestSKProduct.h"
 #import "PFUnitTestCase.h"
 #import "Parse_Private.h"
+#import "PFObjectPrivate.h"
 
 @protocol PurchaseControllerDataSource <PFCommandRunnerProvider, PFFileManagerProvider>
 

--- a/Tests/Unit/UserUnitTests.m
+++ b/Tests/Unit/UserUnitTests.m
@@ -9,6 +9,7 @@
 
 #import "PFUnitTestCase.h"
 #import "PFUser.h"
+#import "PFObjectPrivate.h"
 
 @interface UserUnitTests : PFUnitTestCase
 


### PR DESCRIPTION
The fix essentailly renames the original ``PFSubclassing.object()`` class method to ``PFSubclassing.instantiateObject()`` method with the same semantics to avoid being flagged by XCode 9 beta 4.