### PR TITLE
Fixes issue related to heap corruption

### DIFF
--- a/Parse/Internal/PFEventuallyQueue.h
+++ b/Parse/Internal/PFEventuallyQueue.h
@@ -67,7 +67,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 - (void)start NS_REQUIRES_SUPER;
 - (void)resume NS_REQUIRES_SUPER;
 - (void)pause NS_REQUIRES_SUPER;
-- (void)stop NS_REQUIRES_SUPER;
+- (void)terminate NS_REQUIRES_SUPER;
 - (void)removeAllCommands NS_REQUIRES_SUPER;
 
 @end

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -406,8 +406,8 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     if (connected) {
         dispatch_async(_synchronizationQueue, ^{
             @strongify(self);
-            if (_retryingSemaphore) {
-                dispatch_semaphore_signal(_retryingSemaphore);
+            if (self->_retryingSemaphore) {
+                dispatch_semaphore_signal(self->_retryingSemaphore);
             }
         });
     }

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -80,10 +80,6 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     return self;
 }
 
-- (void)dealloc {
-    [self _stopMonitoringNetworkReachability];
-}
-
 ///--------------------------------------
 #pragma mark - Enqueueing Commands
 ///--------------------------------------
@@ -197,7 +193,8 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     dispatch_suspend(_processingQueueSource);
 }
 
-- (void)stop {
+- (void)terminate {
+    [self _stopMonitoringNetworkReachability];
     dispatch_source_cancel(_processingQueueSource);
 }
 
@@ -392,9 +389,11 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 
 /** Manually sets the network connection status. */
 - (void)setConnected:(BOOL)connected {
+    @weakify(self);
     BFTaskCompletionSource *barrier = [BFTaskCompletionSource taskCompletionSource];
     dispatch_async(_processingQueue, ^{
         dispatch_sync(_synchronizationQueue, ^{
+            @strongify(self);
             if (self.connected != connected) {
                 _connected = connected;
                 if (connected) {
@@ -406,6 +405,7 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     });
     if (connected) {
         dispatch_async(_synchronizationQueue, ^{
+            @strongify(self);
             if (_retryingSemaphore) {
                 dispatch_semaphore_signal(_retryingSemaphore);
             }

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -383,7 +383,6 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     [[PFReachability sharedParseReachability] removeListener:self];
 
     self.monitorsReachability = NO;
-    self.connected = YES;
 #endif
 }
 

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -405,9 +405,8 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     });
     if (connected) {
         dispatch_async(_synchronizationQueue, ^{
-            @strongify(self);
-            if (self->_retryingSemaphore) {
-                dispatch_semaphore_signal(self->_retryingSemaphore);
+            if (_retryingSemaphore) {
+                dispatch_semaphore_signal(_retryingSemaphore);
             }
         });
     }

--- a/Parse/Internal/PFReachability.m
+++ b/Parse/Internal/PFReachability.m
@@ -130,7 +130,9 @@ static void _reachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReac
 }
 
 - (void)removeListener:(id<PFReachabilityListener>)listener {
+    @weakify(listener);
     dispatch_barrier_sync(_synchronizationQueue, ^{
+        @strongify(listener);
         [_listenersArray filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
             id weakObject = [evaluatedObject weakObject];
             return (weakObject == nil || weakObject == listener);

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -181,8 +181,8 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
                 if (commandCache.commandCount > 0) {
                     [commandCache removeAllCommands];
                 }
-                // we won't need it after stop everything...
-                [commandCache stop];
+                // we won't need it after, terminate...
+                [commandCache terminate];
             }
         }
 #endif


### PR DESCRIPTION
- a block was capturing self in dealloc through _stopMonitoring
- this removed the retain cycle at dealloc

Fixes #1168

This wasn't crashing before as `dealloc` was never called (cycle). Now that dealloc is properly called, setting `self.connected = YES` was creating a heap corruption as the blocks were not able to correctly retain `self` for executing the `setConnected:` logic