### PR TITLE
Set bolts back to 1.8.4

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "BoltsFramework/Bolts-ObjC" ~> 1.9
+github "BoltsFramework/Bolts-ObjC" == 1.8.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "BoltsFramework/Bolts-ObjC" "1.9.0"
+github "BoltsFramework/Bolts-ObjC" "1.8.4"
 github "erikdoe/OCMock" "v3.4.1"

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -89,7 +89,7 @@ Pod::Spec.new do |s|
   
     s.libraries        = 'z', 'sqlite3'
   
-    s.dependency 'Bolts/Tasks', '~> 1.9'
+    s.dependency 'Bolts/Tasks', '~> 1.8.4'
   end
 
   s.subspec 'FacebookUtils' do |s|

--- a/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryCollectionViewController/DeletionCollectionViewController.swift
+++ b/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryCollectionViewController/DeletionCollectionViewController.swift
@@ -72,9 +72,9 @@ class DeletionCollectionViewController: PFQueryCollectionViewController, UIAlert
             alertDialog.addAction(UIAlertAction(title: "Save", style: .default) { action in
                 if let title = titleTextField?.text {
                     let object = PFObject(className: self.parseClassName!, dictionary: [ "title": title ])
-                    object.saveEventually().continueOnSuccessWith { _ -> AnyObject! in
+                    object.saveEventually().continue(successBlock: { _ -> AnyObject! in
                         return self.loadObjects()
-                    }
+                    })
                 }
                 })
 
@@ -128,9 +128,9 @@ class DeletionCollectionViewController: PFQueryCollectionViewController, UIAlert
                 dictionary: [ "title": title ]
             )
             
-            object.saveEventually().continueOnSuccessWith { _ -> AnyObject! in
+            object.saveEventually().continue(successBlock: { _ -> AnyObject! in
                 return self.loadObjects()
-            }
+            })
         }
     }
 }

--- a/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryTableViewController/DeletionTableViewController.swift
+++ b/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryTableViewController/DeletionTableViewController.swift
@@ -72,9 +72,9 @@ class DeletionTableViewController: PFQueryTableViewController, UIAlertViewDelega
             alertDialog.addAction(UIAlertAction(title: "Save", style: .default) { _ in
                 if let title = titleTextField.text {
                     let object = PFObject(className: self.parseClassName!, dictionary: [ "title": title ])
-                    object.saveInBackground().continueOnSuccessWith { _ -> AnyObject! in
+                    object.saveInBackground().continue(successBlock: { _ -> AnyObject! in
                         return self.loadObjects()
-                    }
+                    })
                 }
             })
 
@@ -110,9 +110,9 @@ class DeletionTableViewController: PFQueryTableViewController, UIAlertViewDelega
 
         if let title = alertView.textField(at: 0)?.text {
             let object = PFObject(className: self.parseClassName!, dictionary: [ "title": title ])
-            object.saveEventually().continueOnSuccessWith { _ -> AnyObject! in
+            object.saveEventually().continue(successBlock: { _ -> AnyObject! in
                 return self.loadObjects()
-            }
+            })
         }
     }
 }

--- a/Rakefile
+++ b/Rakefile
@@ -351,7 +351,7 @@ namespace :package do
                  package_watchos_name)
 
     Rake::Task['build:parseui:framework'].invoke
-    parseui_framework_path = File.join(build_folder, 'ParseUI.framework')
+    parseui_framework_path = File.join(build_folder, 'iOS', 'ParseUI.framework')
     make_package(release_folder,
                 [parseui_framework_path],
                 package_parseui_name)


### PR DESCRIPTION
Until we have a proper solution for not throwing exceptions within tasks (error passing across the SDK?) We have to properly continue to function without throwing errors.

This reverts bolts to 1.8.4, which still has the task exception handling.