### PR TITLE
Consistency errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: *prepare
       - run: |
             xcrun simctl create "Apple TV 1080p" com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p com.apple.CoreSimulator.SimRuntime.tvOS-11-0
-            bundle exec rake test:deployment
+            bundle exec rake package:release
   jazzy:
     <<: *defaults
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ jobs:
       - xcrun simctl create "Apple TV 1080p" com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p com.apple.CoreSimulator.SimRuntime.tvOS-11-2
       - bundle exec rake test:deployment
       - ./Scripts/jazzy.sh
+      - xcrun simctl create "Apple TV 1080p" com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p com.apple.CoreSimulator.SimRuntime.tvOS-11-0
+      - bundle exec rake package:release
       deploy:
         - provider: releases
           api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Parse-SDK-iOS-OSX Chnagelog
+
+### master
+
+* Fixes NSInternalInconsistencyException handling starting Bolts 1.9.0 by emitting soft NSErrors
+* Fixes issue affecting public getter/setters in PFACL's in Swift (#1083)
+* Prevent deadlocks when saving objects with cicrular references (#916)
+* Prevent deadlocks when running fetchAll with circluar references (#1184)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@
 * Fixes issue affecting public getter/setters in PFACL's in Swift (#1083)
 * Prevent deadlocks when saving objects with cicrular references (#916)
 * Prevent deadlocks when running fetchAll with circluar references (#1184)
+* Adds NSNotification when an invalid session token is encountered
+

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gem 'xcpretty'
 gem 'xcodeproj'
 gem 'cocoapods'
 gem 'jazzy', '~> 0.9.0'
-

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.17.0-alpha.4'
+  s.version          = '1.17.0-alpha.5'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.16.0'
+  s.version          = '1.16.1-alpha.1'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.17.0-alpha.3'
+  s.version          = '1.17.0-alpha.4'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.16.1-alpha.1'
+  s.version          = '1.17.0-alpha.1'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.17.0-alpha.1'
+  s.version          = '1.17.0-alpha.2'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.17.0-alpha.2'
+  s.version          = '1.17.0-alpha.3'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -6826,6 +6826,9 @@
 						LastSwiftMigration = 0900;
 						TestTargetID = 4AE33A0A1F5451AD0088DCA0;
 					};
+					81C09F501AF97A490043B49C = {
+						LastSwiftMigration = 0920;
+					};
 					81C3821B19CCA89E0066284A = {
 						CreatedOnToolsVersion = 6.0.1;
 						LastSwiftMigration = 0830;
@@ -8588,6 +8591,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F55ABB5A1B4F39DA00A0ECD5 /* ParseUnitTests-macOS.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -8595,6 +8599,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F55ABB5A1B4F39DA00A0ECD5 /* ParseUnitTests-macOS.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Parse/Parse/Internal/ACL/PFACLPrivate.h
+++ b/Parse/Parse/Internal/ACL/PFACLPrivate.h
@@ -20,7 +20,7 @@
 /*
  Gets the encoded format for an ACL.
  */
-- (NSDictionary *)encodeIntoDictionary;
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error;
 
 /*
  Creates a new ACL object from an existing dictionary.

--- a/Parse/Parse/Internal/Analytics/Controller/PFAnalyticsController.m
+++ b/Parse/Parse/Internal/Analytics/Controller/PFAnalyticsController.m
@@ -77,7 +77,11 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        NSDictionary *encodedDimensions = [[PFNoObjectEncoder objectEncoder] encodeObject:dimensions];
+        NSError *error;
+        NSDictionary *encodedDimensions = [[PFNoObjectEncoder objectEncoder] encodeObject:dimensions error:&error];
+        if (encodedDimensions == nil && error != nil) {
+            return [BFTask taskWithError:error];
+        }
         PFRESTCommand *command = [PFRESTAnalyticsCommand trackEventCommandWithEventName:name
                                                                              dimensions:encodedDimensions
                                                                            sessionToken:sessionToken];

--- a/Parse/Parse/Internal/Analytics/Controller/PFAnalyticsController.m
+++ b/Parse/Parse/Internal/Analytics/Controller/PFAnalyticsController.m
@@ -79,7 +79,7 @@
         @strongify(self);
         NSError *error;
         NSDictionary *encodedDimensions = [[PFNoObjectEncoder objectEncoder] encodeObject:dimensions error:&error];
-        if (encodedDimensions == nil && error != nil) {
+        if (encodedDimensions == nil) {
             return [BFTask taskWithError:error];
         }
         PFRESTCommand *command = [PFRESTAnalyticsCommand trackEventCommandWithEventName:name

--- a/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
+++ b/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
@@ -47,10 +47,14 @@
     @weakify(self);
     return [[[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        NSDictionary *encodedParameters = [[PFNoObjectEncoder objectEncoder] encodeObject:parameters];
+        NSError *error;
+        NSDictionary *encodedParameters = [[PFNoObjectEncoder objectEncoder] encodeObject:parameters error:&error];
+        PFBailTaskIfError(encodedParameters, error);
         PFRESTCloudCommand *command = [PFRESTCloudCommand commandForFunction:functionName
                                                               withParameters:encodedParameters
-                                                                sessionToken:sessionToken];
+                                                                sessionToken:sessionToken
+                                                                       error:&error];
+        PFBailTaskIfError(command, error);
         return [self.dataSource.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return ((PFCommandResult *)(task.result)).result[@"result"];

--- a/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
+++ b/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
@@ -49,12 +49,12 @@
         @strongify(self);
         NSError *error;
         NSDictionary *encodedParameters = [[PFNoObjectEncoder objectEncoder] encodeObject:parameters error:&error];
-        PFBailTaskIfError(encodedParameters, error);
+        PFPreconditionReturnFailedTask(encodedParameters, error);
         PFRESTCloudCommand *command = [PFRESTCloudCommand commandForFunction:functionName
                                                               withParameters:encodedParameters
                                                                 sessionToken:sessionToken
                                                                        error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.dataSource.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return ((PFCommandResult *)(task.result)).result[@"result"];

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -71,7 +71,8 @@
             } else {
                 parameters = command.parameters;
             }
-            requestParameters = [[PFPointerObjectEncoder objectEncoder] encodeObject:parameters];
+            NSError *error = nil;
+            requestParameters = [[PFPointerObjectEncoder objectEncoder] encodeObject:parameters error:&error];
         }
 
         return [PFHTTPURLRequestConstructor urlRequestWithURL:url

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -73,7 +73,7 @@
             }
             NSError *error = nil;
             requestParameters = [[PFPointerObjectEncoder objectEncoder] encodeObject:parameters error:&error];
-            PFBailTaskIfError(requestParameters, error);
+            PFPreconditionReturnFailedTask(requestParameters, error);
         }
 
         return [PFHTTPURLRequestConstructor urlRequestWithURL:url

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -73,6 +73,7 @@
             }
             NSError *error = nil;
             requestParameters = [[PFPointerObjectEncoder objectEncoder] encodeObject:parameters error:&error];
+            PFBailTaskIfError(requestParameters, error);
         }
 
         return [PFHTTPURLRequestConstructor urlRequestWithURL:url

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -147,7 +147,9 @@
                                    withOptions:(PFCommandRunningOptions)options
                              cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self _performCommandRunningBlock:^id {
-        [command resolveLocalIds];
+        NSError *error;
+        BOOL success = [command resolveLocalIds:&error];
+        PFBailTaskIfError(success, error);
         return [[self.requestConstructor getDataURLRequestAsyncForCommand:command] continueWithSuccessBlock:^id(BFTask <NSURLRequest *>*task) {
             return [_session performDataURLRequestAsync:task.result forCommand:command cancellationToken:cancellationToken];
         }];
@@ -168,7 +170,9 @@
     return [self _performCommandRunningBlock:^id {
         @strongify(self);
 
-        [command resolveLocalIds];
+        NSError *error;
+        BOOL success = [command resolveLocalIds:&error];
+        PFBailTaskIfError(success, error);
         return [[self.requestConstructor getFileUploadURLRequestAsyncForCommand:command
                                                                 withContentType:contentType
                                                           contentSourceFilePath:sourceFilePath] continueWithSuccessBlock:^id(BFTask<NSURLRequest *> *task) {

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -149,7 +149,7 @@
     return [self _performCommandRunningBlock:^id {
         NSError *error;
         BOOL success = [command resolveLocalIds:&error];
-        PFBailTaskIfError(success, error);
+        PFPreconditionReturnFailedTask(success, error);
         return [[self.requestConstructor getDataURLRequestAsyncForCommand:command] continueWithSuccessBlock:^id(BFTask <NSURLRequest *>*task) {
             return [_session performDataURLRequestAsync:task.result forCommand:command cancellationToken:cancellationToken];
         }];
@@ -172,7 +172,7 @@
 
         NSError *error;
         BOOL success = [command resolveLocalIds:&error];
-        PFBailTaskIfError(success, error);
+        PFPreconditionReturnFailedTask(success, error);
         return [[self.requestConstructor getFileUploadURLRequestAsyncForCommand:command
                                                                 withContentType:contentType
                                                           contentSourceFilePath:sourceFilePath] continueWithSuccessBlock:^id(BFTask<NSURLRequest *> *task) {

--- a/Parse/Parse/Internal/Commands/PFRESTAnalyticsCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTAnalyticsCommand.m
@@ -51,11 +51,12 @@ NSString *const PFRESTAnalyticsEventNameCrashReport = @"_CrashReport";
     if (!dictionary[@"at"]) {
         dictionary[@"at"] = [NSDate date];
     }
-
+    // TODO: flovilmart do not swallow error here
     return [self commandWithHTTPPath:httpPath
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:dictionary
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:nil];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTCloudCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTCloudCommand.h
@@ -15,7 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)commandForFunction:(NSString *)function
                     withParameters:(nullable NSDictionary *)parameters
-                      sessionToken:(nullable NSString *)sessionToken;
+                      sessionToken:(nullable NSString *)sessionToken
+                             error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/Internal/Commands/PFRESTCloudCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTCloudCommand.m
@@ -16,12 +16,14 @@
 
 + (instancetype)commandForFunction:(NSString *)function
                     withParameters:(NSDictionary *)parameters
-                      sessionToken:(NSString *)sessionToken {
+                      sessionToken:(NSString *)sessionToken
+                             error:(NSError **)error {
     NSString *path = [NSString stringWithFormat:@"functions/%@", function];
     return [self commandWithHTTPPath:path
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:parameters
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:error];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTCommand.h
@@ -32,13 +32,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)commandWithHTTPPath:(NSString *)path
                          httpMethod:(NSString *)httpMethod
                          parameters:(nullable NSDictionary *)parameters
-                       sessionToken:(nullable NSString *)sessionToken;
+                       sessionToken:(nullable NSString *)sessionToken
+                              error:(NSError **)error;
 
 + (instancetype)commandWithHTTPPath:(NSString *)path
                          httpMethod:(NSString *)httpMethod
                          parameters:(nullable NSDictionary *)parameters
                    operationSetUUID:(nullable NSString *)operationSetIdentifier
-                       sessionToken:(nullable NSString *)sessionToken;
+                       sessionToken:(nullable NSString *)sessionToken
+                              error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/Internal/Commands/PFRESTCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTCommand.m
@@ -225,7 +225,7 @@ static const int PFRESTCommandCacheKeyParseAPIVersion = 2;
 
     if ([[self class] forEachLocalIdIn:data doBlock:block]) {
         self.parameters = [[PFPointerOrLocalIdObjectEncoder objectEncoder] encodeObject:data error:error];
-        if (!self.parameters) {
+        if (!self.parameters && error && *error) {
             return NO;
         }
     }

--- a/Parse/Parse/Internal/Commands/PFRESTCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTCommand.m
@@ -235,17 +235,13 @@ static const int PFRESTCommandCacheKeyParseAPIVersion = 2;
         return YES;
     }
     BOOL modified = NO;
-    BOOL success = [[self class] forEachLocalIdIn:data doBlock:block modified:&modified error:error];
-    if (!success) {
-        return NO;
-    }
-    if (success) {
+    if ([[self class] forEachLocalIdIn:data doBlock:block modified:&modified error:error]) {
         self.parameters = [[PFPointerOrLocalIdObjectEncoder objectEncoder] encodeObject:data error:error];
-        if (!self.parameters && error && *error) {
-            return NO;
+        if (self.parameters && !(error && *error)) {
+            return YES;
         }
     }
-    return YES;
+    return NO;
 }
 
 - (BOOL)resolveLocalIds:(NSError * __autoreleasing *)error {

--- a/Parse/Parse/Internal/Commands/PFRESTCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTCommand.m
@@ -124,7 +124,7 @@ static const int PFRESTCommandCacheKeyParseAPIVersion = 2;
     }
     if (self.parameters) {
         NSDictionary *parameters = [[PFPointerOrLocalIdObjectEncoder objectEncoder] encodeObject:self.parameters error:error];
-        if (!parameters && error) {
+        if (!parameters) {
             return nil;
         }
         dictionary[PFRESTCommandParametersEncodingKey] = parameters;
@@ -225,7 +225,7 @@ static const int PFRESTCommandCacheKeyParseAPIVersion = 2;
 
     if ([[self class] forEachLocalIdIn:data doBlock:block]) {
         self.parameters = [[PFPointerOrLocalIdObjectEncoder objectEncoder] encodeObject:data error:error];
-        if (!self.parameters && error) {
+        if (!self.parameters) {
             return NO;
         }
     }

--- a/Parse/Parse/Internal/Commands/PFRESTConfigCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTConfigCommand.m
@@ -18,7 +18,8 @@
     return [self commandWithHTTPPath:@"config"
                           httpMethod:PFHTTPRequestMethodGET
                           parameters:nil
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:nil];
 }
 
 + (instancetype)configUpdateCommandWithConfigParameters:(NSDictionary *)parameters
@@ -27,7 +28,8 @@
     return [self commandWithHTTPPath:@"config"
                           httpMethod:PFHTTPRequestMethodPUT
                           parameters:commandParameters
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:nil];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTFileCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTFileCommand.m
@@ -23,7 +23,8 @@
     return [self commandWithHTTPPath:httpPath
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:nil
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:nil];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTObjectBatchCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTObjectBatchCommand.h
@@ -19,7 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)batchCommandWithCommands:(NSArray<PFRESTCommand *> *)commands
                             sessionToken:(nullable NSString *)sessionToken
-                               serverURL:(NSURL *)serverURL;
+                               serverURL:(NSURL *)serverURL
+                                   error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/Internal/Commands/PFRESTObjectBatchCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTObjectBatchCommand.m
@@ -19,7 +19,8 @@ NSUInteger const PFRESTObjectBatchCommandSubcommandsLimit = 50;
 
 + (nonnull instancetype)batchCommandWithCommands:(nonnull NSArray<PFRESTCommand *> *)commands
                                     sessionToken:(nullable NSString *)sessionToken
-                                       serverURL:(nonnull NSURL *)serverURL {
+                                       serverURL:(nonnull NSURL *)serverURL
+                                           error:(NSError **)error {
     PFParameterAssert(commands.count <= PFRESTObjectBatchCommandSubcommandsLimit,
                       @"Max of %d commands are allowed in a single batch command",
                       (int)PFRESTObjectBatchCommandSubcommandsLimit);
@@ -40,7 +41,8 @@ NSUInteger const PFRESTObjectBatchCommandSubcommandsLimit = 50;
     return [self commandWithHTTPPath:@"batch"
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:@{ @"requests" : requests }
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:error];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTObjectCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTObjectCommand.m
@@ -24,7 +24,8 @@
     PFRESTObjectCommand *command = [self commandWithHTTPPath:httpPath
                                                   httpMethod:PFHTTPRequestMethodGET
                                                   parameters:nil
-                                                sessionToken:sessionToken];
+                                                sessionToken:sessionToken
+                                                       error:nil];
     return command;
 }
 
@@ -39,7 +40,8 @@
                                                   httpMethod:PFHTTPRequestMethodPOST
                                                   parameters:changes
                                             operationSetUUID:operationSetIdentifier
-                                                sessionToken:sessionToken];
+                                                sessionToken:sessionToken
+                                                       error:nil];
     return command;
 }
 
@@ -55,7 +57,8 @@
                                                   httpMethod:PFHTTPRequestMethodPUT
                                                   parameters:changes
                                             operationSetUUID:operationSetIdentifier
-                                                sessionToken:sessionToken];
+                                                sessionToken:sessionToken
+                                                       error:nil];
     return command;
 }
 
@@ -70,7 +73,8 @@
     PFRESTObjectCommand *command = [self commandWithHTTPPath:httpPath
                                                   httpMethod:PFHTTPRequestMethodDELETE
                                                   parameters:nil
-                                                sessionToken:sessionToken];
+                                                sessionToken:sessionToken
+                                                       error:nil];
     return command;
 }
 

--- a/Parse/Parse/Internal/Commands/PFRESTPushCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTPushCommand.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFRESTPushCommand : PFRESTCommand
 
 + (instancetype)sendPushCommandWithPushState:(PFPushState *)state
-                                sessionToken:(nullable NSString *)sessionToken;
+                                sessionToken:(nullable NSString *)sessionToken
+                                       error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/Internal/Commands/PFRESTPushCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTPushCommand.m
@@ -20,11 +20,15 @@
 @implementation PFRESTPushCommand
 
 + (instancetype)sendPushCommandWithPushState:(PFPushState *)state
-                                sessionToken:(NSString *)sessionToken {
+                                sessionToken:(NSString *)sessionToken
+                                       error:(NSError **)error {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 
     if (state.queryState) {
-        NSDictionary *queryParameters = [PFRESTQueryCommand findCommandParametersForQueryState:state.queryState];
+        NSDictionary *queryParameters = [PFRESTQueryCommand findCommandParametersForQueryState:state.queryState error:error];
+        if (!queryParameters && error) {
+            return nil;
+        }
         parameters[@"where"] = queryParameters[@"where"];
     } else {
         if (state.channels) {
@@ -55,7 +59,8 @@
     return [self commandWithHTTPPath:@"push"
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:parameters
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:error];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTPushCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTPushCommand.m
@@ -26,7 +26,7 @@
 
     if (state.queryState) {
         NSDictionary *queryParameters = [PFRESTQueryCommand findCommandParametersForQueryState:state.queryState error:error];
-        if (!queryParameters && error) {
+        if (!queryParameters) {
             return nil;
         }
         parameters[@"where"] = queryParameters[@"where"];

--- a/Parse/Parse/Internal/Commands/PFRESTQueryCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTQueryCommand.h
@@ -19,38 +19,44 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Find
 ///--------------------------------------
 
-+ (instancetype)findCommandForQueryState:(PFQueryState *)queryState withSessionToken:(nullable NSString *)sessionToken;
++ (nullable instancetype)findCommandForQueryState:(PFQueryState *)queryState
+                                 withSessionToken:(nullable NSString *)sessionToken
+                                            error:(NSError **)error;
 
-+ (instancetype)findCommandForClassWithName:(NSString *)className
-                                      order:(nullable NSString *)order
-                                 conditions:(nullable NSDictionary *)conditions
-                               selectedKeys:(nullable NSSet *)selectedKeys
-                               includedKeys:(nullable NSSet *)includedKeys
-                                      limit:(NSInteger)limit
-                                       skip:(NSInteger)skip
-                               extraOptions:(nullable NSDictionary *)extraOptions
-                             tracingEnabled:(BOOL)trace
-                               sessionToken:(nullable NSString *)sessionToken;
++ (nullable instancetype)findCommandForClassWithName:(NSString *)className
+                                               order:(nullable NSString *)order
+                                          conditions:(nullable NSDictionary *)conditions
+                                        selectedKeys:(nullable NSSet *)selectedKeys
+                                        includedKeys:(nullable NSSet *)includedKeys
+                                               limit:(NSInteger)limit
+                                                skip:(NSInteger)skip
+                                        extraOptions:(nullable NSDictionary *)extraOptions
+                                      tracingEnabled:(BOOL)trace
+                                        sessionToken:(nullable NSString *)sessionToken
+                                               error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - Count
 ///--------------------------------------
 
-+ (instancetype)countCommandFromFindCommand:(PFRESTQueryCommand *)findCommand;
++ (nullable instancetype)countCommandFromFindCommand:(PFRESTQueryCommand *)findCommand
+                                               error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - Parameters
 ///--------------------------------------
 
-+ (NSDictionary *)findCommandParametersForQueryState:(PFQueryState *)queryState;
-+ (NSDictionary *)findCommandParametersWithOrder:(nullable NSString *)order
-                                      conditions:(nullable NSDictionary *)conditions
-                                    selectedKeys:(nullable NSSet *)selectedKeys
-                                    includedKeys:(nullable NSSet *)includedKeys
-                                           limit:(NSInteger)limit
-                                            skip:(NSInteger)skip
-                                    extraOptions:(nullable NSDictionary *)extraOptions
-                                  tracingEnabled:(BOOL)trace;
++ (nullable NSDictionary *)findCommandParametersForQueryState:(PFQueryState *)queryState
+                                                        error:(NSError **)error;
++ (nullable NSDictionary *)findCommandParametersWithOrder:(nullable NSString *)order
+                                               conditions:(nullable NSDictionary *)conditions
+                                             selectedKeys:(nullable NSSet *)selectedKeys
+                                             includedKeys:(nullable NSSet *)includedKeys
+                                                    limit:(NSInteger)limit
+                                                     skip:(NSInteger)skip
+                                             extraOptions:(nullable NSDictionary *)extraOptions
+                                           tracingEnabled:(BOOL)trace
+                                                    error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -22,23 +22,26 @@
 #pragma mark - Find
 ///--------------------------------------
 
-+ (instancetype)findCommandForQueryState:(PFQueryState *)queryState withSessionToken:(NSString *)sessionToken {
-    NSDictionary *parameters = [self findCommandParametersForQueryState:queryState];
++ (nullable instancetype)findCommandForQueryState:(PFQueryState *)queryState withSessionToken:(NSString *)sessionToken error:(NSError **)error {
+    NSDictionary *parameters = [self findCommandParametersForQueryState:queryState error:error];
+    PFBailIfError(parameters, error, nil);
     return [self _findCommandForClassWithName:queryState.parseClassName
                                    parameters:parameters
-                                 sessionToken:sessionToken];
+                                 sessionToken:sessionToken
+                                        error:error];
 }
 
-+ (instancetype)findCommandForClassWithName:(NSString *)className
-                                      order:(NSString *)order
-                                 conditions:(NSDictionary *)conditions
-                               selectedKeys:(NSSet *)selectedKeys
-                               includedKeys:(NSSet *)includedKeys
-                                      limit:(NSInteger)limit
-                                       skip:(NSInteger)skip
-                               extraOptions:(NSDictionary *)extraOptions
-                             tracingEnabled:(BOOL)trace
-                               sessionToken:(NSString *)sessionToken {
++ (nullable instancetype)findCommandForClassWithName:(NSString *)className
+                                              order:(NSString *)order
+                                         conditions:(NSDictionary *)conditions
+                                       selectedKeys:(NSSet *)selectedKeys
+                                       includedKeys:(NSSet *)includedKeys
+                                              limit:(NSInteger)limit
+                                               skip:(NSInteger)skip
+                                       extraOptions:(NSDictionary *)extraOptions
+                                     tracingEnabled:(BOOL)trace
+                                       sessionToken:(NSString *)sessionToken
+                                              error:(NSError **)error {
     NSDictionary *parameters = [self findCommandParametersWithOrder:order
                                                          conditions:conditions
                                                        selectedKeys:selectedKeys
@@ -46,20 +49,26 @@
                                                               limit:limit
                                                                skip:skip
                                                        extraOptions:extraOptions
-                                                     tracingEnabled:trace];
+                                                     tracingEnabled:trace
+                                                              error:error];
+    PFBailIfError(parameters, error, nil);
     return [self _findCommandForClassWithName:className
                                    parameters:parameters
-                                 sessionToken:sessionToken];
+                                 sessionToken:sessionToken
+                                        error:error];
 }
 
-+ (instancetype)_findCommandForClassWithName:(NSString *)className
++ (nullable instancetype)_findCommandForClassWithName:(NSString *)className
                                   parameters:(NSDictionary *)parameters
-                                sessionToken:(NSString *)sessionToken {
+                                sessionToken:(NSString *)sessionToken
+                                       error:(NSError **)error {
     NSString *httpPath = [NSString stringWithFormat:@"classes/%@", className];
     PFRESTQueryCommand *command = [self commandWithHTTPPath:httpPath
                                                  httpMethod:PFHTTPRequestMethodGET
                                                  parameters:parameters
-                                               sessionToken:sessionToken];
+                                               sessionToken:sessionToken
+                                                      error:error];
+    PFBailIfError(command, error, nil);
     return command;
 }
 
@@ -67,7 +76,7 @@
 #pragma mark - Count
 ///--------------------------------------
 
-+ (instancetype)countCommandFromFindCommand:(PFRESTQueryCommand *)findCommand {
++ (nullable instancetype)countCommandFromFindCommand:(PFRESTQueryCommand *)findCommand error:(NSError **)error {
     NSMutableDictionary *parameters = [findCommand.parameters mutableCopy];
     parameters[@"count"] = @"1";
     parameters[@"limit"] = @"0"; // Set the limit to 0, as we are not interested in results at all.
@@ -76,14 +85,15 @@
     return [self commandWithHTTPPath:findCommand.httpPath
                           httpMethod:findCommand.httpMethod
                           parameters:[parameters copy]
-                        sessionToken:findCommand.sessionToken];
+                        sessionToken:findCommand.sessionToken
+                               error:error];
 }
 
 ///--------------------------------------
 #pragma mark - Parameters
 ///--------------------------------------
 
-+ (NSDictionary *)findCommandParametersForQueryState:(PFQueryState *)queryState {
++ (nullable NSDictionary *)findCommandParametersForQueryState:(PFQueryState *)queryState error:(NSError **)error {
     return [self findCommandParametersWithOrder:queryState.sortOrderString
                                      conditions:queryState.conditions
                                    selectedKeys:queryState.selectedKeys
@@ -91,17 +101,19 @@
                                           limit:queryState.limit
                                            skip:queryState.skip
                                    extraOptions:queryState.extraOptions
-                                 tracingEnabled:queryState.trace];
+                                 tracingEnabled:queryState.trace
+                                          error:error];
 }
 
-+ (NSDictionary *)findCommandParametersWithOrder:(NSString *)order
++ (nullable NSDictionary *)findCommandParametersWithOrder:(NSString *)order
                                       conditions:(NSDictionary *)conditions
                                     selectedKeys:(NSSet *)selectedKeys
                                     includedKeys:(NSSet *)includedKeys
                                            limit:(NSInteger)limit
                                             skip:(NSInteger)skip
                                     extraOptions:(NSDictionary *)extraOptions
-                                  tracingEnabled:(BOOL)trace {
+                                  tracingEnabled:(BOOL)trace
+                                           error:(NSError **)error {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 
     if (order.length) {
@@ -131,6 +143,8 @@
         parameters[key] = obj;
     }];
 
+    __block BOOL encodingHasErrored = NO;
+    __block NSError *encodingError;
     if (conditions.count > 0) {
         NSMutableDictionary *whereData = [[NSMutableDictionary alloc] init];
         [conditions enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -152,7 +166,13 @@
                                                                              limit:subquery.state.limit
                                                                               skip:subquery.state.skip
                                                                       extraOptions:nil
-                                                                    tracingEnabled:NO];
+                                                                    tracingEnabled:NO
+                                                                             error:&encodingError];
+                    if (!queryDict && encodingError) {
+                        *stop = true;
+                        encodingHasErrored = true;
+                        return;
+                    }
 
                     queryDict = queryDict[@"where"];
                     if (queryDict.count > 0) {
@@ -163,42 +183,74 @@
                 }
                 whereData[key] = newArray;
             } else {
-                id object = [self _encodeSubqueryIfNeeded:obj];
-                whereData[key] = [[PFPointerObjectEncoder objectEncoder] encodeObject:object];
+                id object = [self _encodeSubqueryIfNeeded:obj error:&encodingError];
+                if (!object && encodingError) {
+                    *stop = true;
+                    encodingHasErrored = true;
+                    return;
+                }
+                id pointer = [[PFPointerObjectEncoder objectEncoder] encodeObject:object error:&encodingError];
+                if (!pointer && encodingError) {
+                    *stop = true;
+                    encodingHasErrored = true;
+                    return;
+                }
+                whereData[key] = pointer;
             }
         }];
 
         parameters[@"where"] = whereData;
     }
+    if (encodingHasErrored && encodingError) {
+        *error = encodingError;
+        return nil;
+    }
 
     return parameters;
 }
 
-+ (id)_encodeSubqueryIfNeeded:(id)object {
++ (nullable id)_encodeSubqueryIfNeeded:(id)object error:(NSError **)error {
     if (![object isKindOfClass:[NSDictionary class]]) {
         return object;
     }
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithCapacity:[object count]];
+    __block BOOL hadFailed = NO;
+    __block NSError *commandEncodingError = nil;
     [object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         if ([obj isKindOfClass:[PFQuery class]]) {
             PFQuery *subquery = (PFQuery *)obj;
-            NSMutableDictionary *subqueryParameters = [[self findCommandParametersWithOrder:subquery.state.sortOrderString
-                                                                                 conditions:subquery.state.conditions
-                                                                               selectedKeys:subquery.state.selectedKeys
-                                                                               includedKeys:subquery.state.includedKeys
-                                                                                      limit:subquery.state.limit
-                                                                                       skip:subquery.state.skip
-                                                                               extraOptions:subquery.state.extraOptions
-                                                                             tracingEnabled:NO] mutableCopy];
+            NSDictionary *command = [self findCommandParametersWithOrder:subquery.state.sortOrderString
+                                                              conditions:subquery.state.conditions
+                                                            selectedKeys:subquery.state.selectedKeys
+                                                            includedKeys:subquery.state.includedKeys
+                                                                    limit:subquery.state.limit
+                                                                    skip:subquery.state.skip
+                                                            extraOptions:subquery.state.extraOptions
+                                                          tracingEnabled:NO
+                                                                   error:&commandEncodingError];
+            if (!command && commandEncodingError) {
+                hadFailed = YES;
+                *stop = YES;
+                return;
+            }
+            NSMutableDictionary *subqueryParameters = [command mutableCopy];
             subqueryParameters[@"className"] = subquery.parseClassName;
             obj = subqueryParameters;
         } else if ([obj isKindOfClass:[NSDictionary class]]) {
-            obj = [self _encodeSubqueryIfNeeded:obj];
+            obj = [self _encodeSubqueryIfNeeded:obj error:&commandEncodingError];
+            if (!obj && commandEncodingError) {
+                hadFailed = YES;
+                *stop = YES;
+                return;
+            }
         }
-
         parameters[key] = obj;
     }];
+    if (hadFailed && commandEncodingError) {
+        *error = commandEncodingError;
+        return nil;
+    }
     return parameters;
 }
 

--- a/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -24,7 +24,7 @@
 
 + (nullable instancetype)findCommandForQueryState:(PFQueryState *)queryState withSessionToken:(NSString *)sessionToken error:(NSError **)error {
     NSDictionary *parameters = [self findCommandParametersForQueryState:queryState error:error];
-    PFBailIfError(parameters, error, nil);
+    PFPreconditionBailOnError(parameters, error, nil);
     return [self _findCommandForClassWithName:queryState.parseClassName
                                    parameters:parameters
                                  sessionToken:sessionToken
@@ -51,7 +51,7 @@
                                                        extraOptions:extraOptions
                                                      tracingEnabled:trace
                                                               error:error];
-    PFBailIfError(parameters, error, nil);
+    PFPreconditionBailOnError(parameters, error, nil);
     return [self _findCommandForClassWithName:className
                                    parameters:parameters
                                  sessionToken:sessionToken
@@ -68,7 +68,7 @@
                                                  parameters:parameters
                                                sessionToken:sessionToken
                                                       error:error];
-    PFBailIfError(command, error, nil);
+    PFPreconditionBailOnError(command, error, nil);
     return command;
 }
 

--- a/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -209,7 +209,7 @@
     return parameters;
 }
 
-+ (nullable id)_encodeSubqueryIfNeeded:(id)object error:(NSError **)error {
++ (nullable id)_encodeSubqueryIfNeeded:(id)object error:(NSError * __autoreleasing *)error {
     if (![object isKindOfClass:[NSDictionary class]]) {
         return object;
     }

--- a/Parse/Parse/Internal/Commands/PFRESTSessionCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTSessionCommand.m
@@ -17,7 +17,8 @@
     return [self commandWithHTTPPath:@"sessions/me"
                           httpMethod:PFHTTPRequestMethodGET
                           parameters:nil
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:nil];
 }
 
 @end

--- a/Parse/Parse/Internal/Commands/PFRESTUserCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTUserCommand.h
@@ -21,13 +21,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)logInUserCommandWithUsername:(NSString *)username
                                     password:(NSString *)password
-                            revocableSession:(BOOL)revocableSessionEnabled;
+                            revocableSession:(BOOL)revocableSessionEnabled
+                                       error:(NSError **)error;
 + (instancetype)serviceLoginUserCommandWithAuthenticationType:(NSString *)authenticationType
                                            authenticationData:(NSDictionary *)authenticationData
-                                             revocableSession:(BOOL)revocableSessionEnabled;
+                                             revocableSession:(BOOL)revocableSessionEnabled
+                                                        error:(NSError **)error;
 + (instancetype)serviceLoginUserCommandWithParameters:(NSDictionary *)parameters
                                      revocableSession:(BOOL)revocableSessionEnabled
-                                         sessionToken:(nullable NSString *)sessionToken;
+                                         sessionToken:(nullable NSString *)sessionToken
+                                                error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - Sign Up
@@ -35,21 +38,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)signUpUserCommandWithParameters:(NSDictionary *)parameters
                                revocableSession:(BOOL)revocableSessionEnabled
-                                   sessionToken:(nullable NSString *)sessionToken;
+                                   sessionToken:(nullable NSString *)sessionToken
+                                          error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - Current User
 ///--------------------------------------
 
-+ (instancetype)getCurrentUserCommandWithSessionToken:(NSString *)sessionToken;
-+ (instancetype)upgradeToRevocableSessionCommandWithSessionToken:(NSString *)sessionToken;
-+ (instancetype)logOutUserCommandWithSessionToken:(NSString *)sessionToken;
++ (instancetype)getCurrentUserCommandWithSessionToken:(NSString *)sessionToken error:(NSError **)error;
++ (instancetype)upgradeToRevocableSessionCommandWithSessionToken:(NSString *)sessionToken error:(NSError **)error;
++ (instancetype)logOutUserCommandWithSessionToken:(NSString *)sessionToken error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - Password Rest
 ///--------------------------------------
 
-+ (instancetype)resetPasswordCommandForUserWithEmail:(NSString *)email;
++ (instancetype)resetPasswordCommandForUserWithEmail:(NSString *)email error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/Internal/Commands/PFRESTUserCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTUserCommand.m
@@ -38,7 +38,7 @@ static NSString *const PFRESTUserCommandRevocableSessionHeaderEnabledValue = @"1
                                                 parameters:parameters
                                               sessionToken:sessionToken
                                                      error:error];
-    PFBailIfError(command, error, nil);
+    PFPreconditionBailOnError(command, error, nil);
     if (revocableSessionEnabled) {
         command.additionalRequestHeaders = @{ PFRESTUserCommandRevocableSessionHeader :
                                                   PFRESTUserCommandRevocableSessionHeaderEnabledValue};

--- a/Parse/Parse/Internal/Commands/PFRESTUserCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTUserCommand.m
@@ -31,11 +31,14 @@ static NSString *const PFRESTUserCommandRevocableSessionHeaderEnabledValue = @"1
                           httpMethod:(NSString *)httpMethod
                           parameters:(NSDictionary *)parameters
                         sessionToken:(NSString *)sessionToken
-                    revocableSession:(BOOL)revocableSessionEnabled {
+                    revocableSession:(BOOL)revocableSessionEnabled
+                               error:(NSError **) error {
     PFRESTUserCommand *command = [self commandWithHTTPPath:path
                                                 httpMethod:httpMethod
                                                 parameters:parameters
-                                              sessionToken:sessionToken];
+                                              sessionToken:sessionToken
+                                                     error:error];
+    PFBailIfError(command, error, nil);
     if (revocableSessionEnabled) {
         command.additionalRequestHeaders = @{ PFRESTUserCommandRevocableSessionHeader :
                                                   PFRESTUserCommandRevocableSessionHeaderEnabledValue};
@@ -50,33 +53,39 @@ static NSString *const PFRESTUserCommandRevocableSessionHeaderEnabledValue = @"1
 
 + (instancetype)logInUserCommandWithUsername:(NSString *)username
                                     password:(NSString *)password
-                            revocableSession:(BOOL)revocableSessionEnabled {
+                            revocableSession:(BOOL)revocableSessionEnabled
+                                       error:(NSError **) error {
     NSDictionary *parameters = @{ @"username" : username,
                                   @"password" : password };
     return [self _commandWithHTTPPath:@"login"
                            httpMethod:PFHTTPRequestMethodGET
                            parameters:parameters
                          sessionToken:nil
-                     revocableSession:revocableSessionEnabled];
+                     revocableSession:revocableSessionEnabled
+                                error:error];
 }
 
 + (instancetype)serviceLoginUserCommandWithAuthenticationType:(NSString *)authenticationType
                                            authenticationData:(NSDictionary *)authenticationData
-                                             revocableSession:(BOOL)revocableSessionEnabled {
+                                             revocableSession:(BOOL)revocableSessionEnabled
+                                                        error:(NSError **)error {
     NSDictionary *parameters = @{ @"authData" : @{ authenticationType : authenticationData } };
     return [self serviceLoginUserCommandWithParameters:parameters
                                       revocableSession:revocableSessionEnabled
-                                          sessionToken:nil];
+                                          sessionToken:nil
+                                                 error:error];
 }
 
 + (instancetype)serviceLoginUserCommandWithParameters:(NSDictionary *)parameters
                                      revocableSession:(BOOL)revocableSessionEnabled
-                                         sessionToken:(NSString *)sessionToken {
+                                         sessionToken:(NSString *)sessionToken
+                                                error:(NSError **)error {
     return [self _commandWithHTTPPath:@"users"
                            httpMethod:PFHTTPRequestMethodPOST
                            parameters:parameters
                          sessionToken:sessionToken
-                     revocableSession:revocableSessionEnabled];
+                     revocableSession:revocableSessionEnabled
+                                error:error];
 }
 
 ///--------------------------------------
@@ -85,48 +94,54 @@ static NSString *const PFRESTUserCommandRevocableSessionHeaderEnabledValue = @"1
 
 + (instancetype)signUpUserCommandWithParameters:(NSDictionary *)parameters
                                revocableSession:(BOOL)revocableSessionEnabled
-                                   sessionToken:(NSString *)sessionToken {
+                                   sessionToken:(NSString *)sessionToken
+                                          error:(NSError **)error {
     return [self _commandWithHTTPPath:@"users"
                            httpMethod:PFHTTPRequestMethodPOST
                            parameters:parameters
                          sessionToken:sessionToken
-                     revocableSession:revocableSessionEnabled];
+                     revocableSession:revocableSessionEnabled
+                                error:error];
 }
 
 ///--------------------------------------
 #pragma mark - Current User
 ///--------------------------------------
 
-+ (instancetype)getCurrentUserCommandWithSessionToken:(NSString *)sessionToken {
++ (instancetype)getCurrentUserCommandWithSessionToken:(NSString *)sessionToken error:(NSError **)error {
     return [self commandWithHTTPPath:@"users/me"
                           httpMethod:PFHTTPRequestMethodGET
                           parameters:nil
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:error];
 }
 
-+ (instancetype)upgradeToRevocableSessionCommandWithSessionToken:(NSString *)sessionToken {
++ (instancetype)upgradeToRevocableSessionCommandWithSessionToken:(NSString *)sessionToken error:(NSError **)error {
     return [self commandWithHTTPPath:@"upgradeToRevocableSession"
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:nil
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:error];
 }
 
-+ (instancetype)logOutUserCommandWithSessionToken:(NSString *)sessionToken {
++ (instancetype)logOutUserCommandWithSessionToken:(NSString *)sessionToken error:(NSError **)error {
     return [self commandWithHTTPPath:@"logout"
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:nil
-                        sessionToken:sessionToken];
+                        sessionToken:sessionToken
+                               error:error];
 }
 
 ///--------------------------------------
 #pragma mark - Additional User Commands
 ///--------------------------------------
 
-+ (instancetype)resetPasswordCommandForUserWithEmail:(NSString *)email {
++ (instancetype)resetPasswordCommandForUserWithEmail:(NSString *)email error:(NSError **)error {
     return [self commandWithHTTPPath:@"requestPasswordReset"
                           httpMethod:PFHTTPRequestMethodPOST
                           parameters:@{ @"email" : email }
-                        sessionToken:nil];
+                        sessionToken:nil
+                               error:error];
 }
 
 @end

--- a/Parse/Parse/Internal/Config/Controller/PFCurrentConfigController.m
+++ b/Parse/Parse/Internal/Config/Controller/PFCurrentConfigController.m
@@ -74,7 +74,7 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
         NSDictionary *configParameters = @{ PFConfigParametersRESTKey : (config.parametersDictionary ?: @{}) };
         NSError *error;
         id encodedObject = [[PFPointerObjectEncoder objectEncoder] encodeObject:configParameters error:&error];
-        if (!encodedObject && error) {
+        if (!encodedObject) {
             return [BFTask taskWithError:error];
         }
         NSData *jsonData = [PFJSONSerialization dataFromJSONObject:encodedObject];

--- a/Parse/Parse/Internal/Config/Controller/PFCurrentConfigController.m
+++ b/Parse/Parse/Internal/Config/Controller/PFCurrentConfigController.m
@@ -72,7 +72,11 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
         _currentConfig = config;
 
         NSDictionary *configParameters = @{ PFConfigParametersRESTKey : (config.parametersDictionary ?: @{}) };
-        id encodedObject = [[PFPointerObjectEncoder objectEncoder] encodeObject:configParameters];
+        NSError *error;
+        id encodedObject = [[PFPointerObjectEncoder objectEncoder] encodeObject:configParameters error:&error];
+        if (!encodedObject && error) {
+            return [BFTask taskWithError:error];
+        }
         NSData *jsonData = [PFJSONSerialization dataFromJSONObject:encodedObject];
         return [[self _getPersistenceGroupAsync] continueWithSuccessBlock:^id(BFTask<id<PFPersistenceGroup>> *task) {
             return [task.result setDataAsync:jsonData forKey:PFConfigCurrentConfigFileName_];

--- a/Parse/Parse/Internal/FieldOperation/PFFieldOperation.h
+++ b/Parse/Parse/Internal/FieldOperation/PFFieldOperation.h
@@ -33,7 +33,7 @@
  @param objectEncoder encoder that will be used to encode the object.
  @return An object to be jsonified.
  */
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder;
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error;
 
 /**
  Returns a field operation that is composed of a previous operation followed by

--- a/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -452,7 +452,7 @@
     NSMutableArray *array = [NSMutableArray arrayWithCapacity:set.count];
     for (PFObject *object in set) {
         id encodedDict = [objectEncoder encodeObject:object error:error];
-        PFBailIfError(encodedDict, error, nil);
+        PFPreconditionBailOnError(encodedDict, error, nil);
         [array addObject:encodedDict];
     }
     return array;

--- a/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -193,7 +193,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error: error];
-    if (!encodedObjects && error) {
+    if (!encodedObjects) {
         return nil;
     }
     return @{ @"__op" : @"Add",
@@ -256,7 +256,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
-    if (!encodedObjects && error) {
+    if (!encodedObjects) {
         return nil;
     }
     return @{ @"__op" : @"AddUnique",
@@ -334,7 +334,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
-    if (!encodedObjects && error) {
+    if (!encodedObjects) {
         return nil;
     }
     return @{ @"__op" : @"Remove",
@@ -463,7 +463,7 @@
     NSDictionary *removeDict = nil;
     if (self.relationsToAdd.count > 0) {
         NSArray *array = [self _convertToArrayInSet:self.relationsToAdd withObjectEncoder:objectEncoder error:error];
-        if (!array && error) {
+        if (!array) {
             return nil;
         }
         addDict = @{ @"__op" : @"AddRelation",
@@ -471,7 +471,7 @@
     }
     if (self.relationsToRemove.count > 0) {
         NSArray *array = [self _convertToArrayInSet:self.relationsToRemove withObjectEncoder:objectEncoder error:error];
-        if (!array && error) {
+        if (!array) {
             return nil;
         }
         removeDict = @{ @"__op" : @"RemoveRelation",

--- a/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -193,7 +193,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error: error];
-    if (!encodedObjects) {
+    if (!encodedObjects && error && *error) {
         return nil;
     }
     return @{ @"__op" : @"Add",
@@ -256,7 +256,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
-    if (!encodedObjects) {
+    if (!encodedObjects && error && *error) {
         return nil;
     }
     return @{ @"__op" : @"AddUnique",
@@ -334,7 +334,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
-    if (!encodedObjects) {
+    if (!encodedObjects && error && *error) {
         return nil;
     }
     return @{ @"__op" : @"Remove",

--- a/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -24,7 +24,7 @@
 //  PFFieldOperation and its subclasses encapsulate operations that can be done on a field.
 @implementation PFFieldOperation
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     PFConsistencyAssertionFailure(@"Operation is invalid.");
     return nil;
 }
@@ -69,8 +69,8 @@
     return [NSString stringWithFormat:@"set to %@", self.value];
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
-    return [objectEncoder encodeObject:self.value];
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
+    return [objectEncoder encodeObject:self.value error:error];
 }
 
 - (PFSetOperation *)mergeWithPrevious:(PFFieldOperation *)previous {
@@ -93,7 +93,7 @@
     return @"delete";
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     return @{ @"__op" : @"Delete" };
 }
 
@@ -134,7 +134,7 @@
     return [NSString stringWithFormat:@"increment by %@", self.amount];
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     return @{ @"__op" : @"Increment",
               @"amount" : self.amount };
 }
@@ -191,8 +191,11 @@
     return [NSString stringWithFormat:@"add %@", self.objects];
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
-    NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects];
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
+    NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error: error];
+    if (!encodedObjects && error) {
+        return nil;
+    }
     return @{ @"__op" : @"Add",
               @"objects" : encodedObjects };
 }
@@ -251,8 +254,11 @@
     return [NSString stringWithFormat:@"addToSet %@", self.objects];
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
-    NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects];
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
+    NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
+    if (!encodedObjects && error) {
+        return nil;
+    }
     return @{ @"__op" : @"AddUnique",
               @"objects" : encodedObjects };
 }
@@ -326,8 +332,11 @@
     return [NSString stringWithFormat:@"remove %@", self.objects];
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
-    NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects];
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
+    NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
+    if (!encodedObjects && error) {
+        return nil;
+    }
     return @{ @"__op" : @"Remove",
               @"objects" : encodedObjects };
 }
@@ -439,25 +448,32 @@
             self.relationsToRemove];
 }
 
-- (NSArray *)_convertToArrayInSet:(NSSet *)set withObjectEncoder:(PFEncoder *)objectEncoder {
+- (NSArray *)_convertToArrayInSet:(NSSet *)set withObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *array = [NSMutableArray arrayWithCapacity:set.count];
     for (PFObject *object in set) {
-        id encodedDict = [objectEncoder encodeObject:object];
+        id encodedDict = [objectEncoder encodeObject:object error:error];
+        PFBailIfError(encodedDict, error, nil);
         [array addObject:encodedDict];
     }
     return array;
 }
 
-- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
+- (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSDictionary *addDict = nil;
     NSDictionary *removeDict = nil;
     if (self.relationsToAdd.count > 0) {
-        NSArray *array = [self _convertToArrayInSet:self.relationsToAdd withObjectEncoder:objectEncoder];
+        NSArray *array = [self _convertToArrayInSet:self.relationsToAdd withObjectEncoder:objectEncoder error:error];
+        if (!array && error) {
+            return nil;
+        }
         addDict = @{ @"__op" : @"AddRelation",
                      @"objects" : array };
     }
     if (self.relationsToRemove.count > 0) {
-        NSArray *array = [self _convertToArrayInSet:self.relationsToRemove withObjectEncoder:objectEncoder];
+        NSArray *array = [self _convertToArrayInSet:self.relationsToRemove withObjectEncoder:objectEncoder error:error];
+        if (!array && error) {
+            return nil;
+        }
         removeDict = @{ @"__op" : @"RemoveRelation",
                         @"objects" : array };
     }

--- a/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -193,9 +193,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error: error];
-    if (!encodedObjects && error && *error) {
-        return nil;
-    }
+    PFPreconditionBailOnError(encodedObjects, error, nil);
     return @{ @"__op" : @"Add",
               @"objects" : encodedObjects };
 }
@@ -256,9 +254,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
-    if (!encodedObjects && error && *error) {
-        return nil;
-    }
+    PFPreconditionBailOnError(encodedObjects, error, nil);
     return @{ @"__op" : @"AddUnique",
               @"objects" : encodedObjects };
 }
@@ -334,9 +330,7 @@
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSMutableArray *encodedObjects = [objectEncoder encodeObject:self.objects error:error];
-    if (!encodedObjects && error && *error) {
-        return nil;
-    }
+    PFPreconditionBailOnError(encodedObjects, error, nil);
     return @{ @"__op" : @"Remove",
               @"objects" : encodedObjects };
 }

--- a/Parse/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -121,7 +121,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
         // anything like ParseObjects and arrays.
         if (!(value == nil || [value isKindOfClass:[NSDictionary class]])) {
             if (depth > 0) {
-                // TODO: flovilmart is it safe?
+                // TODO (flovilmart): is it safe to swallow the error here?
                 id restFormat = [[PFPointerObjectEncoder objectEncoder] encodeObject:value error:nil];
                 if ([restFormat isKindOfClass:[NSDictionary class]]) {
                     return [self valueForContainer:restFormat key:rest depth:depth + 1];

--- a/Parse/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -121,7 +121,8 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
         // anything like ParseObjects and arrays.
         if (!(value == nil || [value isKindOfClass:[NSDictionary class]])) {
             if (depth > 0) {
-                id restFormat = [[PFPointerObjectEncoder objectEncoder] encodeObject:value];
+                // TODO: flovilmart is it safe?
+                id restFormat = [[PFPointerObjectEncoder objectEncoder] encodeObject:value error:nil];
                 if ([restFormat isKindOfClass:[NSDictionary class]]) {
                     return [self valueForContainer:restFormat key:rest depth:depth + 1];
                 }

--- a/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -178,7 +178,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
                                    PFOfflineStoreKeyOfJSON, PFOfflineStoreTableOfObjects, PFOfflineStoreKeyOfUUID];
                 return [database executeQueryAsync:query withArgumentsInArray:@[ uuid ] block:^id(PFSQLiteDatabaseResult *_Nonnull result) {
                     if (![result next]) {
-                        PFConsistencyErrorFailure(@"Attempted to find non-existent uuid %@. Please report this issue with stack traces and logs.", uuid);
+                        PFPreconditionFailure(@"Attempted to find non-existent uuid %@. Please report this issue with stack traces and logs.", uuid);
                     }
                     return [result stringForColumnIndex:0];
                 }];
@@ -384,7 +384,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         NSArray *operationSetUUIDs = nil;
         NSError *error;
         encoded = [object RESTDictionaryWithObjectEncoder:encoder operationSetUUIDs:&operationSetUUIDs error:&error];
-        PFBailTaskIfError(encoded, error);
+        PFPreconditionReturnFailedTask(encoded, error);
         return [encoder encodeFinished];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         // Time to actually save the object
@@ -623,7 +623,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         NSArray *operationSetUUIDs = nil;
         NSError *error;
         dataDictionary = [object RESTDictionaryWithObjectEncoder:encoder operationSetUUIDs:&operationSetUUIDs error:&error];
-        PFBailTaskIfError(dataDictionary, error);
+        PFPreconditionReturnFailedTask(dataDictionary, error);
         return [encoder encodeFinished];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         // Put it in database
@@ -912,7 +912,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
     __block NSString *objectId = nil;
     return [[database executeQueryAsync:query withArgumentsInArray:@[ uuid ] block:^id(PFSQLiteDatabaseResult *result) {
         if (![result next]) {
-            PFConsistencyErrorFailure(@"Attempted to find non-existent uuid %@. Please report this issue with stack traces and logs.", uuid);
+            PFPreconditionFailure(@"Attempted to find non-existent uuid %@. Please report this issue with stack traces and logs.", uuid);
         }
 
         className = [result stringForColumnIndex:0];

--- a/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -972,6 +972,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
     @synchronized(self.lock) {
         pointer = [self.UUIDToObjectMap objectForKey:uuid];
         if (!pointer) {
+            PFPreconditionWithTask(parseClassName, @"Unable to get fetch an object without a className %@ %@ %@", uuid, objectId, parseClassName);
             pointer = [PFObject objectWithoutDataWithClassName:parseClassName objectId:objectId];
 
             // If it doesn't have objectId, we don't really need the UUID, and this simplifies some

--- a/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -265,7 +265,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         return [[BFTask taskForCompletionOfAllTasks:objectValues] continueWithSuccessBlock:^id(BFTask *task) {
             PFDecoder *decoder = [PFOfflineDecoder decoderWithOfflineObjects:offlineObjects];
             NSError *error;
-            if (![object mergeFromRESTDictionary:parsedJson withDecoder:decoder error:&error] && error) {
+            if (![object mergeFromRESTDictionary:parsedJson withDecoder:decoder error:&error]) {
                 return [BFTask taskWithError:error];
             }
             return nil;

--- a/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -264,7 +264,10 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         NSArray *objectValues = offlineObjects.allValues;
         return [[BFTask taskForCompletionOfAllTasks:objectValues] continueWithSuccessBlock:^id(BFTask *task) {
             PFDecoder *decoder = [PFOfflineDecoder decoderWithOfflineObjects:offlineObjects];
-            [object mergeFromRESTDictionary:parsedJson withDecoder:decoder];
+            NSError *error;
+            if (![object mergeFromRESTDictionary:parsedJson withDecoder:decoder error:&error] && error) {
+                return [BFTask taskWithError:error];
+            }
             return nil;
         }];
     }] continueWithBlock:^id(BFTask *task) {

--- a/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -1028,7 +1028,8 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         // See if there's already an entry for new objectId.
         PFObject *existing = [self.classNameAndObjectIdToObjectMap objectForKey:key];
         PFConsistencyAssert(existing == nil || existing == object,
-                            @"Attempted to change an objectId to one that's already known to the OfflineStore.");
+                            @"Attempted to change an objectId to one that's already known to the OfflineStore. className: %@ old: %@, new: %@",
+                            className, oldObjectId, newObjectId);
 
         // Okay, all clear to add the new reference.
         [self.classNameAndObjectIdToObjectMap setObject:object forKey:key];

--- a/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -57,7 +57,7 @@
         @strongify(self);
         NSError *error;
         PFRESTCommand *command = [self _fetchCommandForObjects:objects withSessionToken:sessionToken error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.dataSource.commandRunner runCommandAsync:command
                                                   withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {

--- a/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -55,7 +55,9 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        PFRESTCommand *command = [self _fetchCommandForObjects:objects withSessionToken:sessionToken];
+        NSError *error;
+        PFRESTCommand *command = [self _fetchCommandForObjects:objects withSessionToken:sessionToken error:&error];
+        PFBailTaskIfError(command, error);
         return [self.dataSource.commandRunner runCommandAsync:command
                                                   withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -65,12 +67,14 @@
     }];
 }
 
-- (PFRESTCommand *)_fetchCommandForObjects:(NSArray *)objects withSessionToken:(NSString *)sessionToken {
+- (PFRESTCommand *)_fetchCommandForObjects:(NSArray *)objects
+                          withSessionToken:(NSString *)sessionToken
+                                     error:(NSError **)error {
     NSArray *objectIds = [objects valueForKey:@keypath(PFObject, objectId)];
     PFQuery *query = [PFQuery queryWithClassName:[objects.firstObject parseClassName]];
     [query whereKey:@keypath(PFObject, objectId) containedIn:objectIds];
     query.limit = objectIds.count;
-    return [PFRESTQueryCommand findCommandForQueryState:query.state withSessionToken:sessionToken];
+    return [PFRESTQueryCommand findCommandForQueryState:query.state withSessionToken:sessionToken error:error];
 }
 
 - (BFTask *)_processFetchResultAsync:(NSDictionary *)result forObjects:(NSArray *)objects {
@@ -117,8 +121,12 @@
         id<PFCommandRunning> commandRunner = self.dataSource.commandRunner;
         NSURL *serverURL = commandRunner.serverURL;
         for (NSArray *batch in objectBatches) {
-
-            PFRESTCommand *command = [self _deleteCommandForObjects:batch withSessionToken:sessionToken serverURL:serverURL];
+            NSError *error;
+            PFRESTCommand *command = [self _deleteCommandForObjects:batch withSessionToken:sessionToken serverURL:serverURL error:&error];
+            if (!command && error) {
+                [tasks addObject:[BFTask taskWithError:error]];
+                continue;
+            }
             BFTask *task = [[commandRunner runCommandAsync:command
                                                withOptions:PFCommandRunningOptionRetryIfFailed] continueWithSuccessBlock:^id(BFTask *task) {
                 PFCommandResult *result = task.result;
@@ -149,14 +157,15 @@
 
 - (PFRESTCommand *)_deleteCommandForObjects:(NSArray *)objects
                            withSessionToken:(NSString *)sessionToken
-                                  serverURL:(NSURL *)serverURL {
+                                  serverURL:(NSURL *)serverURL
+                                      error:(NSError **)error {
     NSMutableArray *commands = [NSMutableArray arrayWithCapacity:objects.count];
     for (PFObject *object in objects) {
         PFRESTCommand *deleteCommand = [PFRESTObjectCommand deleteObjectCommandForObjectState:object._state
                                                                              withSessionToken:sessionToken];
         [commands addObject:deleteCommand];
     }
-    return [PFRESTObjectBatchCommand batchCommandWithCommands:commands sessionToken:sessionToken serverURL:serverURL];
+    return [PFRESTObjectBatchCommand batchCommandWithCommands:commands sessionToken:sessionToken serverURL:serverURL error:error];
 }
 
 - (BFTask *)_processDeleteResultsAsync:(NSArray *)results forObjects:(NSArray *)objects {

--- a/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -123,7 +123,7 @@
         for (NSArray *batch in objectBatches) {
             NSError *error;
             PFRESTCommand *command = [self _deleteCommandForObjects:batch withSessionToken:sessionToken serverURL:serverURL error:&error];
-            if (!command && error) {
+            if (!command) {
                 [tasks addObject:[BFTask taskWithError:error]];
                 continue;
             }

--- a/Parse/Parse/Internal/Object/Coder/File/PFObjectFileCoder.m
+++ b/Parse/Parse/Internal/Object/Coder/File/PFObjectFileCoder.m
@@ -23,7 +23,8 @@
 + (NSData *)dataFromObject:(PFObject *)object usingEncoder:(PFEncoder *)encoder {
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     result[@"classname"] = object._state.parseClassName;
-    result[@"data"] = [object._state dictionaryRepresentationWithObjectEncoder:encoder];
+    // TODO: @flovilmart verify if it's safe
+    result[@"data"] = [object._state dictionaryRepresentationWithObjectEncoder:encoder error:nil];
     return [PFJSONSerialization dataFromJSONObject:result];
 }
 

--- a/Parse/Parse/Internal/Object/Coder/File/PFObjectFileCoder.m
+++ b/Parse/Parse/Internal/Object/Coder/File/PFObjectFileCoder.m
@@ -23,7 +23,7 @@
 + (NSData *)dataFromObject:(PFObject *)object usingEncoder:(PFEncoder *)encoder {
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     result[@"classname"] = object._state.parseClassName;
-    // TODO: @flovilmart verify if it's safe
+    // TODO (flovilmart): is it safe to swallow error here?
     result[@"data"] = [object._state dictionaryRepresentationWithObjectEncoder:encoder error:nil];
     return [PFJSONSerialization dataFromJSONObject:result];
 }

--- a/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
+++ b/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
@@ -42,7 +42,7 @@
 - (void)releaseLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
 
 - (void)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId error:(NSError **)error;
-- (NSString *)objectIdForLocalId:(NSString *)localId error:(NSError **)error;
+- (NSString *)objectIdForLocalId:(NSString *)localId;
 
 // For testing only.
 - (BOOL)clear;

--- a/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
+++ b/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
@@ -38,11 +38,11 @@
 ///--------------------------------------
 
 - (NSString *)createLocalId;
-- (void)retainLocalIdOnDisk:(NSString *)localId;
-- (void)releaseLocalIdOnDisk:(NSString *)localId;
+- (void)retainLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
+- (void)releaseLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
 
-- (void)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId;
-- (NSString *)objectIdForLocalId:(NSString *)localId;
+- (void)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId error:(NSError **)error;
+- (NSString *)objectIdForLocalId:(NSString *)localId error:(NSError **)error;
 
 // For testing only.
 - (BOOL)clear;

--- a/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
+++ b/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
@@ -38,10 +38,10 @@
 ///--------------------------------------
 
 - (NSString *)createLocalId;
-- (void)retainLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
-- (void)releaseLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
+- (BOOL)retainLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
+- (BOOL)releaseLocalIdOnDisk:(NSString *)localId error:(NSError **)error;
 
-- (void)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId error:(NSError **)error;
+- (BOOL)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId error:(NSError **)error;
 - (NSString *)objectIdForLocalId:(NSString *)localId;
 
 // For testing only.

--- a/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -210,7 +210,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 - (BOOL)retainLocalIdOnDisk:(NSString *)localId error:(NSError **)error {
     @synchronized (_lock) {
         PFObjectLocalIdStoreMapEntry *entry = [self getMapEntry:localId error:error];
-        if (!entry && error) {
+        if (!entry) {
             return NO;
         }
         entry.referenceCount++;
@@ -225,7 +225,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 - (BOOL)releaseLocalIdOnDisk:(NSString *)localId error:(NSError **)error {
     @synchronized (_lock) {
         PFObjectLocalIdStoreMapEntry *entry = [self getMapEntry:localId error:error];
-        if (!entry && error) {
+        if (!entry) {
             return NO;
         }
         if (--entry.referenceCount > 0) {
@@ -242,7 +242,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 - (BOOL)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId error:(NSError **)error {
     @synchronized (_lock) {
         PFObjectLocalIdStoreMapEntry *entry = [self getMapEntry:localId error:error];
-        if (!entry && error) {
+        if (!entry) {
             return NO;
         }
         if (entry.referenceCount > 0) {

--- a/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -134,7 +134,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 /**
  * Grabs one entry in the local id map off the disk.
  */
-- (PFObjectLocalIdStoreMapEntry *)getMapEntry:(NSString *)localId error:(NSError **) error {
+- (PFObjectLocalIdStoreMapEntry *)getMapEntry:(NSString *)localId error:(NSError * __autoreleasing *) error {
 
     PFConsistencyError(error, [[self class] isLocalId:localId], nil, @"Tried to get invalid local id: \"%@\".", localId);
 
@@ -167,7 +167,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 /**
  * Writes one entry to the local id map on disk.
  */
-- (BOOL)putMapEntry:(PFObjectLocalIdStoreMapEntry *)entry forLocalId:(NSString *)localId error:(NSError **)error {
+- (BOOL)putMapEntry:(PFObjectLocalIdStoreMapEntry *)entry forLocalId:(NSString *)localId error:(NSError * __autoreleasing *)error {
     PFConsistencyError(error, [[self class] isLocalId:localId], NO, @"Tried to get invalid local id: \"%@\".", localId);
 
     NSString *file = [_diskPath stringByAppendingPathComponent:localId];
@@ -178,7 +178,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 /**
  * Removes an entry from the local id map on disk.
  */
-- (BOOL)removeMapEntry:(NSString *)localId error:(NSError **)error {
+- (BOOL)removeMapEntry:(NSString *)localId error:(NSError * __autoreleasing *)error {
     PFConsistencyError(error, [[self class] isLocalId:localId], NO, @"Tried to get invalid local id: \"%@\".", localId);
 
     NSString *file = [_diskPath stringByAppendingPathComponent:localId];

--- a/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -136,7 +136,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  */
 - (PFObjectLocalIdStoreMapEntry *)getMapEntry:(NSString *)localId error:(NSError * __autoreleasing *) error {
 
-    PFConsistencyError(error, [[self class] isLocalId:localId], nil, @"Tried to get invalid local id: \"%@\".", localId);
+    PFPreconditionBailAndSetError([[self class] isLocalId:localId], error, nil, @"Tried to get invalid local id: \"%@\".", localId);
 
     PFObjectLocalIdStoreMapEntry *entry = nil;
 
@@ -168,7 +168,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  * Writes one entry to the local id map on disk.
  */
 - (BOOL)putMapEntry:(PFObjectLocalIdStoreMapEntry *)entry forLocalId:(NSString *)localId error:(NSError * __autoreleasing *)error {
-    PFConsistencyError(error, [[self class] isLocalId:localId], NO, @"Tried to get invalid local id: \"%@\".", localId);
+    PFPreconditionBailAndSetError([[self class] isLocalId:localId],error, NO, @"Tried to get invalid local id: \"%@\".", localId);
 
     NSString *file = [_diskPath stringByAppendingPathComponent:localId];
     [entry writeToFile:file];
@@ -179,7 +179,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  * Removes an entry from the local id map on disk.
  */
 - (BOOL)removeMapEntry:(NSString *)localId error:(NSError * __autoreleasing *)error {
-    PFConsistencyError(error, [[self class] isLocalId:localId], NO, @"Tried to get invalid local id: \"%@\".", localId);
+    PFPreconditionBailAndSetError([[self class] isLocalId:localId], error, NO, @"Tried to get invalid local id: \"%@\".", localId);
 
     NSString *file = [_diskPath stringByAppendingPathComponent:localId];
     [[NSFileManager defaultManager] removeItemAtPath:file error:nil];

--- a/Parse/Parse/Internal/Object/OperationSet/PFOperationSet.h
+++ b/Parse/Parse/Internal/Object/OperationSet/PFOperationSet.h
@@ -42,7 +42,8 @@
  Converts this operation set into its REST format for serializing to the pinning store
  */
 - (NSDictionary *)RESTDictionaryUsingObjectEncoder:(PFEncoder *)objectEncoder
-                                 operationSetUUIDs:(NSArray **)operationSetUUIDs;
+                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
+                                             error:(NSError **)error;
 
 /**
  The inverse of RESTDictionaryUsingObjectEncoder.

--- a/Parse/Parse/Internal/Object/OperationSet/PFOperationSet.m
+++ b/Parse/Parse/Internal/Object/OperationSet/PFOperationSet.m
@@ -74,7 +74,7 @@ static NSString *const PFOperationSetKeyACL = @"ACL";
 
 - (nullable NSDictionary *)RESTDictionaryUsingObjectEncoder:(PFEncoder *)objectEncoder
                                  operationSetUUIDs:(NSArray **)operationSetUUIDs
-                                             error:(NSError **)error {
+                                             error:(NSError * __autoreleasing *)error {
     NSMutableDictionary *operationSetResult = [[NSMutableDictionary alloc] init];
     __block NSError *encodingError;
     __block BOOL wasStopped = false;

--- a/Parse/Parse/Internal/Object/OperationSet/PFOperationSet.m
+++ b/Parse/Parse/Internal/Object/OperationSet/PFOperationSet.m
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import "PFAssert.h"
 #import "PFOperationSet.h"
 
 #import "PFACL.h"
@@ -71,15 +72,29 @@ static NSString *const PFOperationSetKeyACL = @"ACL";
 #pragma mark - Encoding
 ///--------------------------------------
 
-- (NSDictionary *)RESTDictionaryUsingObjectEncoder:(PFEncoder *)objectEncoder
-                                 operationSetUUIDs:(NSArray **)operationSetUUIDs {
+- (nullable NSDictionary *)RESTDictionaryUsingObjectEncoder:(PFEncoder *)objectEncoder
+                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
+                                             error:(NSError **)error {
     NSMutableDictionary *operationSetResult = [[NSMutableDictionary alloc] init];
+    __block NSError *encodingError;
+    __block BOOL wasStopped = false;
     [self.dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        operationSetResult[key] = [obj encodeWithObjectEncoder:objectEncoder];
+        id result = [obj encodeWithObjectEncoder:objectEncoder error:&encodingError];
+        if (!result && encodingError) {
+            *stop = YES;
+            wasStopped = YES;
+            return;
+        }
+        operationSetResult[key] = result;
     }];
 
+    if (wasStopped && error) {
+        *error = encodingError;
+        return nil;
+    }
+
     operationSetResult[PFOperationSetKeyUUID] = self.uuid;
-    operationSetResult[PFOperationSetKeyUpdatedAt] = [objectEncoder encodeObject:self.updatedAt];
+    operationSetResult[PFOperationSetKeyUpdatedAt] = [objectEncoder encodeObject:self.updatedAt error:nil];
 
     if (self.saveEventually) {
         operationSetResult[PFOperationSetKeyIsSaveEventually] = @YES;

--- a/Parse/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Parse/Internal/Object/PFObjectPrivate.h
@@ -253,8 +253,9 @@
                           deletingEventuallyCount:(NSUInteger)deletingEventuallyCount
                                             error:(NSError **)error;
 
-- (void)mergeFromRESTDictionary:(NSDictionary *)object
-                    withDecoder:(PFDecoder *)decoder;
+- (BOOL)mergeFromRESTDictionary:(NSDictionary *)object
+                    withDecoder:(PFDecoder *)decoder
+                          error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - Data helpers

--- a/Parse/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Parse/Internal/Object/PFObjectPrivate.h
@@ -217,7 +217,7 @@
 #pragma mark - Serialization helpers
 ///--------------------------------------
 - (NSString *)getOrCreateLocalId;
-- (void)resolveLocalId;
+- (BOOL)resolveLocalId:(NSError **) error;
 
 + (id)_objectFromDictionary:(NSDictionary *)dictionary
            defaultClassName:(NSString *)defaultClassName
@@ -237,18 +237,21 @@
                            usingMigrationBlock:(BFContinuationBlock)block;
 
 - (NSMutableDictionary *)_convertToDictionaryForSaving:(PFOperationSet *)changes
-                                     withObjectEncoder:(PFEncoder *)encoder;
+                                     withObjectEncoder:(PFEncoder *)encoder
+                                                 error:(NSError **)error;
 
 ///--------------------------------------
 #pragma mark - REST operations
 ///--------------------------------------
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
-                                operationSetUUIDs:(NSArray **)operationSetUUIDs;
+                                operationSetUUIDs:(NSArray **)operationSetUUIDs
+                                            error:(NSError **)error;
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
                                             state:(PFObjectState *)state
                                 operationSetQueue:(NSArray *)queue
-                          deletingEventuallyCount:(NSUInteger)deletingEventuallyCount;
+                          deletingEventuallyCount:(NSUInteger)deletingEventuallyCount
+                                            error:(NSError **)error;
 
 - (void)mergeFromRESTDictionary:(NSDictionary *)object
                     withDecoder:(PFDecoder *)decoder;
@@ -283,7 +286,8 @@
 ///--------------------------------------
 - (PFRESTCommand *)_constructSaveCommandForChanges:(PFOperationSet *)changes
                                       sessionToken:(NSString *)sessionToken
-                                     objectEncoder:(PFEncoder *)encoder;
+                                     objectEncoder:(PFEncoder *)encoder
+                                             error:(NSError **)error;
 - (PFRESTCommand *)_currentDeleteCommandWithSessionToken:(NSString *)sessionToken;
 
 ///--------------------------------------

--- a/Parse/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Parse/Internal/Object/PFObjectPrivate.h
@@ -207,7 +207,7 @@
 ///--------------------------------------
 #pragma mark - Validations
 ///--------------------------------------
-- (void)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser;
+- (BOOL)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser error:(NSError **)error;
 /**
  Checks if Parse class name could be used to initialize a given instance of PFObject or it's subclass.
  */

--- a/Parse/Parse/Internal/Object/State/PFObjectState.h
+++ b/Parse/Parse/Internal/Object/State/PFObjectState.h
@@ -59,7 +59,7 @@ typedef void(^PFObjectStateMutationBlock)(PFMutableObjectState *state);
 
  @return `NSDictionary` instance representing object state.
  */
-- (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder NS_REQUIRES_SUPER;
+- (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error NS_REQUIRES_SUPER;
 
 ///--------------------------------------
 #pragma mark - Mutating

--- a/Parse/Parse/Internal/Object/State/PFObjectState.m
+++ b/Parse/Parse/Internal/Object/State/PFObjectState.m
@@ -106,7 +106,7 @@
 #pragma mark - Coding
 ///--------------------------------------
 
-- (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
+- (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError * __autoreleasing *)error {
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     if (self.objectId) {
         result[PFObjectObjectIdRESTKey] = self.objectId;

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -58,6 +58,18 @@ do { \
 } while(0)
 
 /**
+Sets a recoverable error for propagation
+ */
+#define PFConsistencyError(error, condition, rval, description, ...) \
+if (!(condition)) { \
+*error = [NSError errorWithDomain:PFParseErrorDomain\
+                    code:-1\
+                    userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:description, ##__VA_ARGS__]}];\
+return rval;\
+}
+
+
+/**
  Raises an `NSInternalInconsistencyException`. Use `description` to supply the way to fix the exception.
  */
 #define PFConsistencyAssertionFailure(description, ...) \

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -8,6 +8,7 @@
  */
 
 #import "PFMacros.h"
+#import "PFErrorUtilities.h"
 
 #ifndef Parse_PFAssert_h
 #define Parse_PFAssert_h
@@ -62,12 +63,17 @@ Sets a recoverable error for propagation
  */
 #define PFConsistencyError(error, condition, rval, description, ...) \
 if (!(condition)) { \
-*error = [NSError errorWithDomain:PFParseErrorDomain\
-                    code:-1\
-                    userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:description, ##__VA_ARGS__]}];\
+*error = [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
 return rval;\
 }
 
+#define PFBailIfError(condition, error, rval) \
+if (!(condition) && error) { \
+return rval;\
+}
+
+#define PFBailTaskIfError(condition, error) \
+PFBailIfError(condition, error, [BFTask taskWithError:error])
 
 /**
  Raises an `NSInternalInconsistencyException`. Use `description` to supply the way to fix the exception.
@@ -77,6 +83,14 @@ do {\
     [NSException raise:NSInternalInconsistencyException \
                 format:description, ##__VA_ARGS__]; \
 } while(0)
+
+/**
+ Returns a consistency error.
+ */
+#define PFConsistencyErrorFailure(description, ...) \
+return [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];
+
+
 
 /**
  Always raises `NSInternalInconsistencyException` with details

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -62,8 +62,8 @@ do { \
 Sets a recoverable error for propagation
  */
 #define PFConsistencyError(error, condition, rval, description, ...) \
-if (!(condition) && error) { \
-*error = [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
+if (!(condition) && error && *error == nil) { \
+*error =  [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
 return rval;\
 }
 

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -114,7 +114,6 @@ do {\
                 format:description, ##__VA_ARGS__]; \
 } while(0)
 
-
 /**
  Always raises `NSInternalInconsistencyException` with details
  about the method used and class that received the message

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -68,12 +68,14 @@ return rval;\
 }
 
 #define PFBailIfError(condition, error, rval) \
-if (!(condition) && error) { \
+if (!(condition) && *error) { \
 return rval;\
 }
 
 #define PFBailTaskIfError(condition, error) \
-PFBailIfError(condition, error, [BFTask taskWithError:error])
+if (!(condition) && error) { \
+return [BFTask taskWithError:error];\
+}
 
 #define PFPrecondition(condition, description, ...) \
 if (!(condition)) { \

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -62,7 +62,7 @@ do { \
 Sets a recoverable error for propagation
  */
 #define PFConsistencyError(error, condition, rval, description, ...) \
-if (!(condition)) { \
+if (!(condition) && error) { \
 *error = [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
 return rval;\
 }

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -58,33 +58,51 @@ do { \
     } \
 } while(0)
 
+/*
+ Returns an error with the description, if a condition isn't met
+ */
+#define PFPrecondition(condition, description, ...) \
+if (!(condition)) { \
+    return [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
+}
+
+/**
+ Returns a consistency error.
+ */
+#define PFPreconditionFailure(description, ...) \
+PFPrecondition(NO, description, ##__VA_ARGS__)
+
 /**
 Sets a recoverable error for propagation
  */
-#define PFConsistencyError(error, condition, rval, description, ...) \
+#define PFPreconditionBailAndSetError(condition, error, rval, description, ...) \
 if (!(condition) && error && *error == nil) { \
-*error =  [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
-return rval;\
+    *error =  [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
+    return rval;\
 }
 
-#define PFBailIfError(condition, error, rval) \
+/*
+ Returns the passed value if the condition isn't met and the *error is set
+ */
+#define PFPreconditionBailOnError(condition, error, rval) \
 if (!(condition) && *error) { \
-return rval;\
+    return rval;\
 }
 
-#define PFBailTaskIfError(condition, error) \
+/*
+ Returns an failed task with the passed error if a contition isn't met and the error is set
+ */
+#define PFPreconditionReturnFailedTask(condition, error) \
 if (!(condition) && error) { \
-return [BFTask taskWithError:error];\
+    return [BFTask taskWithError:error];\
 }
 
-#define PFPrecondition(condition, description, ...) \
-if (!(condition)) { \
-return [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
-}
-
+/*
+ Returns a failed BFTask with an error description if the condition isn't met
+ */
 #define PFPreconditionWithTask(condition, description, ...) \
 if (!(condition)) { \
-return [BFTask taskWithError:[PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]]];\
+    return [BFTask taskWithError:[PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]]];\
 }
 
 /**
@@ -95,13 +113,6 @@ do {\
     [NSException raise:NSInternalInconsistencyException \
                 format:description, ##__VA_ARGS__]; \
 } while(0)
-
-/**
- Returns a consistency error.
- */
-#define PFConsistencyErrorFailure(description, ...) \
-return [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];
-
 
 
 /**

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -75,6 +75,11 @@ return rval;\
 #define PFBailTaskIfError(condition, error) \
 PFBailIfError(condition, error, [BFTask taskWithError:error])
 
+#define PFPrecondition(condition, description, ...) \
+if (!(condition)) { \
+return [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
+}
+
 /**
  Raises an `NSInternalInconsistencyException`. Use `description` to supply the way to fix the exception.
  */

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -85,7 +85,7 @@ if (!(condition) && error && *error == nil) { \
  Returns the passed value if the condition isn't met and the *error is set
  */
 #define PFPreconditionBailOnError(condition, error, rval) \
-if (!(condition) && *error) { \
+if (!(condition) && error && *error) { \
     return rval;\
 }
 

--- a/Parse/Parse/Internal/PFAssert.h
+++ b/Parse/Parse/Internal/PFAssert.h
@@ -82,6 +82,11 @@ if (!(condition)) { \
 return [PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]];\
 }
 
+#define PFPreconditionWithTask(condition, description, ...) \
+if (!(condition)) { \
+return [BFTask taskWithError:[PFErrorUtilities errorWithCode:-1 message:[NSString stringWithFormat:description, ##__VA_ARGS__]]];\
+}
+
 /**
  Raises an `NSInternalInconsistencyException`. Use `description` to supply the way to fix the exception.
  */

--- a/Parse/Parse/Internal/PFCommandCache.m
+++ b/Parse/Parse/Internal/PFCommandCache.m
@@ -295,7 +295,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
 
         NSError *error = nil;
         NSDictionary *JSON = [command dictionaryRepresentation:&error];
-        PFBailTaskIfError(JSON, error);
+        PFPreconditionReturnFailedTask(JSON, error);
         NSData *data = [NSJSONSerialization dataWithJSONObject:JSON
                                                        options:0
                                                          error:&error];

--- a/Parse/Parse/Internal/PFCommandCache.m
+++ b/Parse/Parse/Internal/PFCommandCache.m
@@ -205,7 +205,11 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
         if (dictionaryResult != nil) {
             NSString *objectId = dictionaryResult[@"objectId"];
             if (objectId) {
-                [self.coreDataSource.objectLocalIdStore setObjectId:objectId forLocalId:command.localId];
+                NSError *error;
+                [self.coreDataSource.objectLocalIdStore setObjectId:objectId forLocalId:command.localId error:&error];
+                if (error != nil) {
+                    return [BFTask taskWithError:error];
+                }
             }
         }
     }

--- a/Parse/Parse/Internal/PFCommandCache.m
+++ b/Parse/Parse/Internal/PFCommandCache.m
@@ -294,7 +294,9 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
         @strongify(self);
 
         NSError *error = nil;
-        NSData *data = [NSJSONSerialization dataWithJSONObject:[command dictionaryRepresentation]
+        NSDictionary *JSON = [command dictionaryRepresentation:&error];
+        PFBailTaskIfError(JSON, error);
+        NSData *data = [NSJSONSerialization dataWithJSONObject:JSON
                                                        options:0
                                                          error:&error];
         NSUInteger commandSize = data.length;

--- a/Parse/Parse/Internal/PFEventuallyPin.m
+++ b/Parse/Parse/Internal/PFEventuallyPin.m
@@ -95,7 +95,7 @@ static NSString *const PFEventuallyPinKeyCommand = @"command";
     NSError *error;
     NSDictionary *commandDictionary = (type == PFEventuallyPinTypeCommand ? [command dictionaryRepresentation:&error] : nil);
     if (type == PFEventuallyPinTypeCommand) {
-        PFBailTaskIfError(commandDictionary, error);
+        PFPreconditionReturnFailedTask(commandDictionary, error);
     }
     return [self _pinEventually:object
                            type:type

--- a/Parse/Parse/Internal/PFEventuallyPin.m
+++ b/Parse/Parse/Internal/PFEventuallyPin.m
@@ -92,7 +92,11 @@ static NSString *const PFEventuallyPinKeyCommand = @"command";
 
 + (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command withUUID:(NSString *)uuid {
     PFEventuallyPinType type = [self _pinTypeForCommand:command];
-    NSDictionary *commandDictionary = (type == PFEventuallyPinTypeCommand ? [command dictionaryRepresentation] : nil);
+    NSError *error;
+    NSDictionary *commandDictionary = (type == PFEventuallyPinTypeCommand ? [command dictionaryRepresentation:&error] : nil);
+    if (type == PFEventuallyPinTypeCommand) {
+        PFBailTaskIfError(commandDictionary, error);
+    }
     return [self _pinEventually:object
                            type:type
                            uuid:uuid

--- a/Parse/Parse/Internal/PFGeoPointPrivate.h
+++ b/Parse/Parse/Internal/PFGeoPointPrivate.h
@@ -23,7 +23,7 @@ extern const double EARTH_RADIUS_KILOMETERS;
 /*
  Gets the encoded format for an GeoPoint.
  */
-- (NSDictionary *)encodeIntoDictionary;
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error;
 
 /**
  Creates an GeoPoint from its encoded format.

--- a/Parse/Parse/Internal/PFNetworkCommand.h
+++ b/Parse/Parse/Internal/PFNetworkCommand.h
@@ -27,7 +27,7 @@
 ///--------------------------------------
 
 + (instancetype)commandFromDictionaryRepresentation:(NSDictionary *)dictionary;
-- (NSDictionary *)dictionaryRepresentation;
+- (NSDictionary *)dictionaryRepresentation:(NSError **)error;
 
 + (BOOL)isValidDictionaryRepresentation:(NSDictionary *)dictionary;
 
@@ -42,6 +42,6 @@
  has not yet been saved, and thus has no objectId, then this method raises an
  exception.
  */
-- (void)resolveLocalIds;
+- (BOOL)resolveLocalIds:(NSError **)error;
 
 @end

--- a/Parse/Parse/Internal/PFPinningEventuallyQueue.m
+++ b/Parse/Parse/Internal/PFPinningEventuallyQueue.m
@@ -169,7 +169,8 @@
             PFOperationSet *operationSet = _operationSetUUIDToOperationSet[eventuallyPin.operationSetUUID];
             return [eventuallyPin.object _constructSaveCommandForChanges:operationSet
                                                             sessionToken:eventuallyPin.sessionToken
-                                                           objectEncoder:[PFPointerObjectEncoder objectEncoder]];
+                                                           objectEncoder:[PFPointerObjectEncoder objectEncoder]
+                                                                   error:error];
         }
         case PFEventuallyPinTypeDelete:
             return [eventuallyPin.object _currentDeleteCommandWithSessionToken:eventuallyPin.sessionToken];

--- a/Parse/Parse/Internal/PFPolygonPrivate.h
+++ b/Parse/Parse/Internal/PFPolygonPrivate.h
@@ -20,7 +20,7 @@
 /*
  Gets the encoded format for a Polygon.
  */
-- (NSDictionary *)encodeIntoDictionary;
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error;
 
 /**
  Creates a Polygon from its encoded format.

--- a/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
+++ b/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
@@ -157,11 +157,12 @@
     }
 
     NSDictionary *params = [[PFEncoder objectEncoder] encodeObject:@{ @"receipt" : appStoreReceipt,
-                                                                      @"productIdentifier" : productIdentifier }];
+                                                                      @"productIdentifier" : productIdentifier } error:nil];
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"validate_purchase"
                                                      httpMethod:PFHTTPRequestMethodPOST
                                                      parameters:params
-                                                   sessionToken:sessionToken];
+                                                   sessionToken:sessionToken
+                                                          error:nil];
     BFTask *task = [self.dataSource.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
     @weakify(self);
     return [task continueWithSuccessBlock:^id(BFTask *task) {

--- a/Parse/Parse/Internal/Push/Controller/PFPushController.m
+++ b/Parse/Parse/Internal/Push/Controller/PFPushController.m
@@ -45,7 +45,7 @@
         @strongify(self);
         NSError *error;
         PFRESTCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:sessionToken error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return @(task.result != nil);

--- a/Parse/Parse/Internal/Push/Controller/PFPushController.m
+++ b/Parse/Parse/Internal/Push/Controller/PFPushController.m
@@ -43,7 +43,9 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        PFRESTCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:sessionToken];
+        NSError *error;
+        PFRESTCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:sessionToken error:&error];
+        PFBailTaskIfError(command, error);
         return [self.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return @(task.result != nil);

--- a/Parse/Parse/Internal/Query/Controller/PFCachedQueryController.m
+++ b/Parse/Parse/Internal/Query/Controller/PFCachedQueryController.m
@@ -153,7 +153,8 @@
 ///--------------------------------------
 
 - (NSString *)cacheKeyForQueryState:(PFQueryState *)queryState sessionToken:(NSString *)sessionToken {
-    return [PFRESTQueryCommand findCommandForQueryState:queryState withSessionToken:sessionToken].cacheKey;
+    // TODO: @flovimart verify if safe
+    return [PFRESTQueryCommand findCommandForQueryState:queryState withSessionToken:sessionToken error:nil].cacheKey;
 }
 
 - (BOOL)hasCachedResultForQueryState:(PFQueryState *)queryState sessionToken:(NSString *)sessionToken {

--- a/Parse/Parse/Internal/Query/Controller/PFCachedQueryController.m
+++ b/Parse/Parse/Internal/Query/Controller/PFCachedQueryController.m
@@ -153,7 +153,7 @@
 ///--------------------------------------
 
 - (NSString *)cacheKeyForQueryState:(PFQueryState *)queryState sessionToken:(NSString *)sessionToken {
-    // TODO: @flovimart verify if safe
+    // TODO (flovilmart): verify if safe to swallow error here
     return [PFRESTQueryCommand findCommandForQueryState:queryState withSessionToken:sessionToken error:nil].cacheKey;
 }
 

--- a/Parse/Parse/Internal/Query/Controller/PFQueryController.m
+++ b/Parse/Parse/Internal/Query/Controller/PFQueryController.m
@@ -64,7 +64,7 @@
 
         NSError *error;
         PFRESTCommand *command = [PFRESTQueryCommand findCommandForQueryState:queryState withSessionToken:sessionToken error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         querySent = (queryState.trace ? [NSDate date] : nil);
         return [self runNetworkCommandAsync:command
                       withCancellationToken:cancellationToken
@@ -117,9 +117,9 @@
         PFRESTQueryCommand *findCommand = [PFRESTQueryCommand findCommandForQueryState:queryState
                                                                       withSessionToken:sessionToken
                                                                                  error:&error];
-        PFBailTaskIfError(findCommand, error);
+        PFPreconditionReturnFailedTask(findCommand, error);
         PFRESTCommand *countCommand = [PFRESTQueryCommand countCommandFromFindCommand:findCommand error:&error];
-        PFBailTaskIfError(countCommand, error);
+        PFPreconditionReturnFailedTask(countCommand, error);
         return [self runNetworkCommandAsync:countCommand
                       withCancellationToken:cancellationToken
                               forQueryState:queryState];

--- a/Parse/Parse/Internal/Query/Controller/PFQueryController.m
+++ b/Parse/Parse/Internal/Query/Controller/PFQueryController.m
@@ -62,7 +62,9 @@
             return [BFTask cancelledTask];
         }
 
-        PFRESTCommand *command = [PFRESTQueryCommand findCommandForQueryState:queryState withSessionToken:sessionToken];
+        NSError *error;
+        PFRESTCommand *command = [PFRESTQueryCommand findCommandForQueryState:queryState withSessionToken:sessionToken error:&error];
+        PFBailTaskIfError(command, error);
         querySent = (queryState.trace ? [NSDate date] : nil);
         return [self runNetworkCommandAsync:command
                       withCancellationToken:cancellationToken
@@ -111,9 +113,13 @@
             return [BFTask cancelledTask];
         }
 
+        NSError *error;
         PFRESTQueryCommand *findCommand = [PFRESTQueryCommand findCommandForQueryState:queryState
-                                                                      withSessionToken:sessionToken];
-        PFRESTCommand *countCommand = [PFRESTQueryCommand countCommandFromFindCommand:findCommand];
+                                                                      withSessionToken:sessionToken
+                                                                                 error:&error];
+        PFBailTaskIfError(findCommand, error);
+        PFRESTCommand *countCommand = [PFRESTQueryCommand countCommandFromFindCommand:findCommand error:&error];
+        PFBailTaskIfError(countCommand, error);
         return [self runNetworkCommandAsync:countCommand
                       withCancellationToken:cancellationToken
                               forQueryState:queryState];

--- a/Parse/Parse/Internal/Relation/PFRelationPrivate.h
+++ b/Parse/Parse/Internal/Relation/PFRelationPrivate.h
@@ -19,7 +19,7 @@
 + (PFRelation *)relationWithTargetClass:(NSString *)targetClass;
 + (PFRelation *)relationFromDictionary:(NSDictionary *)dictionary withDecoder:(PFDecoder *)decoder;
 - (void)ensureParentIs:(PFObject *)someParent andKeyIs:(NSString *)someKey;
-- (NSDictionary *)encodeIntoDictionary;
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error;
 - (BOOL)_hasKnownObject:(PFObject *)object;
 - (void)_addKnownObject:(PFObject *)object;
 - (void)_removeKnownObject:(PFObject *)object;

--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -52,8 +52,7 @@
 ///--------------------------------------
 
 - (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate
-                           forAuthType:(NSString *)authType
-                                 error:(NSError **)error {
+                           forAuthType:(NSString *)authType {
     PFParameterAssert(delegate, @"Authentication delegate can't be `nil`.");
     PFParameterAssert(authType, @"`authType` can't be `nil`.");
     PFParameterAssert(![self authenticationDelegateForAuthType:authType],

--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -51,12 +51,13 @@
 #pragma mark - Authentication Providers
 ///--------------------------------------
 
-- (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate forAuthType:(NSString *)authType {
+- (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate
+                           forAuthType:(NSString *)authType
+                                 error:(NSError **)error {
     PFParameterAssert(delegate, @"Authentication delegate can't be `nil`.");
     PFParameterAssert(authType, @"`authType` can't be `nil`.");
-    PFConsistencyAssert(![self authenticationDelegateForAuthType:authType],
+    PFParameterAssert(![self authenticationDelegateForAuthType:authType],
                         @"Authentication delegate already registered for authType `%@`.", authType);
-
     dispatch_sync(_dataAccessQueue, ^{
         _authenticationDelegates[authType] = delegate;
     });

--- a/Parse/Parse/Internal/User/Controller/PFUserController.m
+++ b/Parse/Parse/Internal/User/Controller/PFUserController.m
@@ -52,7 +52,7 @@
         @strongify(self);
         NSError *error = nil;
         PFRESTCommand *command = [PFRESTUserCommand getCurrentUserCommandWithSessionToken:sessionToken error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -87,7 +87,7 @@
                                                                         password:password
                                                                 revocableSession:revocableSession
                                                                            error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -124,7 +124,7 @@
                                                                                authenticationData:authData
                                                                                  revocableSession:revocableSession
                                                                                             error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -151,7 +151,7 @@
         @strongify(self);
         NSError *error = nil;
         PFRESTCommand *command = [PFRESTUserCommand resetPasswordCommandForUserWithEmail:email error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessResult:nil];
@@ -167,7 +167,7 @@
         @strongify(self);
         NSError *error = nil;
         PFRESTCommand *command = [PFRESTUserCommand logOutUserCommandWithSessionToken:sessionToken error:&error];
-        PFBailTaskIfError(command, error);
+        PFPreconditionReturnFailedTask(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessResult:nil];

--- a/Parse/Parse/Internal/User/Controller/PFUserController.m
+++ b/Parse/Parse/Internal/User/Controller/PFUserController.m
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-
+#import "PFAssert.h"
 #import "PFUserController.h"
 
 #import "BFTask+Private.h"
@@ -50,7 +50,9 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        PFRESTCommand *command = [PFRESTUserCommand getCurrentUserCommandWithSessionToken:sessionToken];
+        NSError *error = nil;
+        PFRESTCommand *command = [PFRESTUserCommand getCurrentUserCommandWithSessionToken:sessionToken error:&error];
+        PFBailTaskIfError(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -80,9 +82,12 @@
                              revocableSession:(BOOL)revocableSession {
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
+        NSError *error = nil;
         PFRESTCommand *command = [PFRESTUserCommand logInUserCommandWithUsername:username
                                                                         password:password
-                                                                revocableSession:revocableSession];
+                                                                revocableSession:revocableSession
+                                                                           error:&error];
+        PFBailTaskIfError(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -114,9 +119,12 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
+        NSError *error;
         PFRESTCommand *command = [PFRESTUserCommand serviceLoginUserCommandWithAuthenticationType:authType
                                                                                authenticationData:authData
-                                                                                 revocableSession:revocableSession];
+                                                                                 revocableSession:revocableSession
+                                                                                            error:&error];
+        PFBailTaskIfError(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
@@ -141,7 +149,9 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        PFRESTCommand *command = [PFRESTUserCommand resetPasswordCommandForUserWithEmail:email];
+        NSError *error = nil;
+        PFRESTCommand *command = [PFRESTUserCommand resetPasswordCommandForUserWithEmail:email error:&error];
+        PFBailTaskIfError(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessResult:nil];
@@ -155,7 +165,9 @@
     @weakify(self);
     return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
-        PFRESTCommand *command = [PFRESTUserCommand logOutUserCommandWithSessionToken:sessionToken];
+        NSError *error = nil;
+        PFRESTCommand *command = [PFRESTUserCommand logOutUserCommandWithSessionToken:sessionToken error:&error];
+        PFBailTaskIfError(command, error);
         return [self.commonDataSource.commandRunner runCommandAsync:command
                                                         withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessResult:nil];

--- a/Parse/Parse/Internal/User/State/PFUserState.m
+++ b/Parse/Parse/Internal/User/State/PFUserState.m
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import "PFAssert.h"
 #import "PFUserState.h"
 #import "PFUserState_Private.h"
 
@@ -48,8 +49,10 @@
 #pragma mark - Serialization
 ///--------------------------------------
 
-- (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder {
-    NSMutableDictionary *dictionary = [[super dictionaryRepresentationWithObjectEncoder:objectEncoder] mutableCopy];
+- (nullable NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
+    NSDictionary *representation = [super dictionaryRepresentationWithObjectEncoder:objectEncoder error:error];
+    PFBailIfError(representation, error, nil);
+    NSMutableDictionary *dictionary = [representation mutableCopy];
     [dictionary removeObjectForKey:PFUserPasswordRESTKey];
     return dictionary;
 }

--- a/Parse/Parse/Internal/User/State/PFUserState.m
+++ b/Parse/Parse/Internal/User/State/PFUserState.m
@@ -51,7 +51,7 @@
 
 - (nullable NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder error:(NSError **)error {
     NSDictionary *representation = [super dictionaryRepresentationWithObjectEncoder:objectEncoder error:error];
-    PFBailIfError(representation, error, nil);
+    PFPreconditionBailOnError(representation, error, nil);
     NSMutableDictionary *dictionary = [representation mutableCopy];
     [dictionary removeObjectForKey:PFUserPasswordRESTKey];
     return dictionary;

--- a/Parse/Parse/PFACL.h
+++ b/Parse/Parse/PFACL.h
@@ -47,12 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Controls whether the public is allowed to read this object.
  */
-@property (nonatomic, assign, getter=getPublicReadAccess) BOOL publicReadAccess;
+@property (nonatomic, assign, getter=getPublicReadAccess) BOOL publicReadAccess NS_SWIFT_NAME(hasPublicReadAccess);
 
 /**
  Controls whether the public is allowed to write this object.
  */
-@property (nonatomic, assign, getter=getPublicWriteAccess) BOOL publicWriteAccess;
+@property (nonatomic, assign, getter=getPublicWriteAccess) BOOL publicWriteAccess NS_SWIFT_NAME(hasPublicWriteAccess);
 
 ///--------------------------------------
 #pragma mark - Controlling Access Per-User

--- a/Parse/Parse/PFACL.m
+++ b/Parse/Parse/PFACL.m
@@ -75,10 +75,10 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
     return [[controller getDefaultACLAsync] waitForResult:NULL withMainThreadWarning:NO];
 }
 
-+ (void)setDefaultACL:(PFACL *)acl withAccessForCurrentUser:(BOOL)currentUserAccess error:(NSError **)error {
++ (void)setDefaultACL:(PFACL *)acl withAccessForCurrentUser:(BOOL)currentUserAccess {
     PFDefaultACLController *controller = [Parse _currentManager].coreManager.defaultACLController;
     // TODO: (nlutsenko) Remove this in favor of assert on `_currentManager`.
-    PFParameterAssert(controller, @"Can't set default ACL before Parse is initialized.");
+    PFConsistencyAssert(controller, @"Can't set default ACL before Parse is initialized.");
     [controller setDefaultACLAsync:acl withCurrentUserAccess:currentUserAccess];
 }
 
@@ -319,7 +319,7 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
     return [self getWriteAccessForUserId:objectId];
 }
 
-- (NSDictionary *)encodeIntoDictionary {
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error {
     return self.state.permissions;
 }
 
@@ -362,7 +362,7 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-    [coder encodeObject:[self encodeIntoDictionary] forKey:PFACLCodingDataKey_];
+    [coder encodeObject:[self encodeIntoDictionary:nil] forKey:PFACLCodingDataKey_];
 }
 
 @end

--- a/Parse/Parse/PFACL.m
+++ b/Parse/Parse/PFACL.m
@@ -75,10 +75,10 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
     return [[controller getDefaultACLAsync] waitForResult:NULL withMainThreadWarning:NO];
 }
 
-+ (void)setDefaultACL:(PFACL *)acl withAccessForCurrentUser:(BOOL)currentUserAccess {
++ (void)setDefaultACL:(PFACL *)acl withAccessForCurrentUser:(BOOL)currentUserAccess error:(NSError **)error {
     PFDefaultACLController *controller = [Parse _currentManager].coreManager.defaultACLController;
     // TODO: (nlutsenko) Remove this in favor of assert on `_currentManager`.
-    PFConsistencyAssert(controller, @"Can't set default ACL before Parse is initialized.");
+    PFParameterAssert(controller, @"Can't set default ACL before Parse is initialized.");
     [controller setDefaultACLAsync:acl withCurrentUserAccess:currentUserAccess];
 }
 

--- a/Parse/Parse/PFConstants.h
+++ b/Parse/Parse/PFConstants.h
@@ -13,7 +13,7 @@
 #pragma mark - SDK Version
 ///--------------------------------------
 
-#define PARSE_VERSION @"1.17.0-alpha.3"
+#define PARSE_VERSION @"1.17.0-alpha.4"
 
 ///--------------------------------------
 #pragma mark - Platform

--- a/Parse/Parse/PFConstants.h
+++ b/Parse/Parse/PFConstants.h
@@ -13,7 +13,7 @@
 #pragma mark - SDK Version
 ///--------------------------------------
 
-#define PARSE_VERSION @"1.17.0-alpha.4"
+#define PARSE_VERSION @"1.17.0-alpha.5"
 
 ///--------------------------------------
 #pragma mark - Platform

--- a/Parse/Parse/PFConstants.h
+++ b/Parse/Parse/PFConstants.h
@@ -13,7 +13,7 @@
 #pragma mark - SDK Version
 ///--------------------------------------
 
-#define PARSE_VERSION @"1.16.0"
+#define PARSE_VERSION @"1.17.0-alpha.2"
 
 ///--------------------------------------
 #pragma mark - Platform

--- a/Parse/Parse/PFConstants.h
+++ b/Parse/Parse/PFConstants.h
@@ -13,7 +13,7 @@
 #pragma mark - SDK Version
 ///--------------------------------------
 
-#define PARSE_VERSION @"1.17.0-alpha.2"
+#define PARSE_VERSION @"1.17.0-alpha.3"
 
 ///--------------------------------------
 #pragma mark - Platform

--- a/Parse/Parse/PFEncoder.h
+++ b/Parse/Parse/PFEncoder.h
@@ -24,8 +24,8 @@
 
 + (instancetype)objectEncoder;
 
-- (id)encodeObject:(id)object;
-- (id)encodeParseObject:(PFObject *)object;
+- (id)encodeObject:(id)object error:(NSError **)error;
+- (id)encodeParseObject:(PFObject *)object error:(NSError **)error;
 
 @end
 

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -33,9 +33,9 @@
     return encoder;
 }
 
-- (id)encodeObject:(id)object {
+- (id)encodeObject:(id)object error:(NSError **) error {
     if ([object isKindOfClass:[PFObject class]]) {
-        return [self encodeParseObject:object];
+        return [self encodeParseObject:object error:error];
     } else if ([object isKindOfClass:[NSData class]]) {
         return @{
                  @"__type" : @"Bytes",
@@ -67,42 +67,54 @@
 
     } else if ([object isKindOfClass:[PFFieldOperation class]]) {
         // Always encode PFFieldOperation with PFPointerOrLocalId
-        return [object encodeWithObjectEncoder:[PFPointerOrLocalIdObjectEncoder objectEncoder]];
+        return [object encodeWithObjectEncoder:[PFPointerOrLocalIdObjectEncoder objectEncoder] error:error];
     } else if ([object isKindOfClass:[PFACL class]]) {
         // TODO (hallucinogen): pass object encoder here
-        return [object encodeIntoDictionary];
+        return [object encodeIntoDictionary:error];
 
     } else if ([object isKindOfClass:[PFGeoPoint class]]) {
         // TODO (hallucinogen): pass object encoder here
-        return [object encodeIntoDictionary];
+        return [object encodeIntoDictionary:error];
 
     } else if ([object isKindOfClass:[PFPolygon class]]) {
         // TODO (hallucinogen): pass object encoder here
-        return [object encodeIntoDictionary];
+        return [object encodeIntoDictionary:error];
 
     } else if ([object isKindOfClass:[PFRelation class]]) {
         // TODO (hallucinogen): pass object encoder here
-        return [object encodeIntoDictionary];
+        return [object encodeIntoDictionary:error];
 
     } else if ([object isKindOfClass:[NSArray class]]) {
         NSMutableArray *newArray = [NSMutableArray arrayWithCapacity:[object count]];
         for (id elem in object) {
-            [newArray addObject:[self encodeObject:elem]];
+            id encodedElem = [self encodeObject:elem error:error];
+            PFBailIfError(encodedElem, error, nil);
+            [newArray addObject:encodedElem];
         }
         return newArray;
 
     } else if ([object isKindOfClass:[NSDictionary class]]) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:[object count]];
+        __block BOOL hasErrored = NO;
+        __block NSError *encodingError = nil;
         [object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            dict[key] = [self encodeObject:obj];
+            dict[key] = [self encodeObject:obj error:&encodingError];
+            if (!dict[key] && encodingError) {
+                hasErrored = YES;
+                *stop = YES;
+            }
         }];
+        if (hasErrored) {
+            *error = encodingError;
+            return nil;
+        }
         return dict;
     }
 
     return object;
 }
 
-- (id)encodeParseObject:(PFObject *)object {
+- (id)encodeParseObject:(PFObject *)object error:(NSError **)error {
     // Do nothing here
     return nil;
 }
@@ -124,7 +136,7 @@
     return encoder;
 }
 
-- (id)encodeParseObject:(PFObject *)object {
+- (id)encodeParseObject:(PFObject *)object error:(NSError **)error {
     PFConsistencyAssertionFailure(@"PFObjects are not allowed here.");
     return nil;
 }
@@ -146,7 +158,7 @@
     return instance;
 }
 
-- (id)encodeParseObject:(PFObject *)object {
+- (id)encodeParseObject:(PFObject *)object error:(NSError **)error {
     if (object.objectId) {
         return @{
                  @"__type" : @"Pointer",
@@ -178,9 +190,9 @@
     return encoder;
 }
 
-- (id)encodeParseObject:(PFObject *)object {
-    PFConsistencyAssert(object.objectId, @"Tried to save an object with a new, unsaved child.");
-    return [super encodeParseObject:object];
+- (id)encodeParseObject:(PFObject *)object error:(NSError **)error {
+    PFConsistencyError(error, object.objectId, nil, @"Tried to save an object with a new, unsaved child.");
+    return [super encodeParseObject:object error:error];
 }
 
 @end
@@ -222,7 +234,7 @@
     return [[self alloc] initWithOfflineStore:store database:database];
 }
 
-- (id)encodeParseObject:(PFObject *)object {
+- (id)encodeParseObject:(PFObject *)object error:(NSError **)error {
     if (object.objectId) {
         return @{ @"__type" : @"Pointer",
                   @"objectId" : object.objectId,

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -98,10 +98,12 @@
         __block BOOL hasErrored = NO;
         __block NSError *encodingError = nil;
         [object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            dict[key] = [self encodeObject:obj error:&encodingError];
-            if (!dict[key] && encodingError) {
+            id result = [self encodeObject:obj error:&encodingError];
+            if (!result && encodingError) {
                 hasErrored = YES;
                 *stop = YES;
+            } else {
+                dict[key] = result;
             }
         }];
         if (hasErrored) {

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -99,7 +99,7 @@
         __block NSError *encodingError = nil;
         [object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             dict[key] = [self encodeObject:obj error:&encodingError];
-            if (!dict[key] && encodingError) {
+            if (!dict[key]) {
                 hasErrored = YES;
                 *stop = YES;
             }

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -99,7 +99,7 @@
         __block NSError *encodingError = nil;
         [object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             dict[key] = [self encodeObject:obj error:&encodingError];
-            if (!dict[key]) {
+            if (!dict[key] && encodingError) {
                 hasErrored = YES;
                 *stop = YES;
             }

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -88,7 +88,7 @@
         NSMutableArray *newArray = [NSMutableArray arrayWithCapacity:[object count]];
         for (id elem in object) {
             id encodedElem = [self encodeObject:elem error:error];
-            PFBailIfError(encodedElem, error, nil);
+            PFPreconditionBailOnError(encodedElem, error, nil);
             [newArray addObject:encodedElem];
         }
         return newArray;
@@ -193,7 +193,7 @@
 }
 
 - (id)encodeParseObject:(PFObject *)object error:(NSError * __autoreleasing *)error {
-    PFConsistencyError(error, object.objectId, nil, @"Tried to save an object with a new, unsaved child.");
+    PFPreconditionBailAndSetError(object.objectId, error, nil, @"Tried to save an object with a new, unsaved child.");
     return [super encodeParseObject:object error:error];
 }
 

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -95,18 +95,18 @@
 
     } else if ([object isKindOfClass:[NSDictionary class]]) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:[object count]];
-        __block BOOL hasErrored = NO;
+        __block BOOL encodingFailed = NO;
         __block NSError *encodingError = nil;
         [object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             id result = [self encodeObject:obj error:&encodingError];
             if (!result && encodingError) {
-                hasErrored = YES;
+                encodingFailed = YES;
                 *stop = YES;
             } else {
                 dict[key] = result;
             }
         }];
-        if (hasErrored) {
+        if (encodingFailed) {
             *error = encodingError;
             return nil;
         }

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -33,7 +33,7 @@
     return encoder;
 }
 
-- (id)encodeObject:(id)object error:(NSError **) error {
+- (id)encodeObject:(id)object error:(NSError * __autoreleasing *) error {
     if ([object isKindOfClass:[PFObject class]]) {
         return [self encodeParseObject:object error:error];
     } else if ([object isKindOfClass:[NSData class]]) {
@@ -190,7 +190,7 @@
     return encoder;
 }
 
-- (id)encodeParseObject:(PFObject *)object error:(NSError **)error {
+- (id)encodeParseObject:(PFObject *)object error:(NSError * __autoreleasing *)error {
     PFConsistencyError(error, object.objectId, nil, @"Tried to save an object with a new, unsaved child.");
     return [super encodeParseObject:object error:error];
 }

--- a/Parse/Parse/PFGeoPoint.m
+++ b/Parse/Parse/PFGeoPoint.m
@@ -103,7 +103,7 @@ static NSString *const PFGeoPointCodingTypeKey = @"__type";
 static NSString *const PFGeoPointCodingLatitudeKey = @"latitude";
 static NSString *const PFGeoPointCodingLongitudeKey = @"longitude";
 
-- (NSDictionary *)encodeIntoDictionary {
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error {
     return @{
              PFGeoPointCodingTypeKey : @"GeoPoint",
              PFGeoPointCodingLatitudeKey : @(self.latitude),
@@ -184,7 +184,7 @@ static NSString *const PFGeoPointCodingLongitudeKey = @"longitude";
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-    NSDictionary *dictionary = [self encodeIntoDictionary];
+    NSDictionary *dictionary = [self encodeIntoDictionary:nil];
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         [coder encodeObject:obj forKey:key];
     }];

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -456,12 +456,10 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
         }
         remaining = nextBatch;
 
-        if (current.count == 0) {
-            // We do cycle-detection when building the list of objects passed to this
-            // function, so this should never get called.  But we should check for it
-            // anyway, so that we get an exception instead of an infinite loop.
-            PFConsistencyAssertionFailure(@"Unable to save a PFObject with a relation to a cycle.");
-        }
+        // We do cycle-detection when building the list of objects passed to this
+        // function, so this should never get called.  But we should check for it
+        // anyway, so that we get an exception instead of an infinite loop.
+        PFPreconditionWithTask(current.count != 0, @"Unable to save a PFObject with a relation to a cycle.");
 
         // If a lazy user is one of the objects in the array, resolve its laziness now and
         // remove it from the list of things to save.
@@ -622,12 +620,10 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             }
             remaining = nextBatch;
 
-            if (current.count == 0) {
-                // We do cycle-detection when building the list of objects passed to this
-                // function, so this should never get called.  But we should check for it
-                // anyway, so that we get an exception instead of an infinite loop.
-                PFConsistencyAssertionFailure(@"Unable to save a PFObject with a relation to a cycle.");
-            }
+            // We do cycle-detection when building the list of objects passed to this
+            // function, so this should never get called.  But we should check for it
+            // anyway, so that we get an exception instead of an infinite loop.
+            PFPrecondition(current.count != 0, @"Unable to save a PFObject with a relation to a cycle.");
 
             // If a lazy user is one of the objects in the array, resolve its laziness now and
             // remove it from the list of things to save.

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -783,7 +783,9 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (BOOL)resolveLocalId:(NSError *__autoreleasing*)error {
     @synchronized (lock) {
-        PFConsistencyAssert(self.localId, @"Tried to resolve a localId for an object with no localId. (%@)", self.parseClassName);
+        if (!self.localId) {
+            PFConsistencyError(error, self.localId, NO, @"Tried to resolve a localId for an object with no localId. (%@)", self.parseClassName);
+        }
         NSString *newObjectId = [[Parse _currentManager].coreManager.objectLocalIdStore objectIdForLocalId:self.localId];
 
         // If we are resolving local ids, then this object is about to go over the network.

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -462,7 +462,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                             @synchronized ([object lock]) {
                                 [object _objectWillSave];
                                 NSError *error;
-                                if (![object _checkSaveParametersWithCurrentUser:currentUser error:&error] && error) {
+                                if (![object _checkSaveParametersWithCurrentUser:currentUser error:&error]) {
                                     return error;
                                 }
                                 command = [object _constructSaveCommandForChanges:[object unsavedChanges]
@@ -1107,14 +1107,14 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                     changes.saveEventually = YES;
                     [self startSave];
                     NSError *error;
-                    if (![self _checkSaveParametersWithCurrentUser:currentUser error:&error] && error) {
+                    if (![self _checkSaveParametersWithCurrentUser:currentUser error:&error]) {
                         saveTask = [BFTask taskWithError:error];
                     } else  {
                         PFRESTCommand *command = [self _constructSaveCommandForChanges:changes
                                                                           sessionToken:sessionToken
                                                                          objectEncoder:[PFPointerOrLocalIdObjectEncoder objectEncoder]
                                                                                  error:&error];
-                        if (!command && error) {
+                        if (!command) {
                             saveTask = [BFTask taskWithError:error];
                         } else {
                             // Enqueue the eventually operation!
@@ -1429,7 +1429,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                 }
                 return [[childrenTask continueWithSuccessBlock:^id(BFTask *task) {
                     NSError *error;
-                    if (![self _checkSaveParametersWithCurrentUser:currentUser error:&error] && error) {
+                    if (![self _checkSaveParametersWithCurrentUser:currentUser error:&error]) {
                         return error;
                     }
                     PFRESTCommand *command = [self _constructSaveCommandForChanges:changes

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -745,7 +745,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return self.localId;
 }
 
-- (BOOL)resolveLocalId:(NSError **)error {
+- (BOOL)resolveLocalId:(NSError *__autoreleasing*)error {
     @synchronized (lock) {
         PFConsistencyAssert(self.localId, @"Tried to resolve a localId for an object with no localId. (%@)", self.parseClassName);
         NSString *newObjectId = [[Parse _currentManager].coreManager.objectLocalIdStore objectIdForLocalId:self.localId];

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -737,7 +737,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return self.localId;
 }
 
-- (void)resolveLocalId {
+- (void)resolveLocalId:(NSError **)error {
     @synchronized (lock) {
         PFConsistencyAssert(self.localId, @"Tried to resolve a localId for an object with no localId. (%@)", self.parseClassName);
         NSString *newObjectId = [[Parse _currentManager].coreManager.objectLocalIdStore objectIdForLocalId:self.localId];
@@ -746,7 +746,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
         // But if it has local ids that haven't been resolved yet, then that's not going to
         // be possible.
         if (!newObjectId) {
-            PFConsistencyAssertionFailure(@"Tried to save an object with a pointer to a new, unsaved object. (%@)", self.parseClassName);
+            PFConsistencyError(error, newObjectId, void, @"Tried to save an object with a pointer to a new, unsaved object. (%@)", self.parseClassName);
         }
 
         // Nil out the localId so that the new objectId won't be saved back to the PFObjectLocalIdStore.
@@ -1771,7 +1771,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             [store updateObjectIdForObject:self oldObjectId:fromObjectId newObjectId:toObjectId];
         }
         if (self.localId) {
-            [[Parse _currentManager].coreManager.objectLocalIdStore setObjectId:toObjectId forLocalId:self.localId];
+            [[Parse _currentManager].coreManager.objectLocalIdStore setObjectId:toObjectId forLocalId:self.localId error:nil];
             self.localId = nil;
         }
     }

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -462,18 +462,24 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                             @synchronized ([object lock]) {
                                 [object _objectWillSave];
                                 [object _checkSaveParametersWithCurrentUser:currentUser];
+                                NSError *error;
                                 command = [object _constructSaveCommandForChanges:[object unsavedChanges]
                                                                      sessionToken:sessionToken
-                                                                    objectEncoder:[PFPointerObjectEncoder objectEncoder]];
+                                                                    objectEncoder:[PFPointerObjectEncoder objectEncoder]
+                                                                            error:&error];
+                                PFBailTaskIfError(command, error);
                                 [object startSave];
                             }
                             [commands addObject:command];
                         }
 
                         id<PFCommandRunning> commandRunner = [Parse _currentManager].commandRunner;
+                        NSError *error;
                         PFRESTCommand *batchCommand = [PFRESTObjectBatchCommand batchCommandWithCommands:commands
                                                                                             sessionToken:sessionToken
-                                                                                               serverURL:commandRunner.serverURL];
+                                                                                               serverURL:commandRunner.serverURL
+                                                                                                   error:&error];
+                        PFBailTaskIfError(batchCommand, error);
                         return [[commandRunner runCommandAsync:batchCommand withOptions:0] continueAsyncWithBlock:^id(BFTask *commandRunnerTask) {
                             NSArray *results = [commandRunnerTask.result result];
 
@@ -737,7 +743,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return self.localId;
 }
 
-- (void)resolveLocalId:(NSError **)error {
+- (BOOL)resolveLocalId:(NSError **)error {
     @synchronized (lock) {
         PFConsistencyAssert(self.localId, @"Tried to resolve a localId for an object with no localId. (%@)", self.parseClassName);
         NSString *newObjectId = [[Parse _currentManager].coreManager.objectLocalIdStore objectIdForLocalId:self.localId];
@@ -746,13 +752,14 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
         // But if it has local ids that haven't been resolved yet, then that's not going to
         // be possible.
         if (!newObjectId) {
-            PFConsistencyError(error, newObjectId, void, @"Tried to save an object with a pointer to a new, unsaved object. (%@)", self.parseClassName);
+            PFConsistencyError(error, newObjectId, NO, @"Tried to save an object with a pointer to a new, unsaved object. (%@)", self.parseClassName);
         }
 
         // Nil out the localId so that the new objectId won't be saved back to the PFObjectLocalIdStore.
         self.localId = nil;
         self.objectId = newObjectId;
     }
+    return YES;
 }
 
 + (id)_objectFromDictionary:(NSDictionary *)dictionary
@@ -867,7 +874,8 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
  Encodes parse object into NSDictionary suitable for persisting into LDS.
  */
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
-                                operationSetUUIDs:(NSArray **)operationSetUUIDs {
+                                operationSetUUIDs:(NSArray **)operationSetUUIDs
+                                            error:(NSError **)error {
     NSArray *operationQueue = nil;
     PFObjectState *state = nil;
     NSUInteger deletingEventuallyCount = 0;
@@ -881,15 +889,17 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                                operationSetUUIDs:operationSetUUIDs
                                            state:state
                                operationSetQueue:operationQueue
-                         deletingEventuallyCount:deletingEventuallyCount];
+                         deletingEventuallyCount:deletingEventuallyCount
+                                           error:error];
 }
 
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
                                             state:(PFObjectState *)state
                                 operationSetQueue:(NSArray *)queue
-                          deletingEventuallyCount:(NSUInteger)deletingEventuallyCount {
-    NSMutableDictionary *result = [[state dictionaryRepresentationWithObjectEncoder:objectEncoder] mutableCopy];
+                          deletingEventuallyCount:(NSUInteger)deletingEventuallyCount
+                                            error:(NSError **)error {
+    NSMutableDictionary *result = [[state dictionaryRepresentationWithObjectEncoder:objectEncoder error:error] mutableCopy];
     result[PFObjectClassNameRESTKey] = state.parseClassName;
     result[PFObjectCompleteRESTKey] = @(state.complete);
 
@@ -901,8 +911,11 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     NSMutableArray *mutableOperationSetUUIDs = [NSMutableArray array];
     for (PFOperationSet *operation in queue) {
         NSArray *ooSetUUIDs = nil;
-        [operations addObject:[operation RESTDictionaryUsingObjectEncoder:objectEncoder
-                                                        operationSetUUIDs:&ooSetUUIDs]];
+        id operationDict = [operation RESTDictionaryUsingObjectEncoder:objectEncoder
+                                                     operationSetUUIDs:&ooSetUUIDs
+                                                                 error:error];
+        PFBailIfError(operation, error, nil);
+        [operations addObject:operationDict];
         [mutableOperationSetUUIDs addObjectsFromArray:ooSetUUIDs];
     }
 
@@ -1079,13 +1092,18 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                     changes.saveEventually = YES;
                     [self startSave];
                     [self _checkSaveParametersWithCurrentUser:currentUser];
+                    NSError *error;
                     PFRESTCommand *command = [self _constructSaveCommandForChanges:changes
                                                                       sessionToken:sessionToken
-                                                                     objectEncoder:[PFPointerOrLocalIdObjectEncoder objectEncoder]];
-
-                    // Enqueue the eventually operation!
-                    saveTask = [[Parse _currentManager].eventuallyQueue enqueueCommandInBackground:command withObject:self];
-                    [self _enqueueSaveEventuallyOperationAsync:changes];
+                                                                     objectEncoder:[PFPointerOrLocalIdObjectEncoder objectEncoder]
+                                                                             error:&error];
+                    if (!command && error) {
+                        saveTask = [BFTask taskWithError:error];
+                    } else {
+                        // Enqueue the eventually operation!
+                        saveTask = [[Parse _currentManager].eventuallyQueue enqueueCommandInBackground:command withObject:self];
+                        [self _enqueueSaveEventuallyOperationAsync:changes];
+                    }
                 }
                 saveTask = [saveTask continueWithBlock:^id(BFTask *task) {
                     @try {
@@ -1133,13 +1151,14 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 ///--------------------------------------
 
 - (NSMutableDictionary *)_convertToDictionaryForSaving:(PFOperationSet *)changes
-                                     withObjectEncoder:(PFEncoder *)encoder {
+                                     withObjectEncoder:(PFEncoder *)encoder
+                                                 error:(NSError **)error {
     @synchronized (lock) {
         NSMutableDictionary *serialized = [NSMutableDictionary dictionary];
         [changes enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             serialized[key] = obj;
         }];
-        return [encoder encodeObject:serialized];
+        return [encoder encodeObject:serialized error:error];
     }
 }
 
@@ -1392,9 +1411,12 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                 }
                 return [[childrenTask continueWithSuccessBlock:^id(BFTask *task) {
                     [self _checkSaveParametersWithCurrentUser:currentUser];
+                    NSError *error;
                     PFRESTCommand *command = [self _constructSaveCommandForChanges:changes
                                                                       sessionToken:sessionToken
-                                                                     objectEncoder:[PFPointerObjectEncoder objectEncoder]];
+                                                                     objectEncoder:[PFPointerObjectEncoder objectEncoder]
+                                                                             error:&error];
+                    PFBailTaskIfError(command, error);
                     return [[Parse _currentManager].commandRunner runCommandAsync:command
                                                                       withOptions:PFCommandRunningOptionRetryIfFailed];
                 }] continueAsyncWithBlock:^id(BFTask *task) {
@@ -1437,11 +1459,13 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Command constructors
 ///--------------------------------------
 
-- (PFRESTCommand *)_constructSaveCommandForChanges:(PFOperationSet *)changes
+- (nullable PFRESTCommand *)_constructSaveCommandForChanges:(PFOperationSet *)changes
                                       sessionToken:(NSString *)sessionToken
-                                     objectEncoder:(PFEncoder *)encoder {
+                                     objectEncoder:(PFEncoder *)encoder
+                                             error:(NSError **)error {
     @synchronized (lock) {
-        NSDictionary *parameters = [self _convertToDictionaryForSaving:changes withObjectEncoder:encoder];
+        NSDictionary *parameters = [self _convertToDictionaryForSaving:changes withObjectEncoder:encoder error:error];
+        PFBailIfError(parameters, error, nil);
 
         if (self._state.objectId) {
             return [PFRESTObjectCommand updateObjectCommandForObjectState:self._state

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -1623,19 +1623,20 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (NSDictionary *)_collectFetchedObjects {
     NSMutableDictionary *fetchedObjects = [NSMutableDictionary dictionary];
+    NSDictionary *dictionary;
     @synchronized (lock) {
-        NSDictionary *dictionary = _estimatedData.dictionaryRepresentation;
-        [PFInternalUtils traverseObject:dictionary usingBlock:^id(id obj) {
-            if ([obj isKindOfClass:[PFObject class]]) {
-                PFObject *object = obj;
-                NSString *objectId = object.objectId;
-                if (objectId && object.dataAvailable) {
-                    fetchedObjects[objectId] = object;
-                }
-            }
-            return obj;
-        }];
+        dictionary = [_estimatedData.dictionaryRepresentation copy];
     }
+    [PFInternalUtils traverseObject:dictionary usingBlock:^id(id obj) {
+        if ([obj isKindOfClass:[PFObject class]]) {
+            PFObject *object = obj;
+            NSString *objectId = object.objectId;
+            if (objectId && object.dataAvailable) {
+                fetchedObjects[objectId] = object;
+            }
+        }
+        return obj;
+    }];
     return fetchedObjects;
 }
 

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -500,7 +500,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                                 [object _objectWillSave];
                                 NSError *error;
                                 if (![object _checkSaveParametersWithCurrentUser:currentUser error:&error]) {
-                                    return error;
+                                    return [BFTask taskWithError:error];
                                 }
                                 command = [object _constructSaveCommandForChanges:[object unsavedChanges]
                                                                      sessionToken:sessionToken
@@ -626,7 +626,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             // We do cycle-detection when building the list of objects passed to this
             // function, so this should never get called.  But we should check for it
             // anyway, so that we get an exception instead of an infinite loop.
-            PFPrecondition(current.count != 0, @"Unable to save a PFObject with a relation to a cycle.");
+            PFPreconditionWithTask(current.count != 0, @"Unable to save a PFObject with a relation to a cycle.");
 
             // If a lazy user is one of the objects in the array, resolve its laziness now and
             // remove it from the list of things to save.
@@ -1467,7 +1467,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                 return [[childrenTask continueWithSuccessBlock:^id(BFTask *task) {
                     NSError *error;
                     if (![self _checkSaveParametersWithCurrentUser:currentUser error:&error]) {
-                        return error;
+                        return [BFTask taskWithError:error];
                     }
                     PFRESTCommand *command = [self _constructSaveCommandForChanges:changes
                                                                       sessionToken:sessionToken

--- a/Parse/Parse/PFPolygon.m
+++ b/Parse/Parse/PFPolygon.m
@@ -104,7 +104,7 @@
 static NSString *const PFPolygonCodingTypeKey = @"__type";
 static NSString *const PFPolygonCodingCoordinatesKey = @"coordinates";
 
-- (NSDictionary *)encodeIntoDictionary {
+- (NSDictionary *)encodeIntoDictionary:(NSError **)error {
     return @{
              PFPolygonCodingTypeKey : @"Polygon",
              PFPolygonCodingCoordinatesKey : self.coordinates
@@ -173,7 +173,7 @@ static NSString *const PFPolygonCodingCoordinatesKey = @"coordinates";
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-    NSDictionary *dictionary = [self encodeIntoDictionary];
+    NSDictionary *dictionary = [self encodeIntoDictionary:nil];
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         [coder encodeObject:obj forKey:key];
     }];

--- a/Parse/Parse/PFRelation.m
+++ b/Parse/Parse/PFRelation.m
@@ -197,7 +197,7 @@ static NSString *const PFRelationKeyObjects = @"objects";
     NSMutableArray *encodedObjects = [NSMutableArray arrayWithCapacity:state.knownObjects.count];
     for (PFObject *knownObject in state.knownObjects) {
         id result = [[PFPointerObjectEncoder objectEncoder] encodeObject:knownObject error:error];
-        if (!result && error) {
+        if (!result) {
             return nil;
         }
         [encodedObjects addObject:result];

--- a/Parse/Parse/PFRelation.m
+++ b/Parse/Parse/PFRelation.m
@@ -192,12 +192,15 @@ static NSString *const PFRelationKeyObjects = @"objects";
     });
 }
 
-- (NSDictionary *)encodeIntoDictionary {
+- (nullable NSDictionary *)encodeIntoDictionary:(NSError **)error {
     PFRelationState *state = [self.state copy];
     NSMutableArray *encodedObjects = [NSMutableArray arrayWithCapacity:state.knownObjects.count];
-
     for (PFObject *knownObject in state.knownObjects) {
-        [encodedObjects addObject:[[PFPointerObjectEncoder objectEncoder] encodeObject:knownObject]];
+        id result = [[PFPointerObjectEncoder objectEncoder] encodeObject:knownObject error:error];
+        if (!result && error) {
+            return nil;
+        }
+        [encodedObjects addObject:result];
     }
 
     return @{

--- a/Parse/Parse/PFUser.m
+++ b/Parse/Parse/PFUser.m
@@ -631,7 +631,7 @@ static BOOL revocableSessionEnabled_;
 #pragma mark - REST operations
 ///--------------------------------------
 
-- (void)mergeFromRESTDictionary:(NSDictionary *)object withDecoder:(PFDecoder *)decoder {
+- (BOOL)mergeFromRESTDictionary:(NSDictionary *)object withDecoder:(PFDecoder *)decoder error:(NSError **)error {
     @synchronized([self lock]) {
         NSMutableDictionary *restDictionary = [object mutableCopy];
 
@@ -656,7 +656,7 @@ static BOOL revocableSessionEnabled_;
 
         self._state = state;
 
-        [super mergeFromRESTDictionary:restDictionary withDecoder:decoder];
+        return [super mergeFromRESTDictionary:restDictionary withDecoder:decoder error:error];
     }
 }
 

--- a/Parse/Parse/PFUser.m
+++ b/Parse/Parse/PFUser.m
@@ -134,15 +134,20 @@ static BOOL revocableSessionEnabled_;
 }
 
 // Checks the properties on the object before saving.
-- (void)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser {
+- (BOOL)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser error:(NSError **)error {
     @synchronized([self lock]) {
-        PFConsistencyAssert(self.objectId || self._lazy,
+        PFConsistencyError(error,
+                           self.objectId || self._lazy,
+                           NO,
                             @"User cannot be saved unless they are already signed up. Call signUp first.");
 
-        PFConsistencyAssert([self _isAuthenticatedWithCurrentUser:currentUser] ||
-                            [self.objectId isEqualToString:currentUser.objectId],
-                            @"User cannot be saved unless they have been authenticated via logIn or signUp", nil);
+        PFConsistencyError(error,
+                           [self _isAuthenticatedWithCurrentUser:currentUser] ||
+                           [self.objectId isEqualToString:currentUser.objectId],
+                           NO,
+                           @"User cannot be saved unless they have been authenticated via logIn or signUp");
     }
+    return YES;
 }
 
 // Checks the properties on the object before signUp.

--- a/Parse/Parse/PFUser.m
+++ b/Parse/Parse/PFUser.m
@@ -509,7 +509,7 @@ static BOOL revocableSessionEnabled_;
                 // self doesn't have any outstanding saves, so we can safely merge its operations
                 // into the current user.
 
-                PFPrecondition(!self._current, @"Attempt to merge currentUser with itself.");
+                PFPreconditionWithTask(!self._current, @"Attempt to merge currentUser with itself.");
 
                 @synchronized ([currentUser lock]) {
                     NSString *oldUsername = [currentUser.username copy];

--- a/Parse/Parse/PFUser.m
+++ b/Parse/Parse/PFUser.m
@@ -509,7 +509,7 @@ static BOOL revocableSessionEnabled_;
                 // self doesn't have any outstanding saves, so we can safely merge its operations
                 // into the current user.
 
-                PFConsistencyAssert(!self._current, @"Attempt to merge currentUser with itself.");
+                PFPrecondition(!self._current, @"Attempt to merge currentUser with itself.");
 
                 @synchronized ([currentUser lock]) {
                     NSString *oldUsername = [currentUser.username copy];

--- a/Parse/Parse/ParseClientConfiguration.m
+++ b/Parse/Parse/ParseClientConfiguration.m
@@ -45,7 +45,7 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 
     configurationBlock(self);
 
-    PFConsistencyAssert(self.applicationId.length, @"`applicationId` should not be nil.");
+    PFParameterAssert(self.applicationId.length, @"`applicationId` should not be nil.");
 
     return self;
 }

--- a/Parse/Parse/Resources/Parse-OSX.Info.plist
+++ b/Parse/Parse/Resources/Parse-OSX.Info.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 </dict>
 </plist>

--- a/Parse/Parse/Resources/Parse-OSX.Info.plist
+++ b/Parse/Parse/Resources/Parse-OSX.Info.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 </dict>
 </plist>

--- a/Parse/Parse/Resources/Parse-OSX.Info.plist
+++ b/Parse/Parse/Resources/Parse-OSX.Info.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 </dict>
 </plist>

--- a/Parse/Parse/Resources/Parse-OSX.Info.plist
+++ b/Parse/Parse/Resources/Parse-OSX.Info.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 </dict>
 </plist>

--- a/Parse/Parse/Resources/Parse-iOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-iOS.Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/Parse/Parse/Resources/Parse-iOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-iOS.Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/Parse/Parse/Resources/Parse-iOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-iOS.Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/Parse/Parse/Resources/Parse-iOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-iOS.Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/Parse/Parse/Resources/Parse-tvOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-tvOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-tvOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-tvOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-tvOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-tvOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-tvOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-tvOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-watchOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-watchOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-watchOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-watchOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-watchOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-watchOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Parse/Resources/Parse-watchOS.Info.plist
+++ b/Parse/Parse/Resources/Parse-watchOS.Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Parse/Tests/Other/Swift/SwiftSubclass.swift
+++ b/Parse/Tests/Other/Swift/SwiftSubclass.swift
@@ -29,4 +29,12 @@ public class SwiftSubclass: PFObject, PFSubclassing {
     func test_validateSwiftImport() {
         let _ = SwiftSubclass(withoutDataWithObjectId: "")
     }
+
+    func test_properACLSetters() {
+        let acl = PFACL()
+        acl.hasPublicReadAccess = true
+        acl.hasPublicWriteAccess = true
+        _ = acl.hasPublicWriteAccess
+        _ = acl.hasPublicReadAccess
+    }
 }

--- a/Parse/Tests/Unit/CloudCommandTests.m
+++ b/Parse/Tests/Unit/CloudCommandTests.m
@@ -20,7 +20,8 @@
 - (void)testFunctionCommand {
     PFRESTCloudCommand *command = [PFRESTCloudCommand commandForFunction:@"a"
                                                           withParameters:nil
-                                                            sessionToken:nil];
+                                                            sessionToken:nil
+                                                                   error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"functions/a");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -29,7 +30,8 @@
 
     command = [PFRESTCloudCommand commandForFunction:@"a"
                                       withParameters:@{ @"b" : @"c" }
-                                        sessionToken:@"yarr"];
+                                        sessionToken:@"yarr"
+                                               error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"functions/a");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);

--- a/Parse/Tests/Unit/CommandURLRequestConstructorTests.m
+++ b/Parse/Tests/Unit/CommandURLRequestConstructorTests.m
@@ -58,7 +58,8 @@
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodPOST
                                                      parameters:@{ @"a" : @"b" }
-                                                   sessionToken:@"yarr"];
+                                                   sessionToken:@"yarr"
+                                                          error:nil];
     command.additionalRequestHeaders = @{ @"CustomHeader" : @"CustomValue" };
 
     NSURLRequest *request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
@@ -79,28 +80,32 @@
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodGET
                                                      parameters:@{ @"a" : @"b" }
-                                                   sessionToken:@"yarr"];
+                                                   sessionToken:@"yarr"
+                                                          error:nil];
     NSURLRequest *request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
     XCTAssertEqualObjects(request.HTTPMethod, @"POST");
 
     command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                       httpMethod:PFHTTPRequestMethodHEAD
                                       parameters:@{ @"a" : @"b" }
-                                    sessionToken:@"yarr"];
+                                    sessionToken:@"yarr"
+                                           error:nil];
     request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
     XCTAssertEqualObjects(request.HTTPMethod, @"POST");
 
     command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                       httpMethod:PFHTTPRequestMethodGET
                                       parameters:@{ @"a" : @"b" }
-                                    sessionToken:@"yarr"];
+                                    sessionToken:@"yarr"
+                                           error:nil];
     request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
     XCTAssertEqualObjects(request.HTTPMethod, @"POST");
 
     command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                       httpMethod:PFHTTPRequestMethodGET
                                       parameters:nil
-                                    sessionToken:@"yarr"];
+                                    sessionToken:@"yarr"
+                                           error:nil];
     request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
     XCTAssertEqualObjects(request.HTTPMethod, @"GET");
 }
@@ -113,7 +118,8 @@
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodPOST
                                                      parameters:@{ @"a" : @100500 }
-                                                   sessionToken:@"yarr"];
+                                                   sessionToken:@"yarr"
+                                                          error:nil];
     NSURLRequest *request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
     id json = [NSJSONSerialization JSONObjectWithData:request.HTTPBody options:0 error:nil];
     XCTAssertNotNil(json);
@@ -128,7 +134,8 @@
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodPOST
                                                      parameters:@{ @"a" : @100500 }
-                                                   sessionToken:@"yarr"];
+                                                   sessionToken:@"yarr"
+                                                          error:nil];
     NSURLRequest *request = [[constructor getFileUploadURLRequestAsyncForCommand:command
                                                                  withContentType:@"boom"
                                                            contentSourceFilePath:@"/dev/null"] waitForResult:nil];

--- a/Parse/Tests/Unit/CommandUnitTests.m
+++ b/Parse/Tests/Unit/CommandUnitTests.m
@@ -50,7 +50,8 @@
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"login"
                                                      httpMethod:PFHTTPRequestMethodPOST
                                                      parameters:nil
-                                                   sessionToken:nil];
+                                                   sessionToken:nil
+                                                          error:nil];
 
     NSError *error = nil;
     PFURLSessionCommandRunner *commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:[Parse _currentManager]
@@ -80,7 +81,8 @@
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"login"
                                                      httpMethod:PFHTTPRequestMethodPOST
                                                      parameters:nil
-                                                   sessionToken:nil];
+                                                   sessionToken:nil
+                                                          error:nil];
 
     NSError *error = nil;
     PFURLSessionCommandRunner *commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:[Parse _currentManager]
@@ -107,7 +109,8 @@
     PFRESTCommand *orderedCommand = [PFRESTCommand commandWithHTTPPath:@"foo"
                                                             httpMethod:PFHTTPRequestMethodGET
                                                             parameters:orderedDict
-                                                          sessionToken:nil];
+                                                          sessionToken:nil
+                                                                 error:nil];
 
     NSMutableDictionary *reversedDict = [NSMutableDictionary dictionary];
     for (int i = 30; i >= 1; --i) {
@@ -117,7 +120,8 @@
     PFRESTCommand *reversedCommand = [PFRESTCommand commandWithHTTPPath:@"foo"
                                                              httpMethod:PFHTTPRequestMethodGET
                                                              parameters:reversedDict
-                                                           sessionToken:nil];
+                                                           sessionToken:nil
+                                                                  error:nil];
 
     XCTAssertEqualObjects(orderedCommand.cacheKey, reversedCommand.cacheKey,
                           @"identifiers should be invariant to dictionary key orders");

--- a/Parse/Tests/Unit/FieldOperationTests.m
+++ b/Parse/Tests/Unit/FieldOperationTests.m
@@ -203,7 +203,9 @@
     OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFAddOperation *operation = [PFAddOperation addWithObjects:@[ @"yarr" ]];
-    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
+    NSError *error;
+    XCTAssertNil([operation encodeWithObjectEncoder:nil error:&error]);
+    XCTAssertNil(error);
     XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"Add",
                                                                            @"objects" : @"yolo" }));
 }
@@ -252,7 +254,9 @@
     OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFAddUniqueOperation *operation = [PFAddUniqueOperation addUniqueWithObjects:@[ @"yarr" ]];
-    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
+    NSError *error;
+    XCTAssertNil([operation encodeWithObjectEncoder:nil error:&error]);
+    XCTAssertNil(error);
     XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"AddUnique",
                                                                            @"objects" : @"yolo" }));
 }
@@ -301,7 +305,9 @@
     OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFRemoveOperation *operation = [PFRemoveOperation removeWithObjects:@[ @"yarr" ]];
-    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
+    NSError *error;
+    XCTAssertNil([operation encodeWithObjectEncoder:nil error:&error]);
+    XCTAssertNil(error);
     XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"Remove",
                                                                            @"objects" : @"yolo" }));
 }

--- a/Parse/Tests/Unit/FieldOperationTests.m
+++ b/Parse/Tests/Unit/FieldOperationTests.m
@@ -30,7 +30,7 @@
 
 - (void)testFieldOperationEncoding {
     PFFieldOperation *operation = [[PFFieldOperation alloc] init];
-    XCTAssertThrows([operation encodeWithObjectEncoder:[PFEncoder objectEncoder]]);
+    XCTAssertThrows([operation encodeWithObjectEncoder:[PFEncoder objectEncoder] error:nil]);
 }
 
 - (void)testFieldOperationMerge {
@@ -82,10 +82,10 @@
 
 - (void)testSetOperationEncoding {
     PFEncoder *encoder = PFStrictClassMock([PFEncoder class]);
-    OCMStub([encoder encodeObject:[OCMArg isEqual:@"yarr"]]).andReturn(@"yolo");
+    OCMStub([encoder encodeObject:[OCMArg isEqual:@"yarr"] error:nil]).andReturn(@"yolo");
 
     PFSetOperation *operation = [PFSetOperation setWithValue:@"yarr"];
-    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder], @"yolo");
+    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], @"yolo");
 }
 
 ///--------------------------------------
@@ -108,10 +108,10 @@
 - (void)testDeleteOperationEncoding {
     PFDeleteOperation *operation = [PFDeleteOperation operation];
 
-    NSDictionary *encoded = [operation encodeWithObjectEncoder:nil];
+    NSDictionary *encoded = [operation encodeWithObjectEncoder:nil error:nil];
     XCTAssertEqualObjects(encoded, @{ @"__op" : @"Delete" });
 
-    encoded = [operation encodeWithObjectEncoder:[PFEncoder objectEncoder]];
+    encoded = [operation encodeWithObjectEncoder:[PFEncoder objectEncoder] error:nil];
     XCTAssertEqualObjects(encoded, @{ @"__op" : @"Delete" });
 }
 
@@ -153,10 +153,10 @@
     NSDictionary *properEncodedDictionary = @{ @"__op" : @"Increment",
                                                @"amount" : @100500 };
 
-    NSDictionary *encoded = [operation encodeWithObjectEncoder:nil];
+    NSDictionary *encoded = [operation encodeWithObjectEncoder:nil error:nil];
     XCTAssertEqualObjects(encoded, properEncodedDictionary);
 
-    encoded = [operation encodeWithObjectEncoder:[PFEncoder objectEncoder]];
+    encoded = [operation encodeWithObjectEncoder:[PFEncoder objectEncoder] error:nil];
     XCTAssertEqualObjects(encoded, properEncodedDictionary);
 }
 
@@ -200,11 +200,11 @@
 
 - (void)testAddOperationEncoding {
     PFEncoder *encoder = PFStrictClassMock([PFEncoder class]);
-    OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]]]).andReturn(@"yolo");
+    OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFAddOperation *operation = [PFAddOperation addWithObjects:@[ @"yarr" ]];
-    XCTAssertThrows([operation encodeWithObjectEncoder:nil]);
-    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder], (@{ @"__op" : @"Add",
+    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
+    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"Add",
                                                                            @"objects" : @"yolo" }));
 }
 
@@ -249,11 +249,11 @@
 
 - (void)testAddUniqueOperationEncoding {
     PFEncoder *encoder = PFStrictClassMock([PFEncoder class]);
-    OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]]]).andReturn(@"yolo");
+    OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFAddUniqueOperation *operation = [PFAddUniqueOperation addUniqueWithObjects:@[ @"yarr" ]];
-    XCTAssertThrows([operation encodeWithObjectEncoder:nil]);
-    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder], (@{ @"__op" : @"AddUnique",
+    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
+    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"AddUnique",
                                                                            @"objects" : @"yolo" }));
 }
 
@@ -298,11 +298,11 @@
 
 - (void)testRemoveOperationEncoding {
     PFEncoder *encoder = PFStrictClassMock([PFEncoder class]);
-    OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]]]).andReturn(@"yolo");
+    OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFRemoveOperation *operation = [PFRemoveOperation removeWithObjects:@[ @"yarr" ]];
-    XCTAssertThrows([operation encodeWithObjectEncoder:nil]);
-    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder], (@{ @"__op" : @"Remove",
+    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
+    XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"Remove",
                                                                            @"objects" : @"yolo" }));
 }
 
@@ -362,28 +362,28 @@
 - (void)testRelationOperationEncoding {
     PFObject *object = [PFObject objectWithClassName:@"Yolo"];
     PFEncoder *encoder = PFStrictClassMock([PFEncoder class]);
-    OCMStub([encoder encodeObject:OCMOCK_ANY]).andReturn(@"yolo");
+    OCMStub([encoder encodeObject:OCMOCK_ANY error:nil]).andReturn(@"yolo");
 
     PFRelationOperation *operation = [PFRelationOperation addRelationToObjects:@[ object, object ]];
-    NSDictionary *encoded = [operation encodeWithObjectEncoder:encoder];
+    NSDictionary *encoded = [operation encodeWithObjectEncoder:encoder error:nil];
     XCTAssertEqualObjects(encoded, (@{ @"__op" : @"AddRelation",
                                        @"objects" : @[ @"yolo" ] }));
 
     operation = [PFRelationOperation removeRelationToObjects:@[ object, object ]];
-    encoded = [operation encodeWithObjectEncoder:encoder];
+    encoded = [operation encodeWithObjectEncoder:encoder error:nil];
     XCTAssertEqualObjects(encoded, (@{ @"__op" : @"RemoveRelation",
                                        @"objects" : @[ @"yolo" ] }));
 
     PFObject *anotherObject = [PFObject objectWithClassName:@"Yolo"];
 
     operation = (PFRelationOperation *)[operation mergeWithPrevious:[PFRelationOperation addRelationToObjects:@[ anotherObject ]]];
-    encoded = [operation encodeWithObjectEncoder:encoder];
+    encoded = [operation encodeWithObjectEncoder:encoder error:nil];
     XCTAssertEqualObjects(encoded, (@{ @"__op" : @"Batch",
                                        @"ops" : @[ @{@"__op" : @"AddRelation", @"objects" : @[ @"yolo" ]},
                                                    @{@"__op" : @"RemoveRelation", @"objects" : @[ @"yolo" ]} ] }));
 
-    XCTAssertThrows([[PFRelationOperation addRelationToObjects:@[]] encodeWithObjectEncoder:encoder]);
-    XCTAssertThrows([[PFRelationOperation removeRelationToObjects:@[]] encodeWithObjectEncoder:encoder]);
+    XCTAssertThrows([[PFRelationOperation addRelationToObjects:@[]] encodeWithObjectEncoder:encoder error:nil]);
+    XCTAssertThrows([[PFRelationOperation removeRelationToObjects:@[]] encodeWithObjectEncoder:encoder error:nil]);
 }
 
 - (void)testRelationOperationMerge {

--- a/Parse/Tests/Unit/FieldOperationTests.m
+++ b/Parse/Tests/Unit/FieldOperationTests.m
@@ -203,9 +203,7 @@
     OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFAddOperation *operation = [PFAddOperation addWithObjects:@[ @"yarr" ]];
-    NSError *error;
-    XCTAssertNil([operation encodeWithObjectEncoder:nil error:&error]);
-    XCTAssertNil(error);
+    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
     XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"Add",
                                                                            @"objects" : @"yolo" }));
 }
@@ -254,9 +252,7 @@
     OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFAddUniqueOperation *operation = [PFAddUniqueOperation addUniqueWithObjects:@[ @"yarr" ]];
-    NSError *error;
-    XCTAssertNil([operation encodeWithObjectEncoder:nil error:&error]);
-    XCTAssertNil(error);
+    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
     XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"AddUnique",
                                                                            @"objects" : @"yolo" }));
 }
@@ -305,9 +301,7 @@
     OCMStub([encoder encodeObject:[OCMArg isEqual:@[ @"yarr" ]] error:nil]).andReturn(@"yolo");
 
     PFRemoveOperation *operation = [PFRemoveOperation removeWithObjects:@[ @"yarr" ]];
-    NSError *error;
-    XCTAssertNil([operation encodeWithObjectEncoder:nil error:&error]);
-    XCTAssertNil(error);
+    XCTAssertThrows([operation encodeWithObjectEncoder:nil error:nil]);
     XCTAssertEqualObjects([operation encodeWithObjectEncoder:encoder error:nil], (@{ @"__op" : @"Remove",
                                                                            @"objects" : @"yolo" }));
 }

--- a/Parse/Tests/Unit/GeoPointUnitTests.m
+++ b/Parse/Tests/Unit/GeoPointUnitTests.m
@@ -42,7 +42,7 @@
 - (void)testGeoPointDictionaryEncoding {
     PFGeoPoint *point = [PFGeoPoint geoPointWithLatitude:10 longitude:20];
 
-    NSDictionary *dictionary = [point encodeIntoDictionary];
+    NSDictionary *dictionary = [point encodeIntoDictionary:nil];
     XCTAssertNotNil(dictionary);
 
     PFGeoPoint *pointFromDictionary = [PFGeoPoint geoPointWithDictionary:dictionary];

--- a/Parse/Tests/Unit/ObjectBatchCommandTests.m
+++ b/Parse/Tests/Unit/ObjectBatchCommandTests.m
@@ -58,7 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray *commands = [self sampleObjectCommands];
     PFRESTObjectBatchCommand *command = [PFRESTObjectBatchCommand batchCommandWithCommands:commands
                                                                               sessionToken:@"yolo"
-                                                                                 serverURL:[NSURL URLWithString:@"https://api.parse.com/1"]];
+                                                                                 serverURL:[NSURL URLWithString:@"https://api.parse.com/1"]
+                                                                                     error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"batch");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -76,10 +77,12 @@ NS_ASSUME_NONNULL_BEGIN
     while (array.count < PFRESTObjectBatchCommandSubcommandsLimit) {
         [array addObjectsFromArray:[self sampleObjectCommands]];
     }
-
+    NSError *error;
     PFAssertThrowsInvalidArgumentException([PFRESTObjectBatchCommand batchCommandWithCommands:array
                                                                                  sessionToken:@"a"
-                                                                                    serverURL:[NSURL URLWithString:@"https://api.parse.com/1"]]);
+                                                                                    serverURL:[NSURL URLWithString:@"https://api.parse.com/1"]
+                                                                                        error:&error]);
+    XCTAssertNil(error);
 }
 
 @end

--- a/Parse/Tests/Unit/ObjectLocalIdStoreTests.m
+++ b/Parse/Tests/Unit/ObjectLocalIdStoreTests.m
@@ -140,4 +140,19 @@
     XCTAssertEqual(expected, actual, @"The number should be parsed correctly.");
 }
 
+- (void)testInvalidLocalId {
+    id<PFFileManagerProvider> dataSource = [self mockedDataSource];
+    PFFileManager *fileManager = dataSource.fileManager;
+    OCMStub([fileManager parseDataItemPathForPathComponent:[OCMArg isNotNil]]).andReturn(NSTemporaryDirectory());
+
+    PFObjectLocalIdStore *store = [[PFObjectLocalIdStore alloc] initWithDataSource:dataSource];
+    NSError *error;
+    BOOL rval = [store retainLocalIdOnDisk:@"bad-local-id" error:&error];
+    XCTAssertFalse(rval);
+    XCTAssertNotNil(error.domain);
+    XCTAssertEqual(error.domain, PFParseErrorDomain);
+    XCTAssertEqual(error.code, -1);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to get invalid local id: \"bad-local-id\".");
+}
+
 @end

--- a/Parse/Tests/Unit/ObjectLocalIdStoreTests.m
+++ b/Parse/Tests/Unit/ObjectLocalIdStoreTests.m
@@ -59,41 +59,41 @@
 
     NSString *localId1 = [store createLocalId];
     XCTAssertNotNil(localId1);
-    [store retainLocalIdOnDisk:localId1]; // refcount = 1
+    [store retainLocalIdOnDisk:localId1 error:nil]; // refcount = 1
     XCTAssertNil([store objectIdForLocalId:localId1]);
 
     NSString *localId2 = [store createLocalId];
     XCTAssertNotNil(localId2);
-    [store retainLocalIdOnDisk:localId2]; // refcount = 1
+    [store retainLocalIdOnDisk:localId2 error:nil]; // refcount = 1
     XCTAssertNil([store objectIdForLocalId:localId2]);
 
-    [store retainLocalIdOnDisk:localId1]; // refcount = 2
+    [store retainLocalIdOnDisk:localId1 error:nil]; // refcount = 2
     XCTAssertNil([store objectIdForLocalId:localId1]);
     XCTAssertNil([store objectIdForLocalId:localId2]);
 
-    [store releaseLocalIdOnDisk:localId1]; // refcount = 1
+    [store releaseLocalIdOnDisk:localId1 error:nil]; // refcount = 1
     XCTAssertNil([store objectIdForLocalId:localId1]);
     XCTAssertNil([store objectIdForLocalId:localId2]);
 
     NSString *objectId1 = @"objectId1";
-    [store setObjectId:objectId1 forLocalId:localId1];
+    [store setObjectId:objectId1 forLocalId:localId1 error:nil];
     XCTAssertEqualObjects(objectId1, [store objectIdForLocalId:localId1]);
     XCTAssertNil([store objectIdForLocalId:localId2]);
 
-    [store retainLocalIdOnDisk:localId1]; // refcount = 2
+    [store retainLocalIdOnDisk:localId1 error:nil]; // refcount = 2
     XCTAssertEqualObjects(objectId1, [store objectIdForLocalId:localId1]);
     XCTAssertNil([store objectIdForLocalId:localId2]);
 
     NSString *objectId2 = @"objectId2";
-    [store setObjectId:objectId2 forLocalId:localId2];
+    [store setObjectId:objectId2 forLocalId:localId2 error:nil];
     XCTAssertEqualObjects(objectId1, [store objectIdForLocalId:localId1]);
     XCTAssertEqualObjects(objectId2, [store objectIdForLocalId:localId2]);
 
-    [store releaseLocalIdOnDisk:localId1]; // refcount = 1
+    [store releaseLocalIdOnDisk:localId1 error:nil]; // refcount = 1
     XCTAssertEqualObjects(objectId1, [store objectIdForLocalId:localId1]);
     XCTAssertEqualObjects(objectId2, [store objectIdForLocalId:localId2]);
 
-    [store releaseLocalIdOnDisk:localId1]; // refcount = 0
+    [store releaseLocalIdOnDisk:localId1 error:nil]; // refcount = 0
     XCTAssertEqualObjects(objectId1, [store objectIdForLocalId:localId1]);
     XCTAssertEqualObjects(objectId2, [store objectIdForLocalId:localId2]);
 
@@ -101,7 +101,7 @@
     XCTAssertNil([store objectIdForLocalId:localId1]);
     XCTAssertEqualObjects(objectId2, [store objectIdForLocalId:localId2]);
 
-    [store releaseLocalIdOnDisk:localId2]; // refcount = 0
+    [store releaseLocalIdOnDisk:localId2 error:nil]; // refcount = 0
     XCTAssertNil([store objectIdForLocalId:localId1]);
     XCTAssertNil([store objectIdForLocalId:localId2]);
 
@@ -120,8 +120,8 @@
     PFObjectLocalIdStore *store = [[PFObjectLocalIdStore alloc] initWithDataSource:dataSource];
 
     NSString *localId = [store createLocalId];
-    [store setObjectId:@"venus" forLocalId:localId];
-    [store retainLocalIdOnDisk:localId];
+    [store setObjectId:@"venus" forLocalId:localId error:nil];
+    [store retainLocalIdOnDisk:localId error:nil];
     [store clearInMemoryCache];
     XCTAssertEqualObjects(@"venus", [store objectIdForLocalId:localId]);
 

--- a/Parse/Tests/Unit/ObjectStateTests.m
+++ b/Parse/Tests/Unit/ObjectStateTests.m
@@ -191,7 +191,7 @@
         @"a": @"b"
     };
 
-    NSDictionary *actual = [mutableState dictionaryRepresentationWithObjectEncoder:[PFEncoder objectEncoder]];
+    NSDictionary *actual = [mutableState dictionaryRepresentationWithObjectEncoder:[PFEncoder objectEncoder] error:nil];
     XCTAssertEqualObjects(actual, expected);
 }
 

--- a/Parse/Tests/Unit/ObjectUnitTests.m
+++ b/Parse/Tests/Unit/ObjectUnitTests.m
@@ -292,4 +292,40 @@
     XCTAssertFalse(objectA.dirty);
 }
 
+-(void)testSaveRelationToACycle {
+    PFObject *objectA = [PFObject objectWithClassName:@"A"];
+    PFObject *objectB = [PFObject objectWithClassName:@"B"];
+    objectA[@"B"] = objectB;
+    objectB[@"A"] = objectA;
+    NSError *error;
+    [objectA save:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Found a circular dependency when saving.");
+}
+-(void)testSaveRelationToACycleInAnArray {
+    PFObject *objectA = [PFObject objectWithClassName:@"A"];
+    PFObject *objectB = [PFObject objectWithClassName:@"B"];
+    objectA[@"B"] = objectB;
+    objectB[@"A"] = @[objectA];
+    NSError *error;
+    [objectA save:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Found a circular dependency when saving.");
+}
+
+-(void)testSaveRelationToACycleInANestedObject {
+    PFObject *objectA = [PFObject objectWithClassName:@"A"];
+    PFObject *objectB = [PFObject objectWithClassName:@"B"];
+    objectA[@"B"] = objectB;
+    objectB[@"A"] = @{@"a": objectA};
+    NSError *error;
+    [objectA save:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Found a circular dependency when saving.");
+}
+
+
 @end

--- a/Parse/Tests/Unit/OperationSetUnitTests.m
+++ b/Parse/Tests/Unit/OperationSetUnitTests.m
@@ -53,7 +53,8 @@
     // Use default PFEncoding
     NSArray *operationSetUUIDs = nil;
     NSDictionary *restified = [operation1 RESTDictionaryUsingObjectEncoder:[PFPointerObjectEncoder objectEncoder]
-                                                         operationSetUUIDs:&operationSetUUIDs];
+                                                         operationSetUUIDs:&operationSetUUIDs
+                                                                     error:nil];
     // Check returned operationSetUUIDs
     XCTAssertNotNil(operationSetUUIDs);
     PFAssertEqualInts(1, operationSetUUIDs.count);

--- a/Parse/Tests/Unit/PolygonUnitTests.m
+++ b/Parse/Tests/Unit/PolygonUnitTests.m
@@ -37,7 +37,7 @@
 - (void)testPolygonDictionaryEncoding {
     PFPolygon *polygon = [PFPolygon polygonWithCoordinates:_testPoints];
 
-    NSDictionary *dictionary = [polygon encodeIntoDictionary];
+    NSDictionary *dictionary = [polygon encodeIntoDictionary:nil];
     XCTAssertNotNil(dictionary);
 
     PFPolygon *polygonFromDictionary = [PFPolygon polygonWithDictionary:dictionary];
@@ -49,7 +49,7 @@
     PFPolygon *polygon = [PFPolygon polygonWithCoordinates:_testPoints];
     
     PFEncoder *encoder = [[PFEncoder alloc] init];
-    NSDictionary *dictionary = [encoder encodeObject:polygon];
+    NSDictionary *dictionary = [encoder encodeObject:polygon error:nil];
     XCTAssertNotNil(dictionary);
     
     PFPolygon *polygonFromDictionary = [PFPolygon polygonWithDictionary:dictionary];

--- a/Parse/Tests/Unit/PushCommandTests.m
+++ b/Parse/Tests/Unit/PushCommandTests.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testEmptyPushCommand {
     PFMutablePushState *state = [[PFMutablePushState alloc] init];
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
     PFMutablePushState *state = [[PFMutablePushState alloc] init];
     state.channels = [NSSet setWithObject:@"El Capitan!"];
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
     [queryState setEqualityConditionWithObject:@"value" forKey:@"key"];
     state.queryState = queryState;
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
     PFMutablePushState *state = [[PFMutablePushState alloc] init];
     state.expirationDate = [NSDate date];
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
     PFMutablePushState *state = [[PFMutablePushState alloc] init];
     state.expirationTimeInterval = @100500;
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     PFMutablePushState *state = [[PFMutablePushState alloc] init];
     state.pushDate = [NSDate dateWithTimeIntervalSinceNow:1.0];
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
     PFMutablePushState *state = [[PFMutablePushState alloc] init];
     state.payload = @{ @"alert" : @"yolo" };
 
-    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr"];
+    PFRESTPushCommand *command = [PFRESTPushCommand sendPushCommandWithPushState:state sessionToken:@"yarr" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"push");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);

--- a/Parse/Tests/Unit/QueryCachedControllerTests.m
+++ b/Parse/Tests/Unit/QueryCachedControllerTests.m
@@ -369,7 +369,7 @@
     PFQueryState *state = [self sampleQueryStateWithCachePolicy:0];
     PFCachedQueryController *controller = [PFCachedQueryController controllerWithCommonDataSource:dataSource];
 
-    NSString *cacheKey = [PFRESTQueryCommand findCommandForQueryState:state withSessionToken:@"a"].cacheKey;
+    NSString *cacheKey = [PFRESTQueryCommand findCommandForQueryState:state withSessionToken:@"a" error:nil].cacheKey;
     XCTAssertEqualObjects([controller cacheKeyForQueryState:state sessionToken:@"a"], cacheKey);
 }
 
@@ -380,7 +380,7 @@
     PFQueryState *state = [self sampleQueryStateWithCachePolicy:0];
     PFCachedQueryController *controller = [PFCachedQueryController controllerWithCommonDataSource:dataSource];
 
-    NSString *cacheKey = [PFRESTQueryCommand findCommandForQueryState:state withSessionToken:@"a"].cacheKey;
+    NSString *cacheKey = [PFRESTQueryCommand findCommandForQueryState:state withSessionToken:@"a" error:nil].cacheKey;
 
     NSString *jsonString = [PFJSONSerialization stringFromJSONObject:[self sampleCommandResult].result];
     OCMStub([[cache ignoringNonObjectArgs] objectForKey:[OCMArg checkWithBlock:^BOOL(id obj) {
@@ -389,7 +389,7 @@
 
     XCTAssertTrue([controller hasCachedResultForQueryState:state sessionToken:@"a"]);
 
-    cacheKey = [PFRESTQueryCommand findCommandForQueryState:state withSessionToken:nil].cacheKey;
+    cacheKey = [PFRESTQueryCommand findCommandForQueryState:state withSessionToken:nil error:nil].cacheKey;
     OCMStub([[cache ignoringNonObjectArgs] objectForKey:[OCMArg checkWithBlock:^BOOL(id obj) {
         return [obj isEqual:cacheKey];
     }] maxAge:0]).andReturn(nil);

--- a/Parse/Tests/Unit/QueryUnitTests.m
+++ b/Parse/Tests/Unit/QueryUnitTests.m
@@ -1413,4 +1413,23 @@
     XCTAssertEqual([queryA hash], [queryB hash]);
 }
 
+- (void)testReproduceIssue1202 {
+    [[Parse _currentManager] clearEventuallyQueue];
+    [Parse _clearCurrentManager];
+    [Parse enableLocalDatastore];
+    [Parse setApplicationId:@"a" clientKey:@"b"];
+    PFObject *objectA = [PFObject objectWithClassName:@"Object" dictionary:@{@"objectId":@"yolo", @"key": @"value"}];
+    objectA.objectId = @"yolo";
+    PFObject *objectB = [PFObject objectWithClassName:@"Object" dictionary:@{@"objectId":@"yolo", @"key": @"value"}];
+    @try {
+        objectB.objectId = @"yolo";
+        XCTFail();
+    }
+    @catch (NSException *e) {
+        XCTAssertEqual(e.name, NSInternalInconsistencyException);
+        XCTAssertEqualObjects(e.reason, @"Attempted to change an objectId to one that's already known to the OfflineStore. className: Object old: (null), new: yolo");
+    }
+}
+
+
 @end

--- a/Parse/Tests/Unit/RelationUnitTests.m
+++ b/Parse/Tests/Unit/RelationUnitTests.m
@@ -141,7 +141,7 @@
 
     [relation _addKnownObject:mockedObject];
 
-    NSDictionary *encoded = [relation encodeIntoDictionary];
+    NSDictionary *encoded = [relation encodeIntoDictionary:nil];
     XCTAssertEqual(1, [encoded[@"objects"] count]);
     XCTAssertNotNil(encoded);
 }

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -346,6 +346,8 @@
 }
 
 - (void)testLocalIdResolutionWithOperations {
+    NSArray *possibleErrors = @[@"Tried to save an object with a pointer to a new, unsaved object.",
+                                @"Tried to resolve a localId for an object with no localId."];
     NSError *error;
     PFObject *objectWithLocalId = [PFObject objectWithoutDataWithClassName:@"Yolo" localId:@"localId"];
     PFObject *object = [PFObject objectWithClassName:@"Yolo"];
@@ -354,7 +356,7 @@
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+    XCTAssertTrue([possibleErrors indexOfObject:error.localizedDescription] != NSNotFound);
 
     error = nil;
 
@@ -363,14 +365,16 @@
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+    XCTAssertTrue([possibleErrors indexOfObject:error.localizedDescription] != NSNotFound);
+
+    error = nil;
 
     PFRemoveOperation *removeOperation = [PFRemoveOperation removeWithObjects:@[objectWithLocalId, object]];
     command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"values":removeOperation} sessionToken:nil error:nil];
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+    XCTAssertTrue([possibleErrors indexOfObject:error.localizedDescription] != NSNotFound);
 }
 
 @end

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -313,4 +313,14 @@
     XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
 }
 
+- (void)testLocalIdResolutionFailureWithNoLocalId {
+    PFObject *object = [PFObject objectWithClassName:@"Yolo"];
+    id command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"object": object} sessionToken:nil error:nil];
+    NSError *error;
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId.");
+}
+
 @end

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -19,6 +19,7 @@
 #import "PFTestCase.h"
 #import "PFObject.h"
 #import "PFObjectPrivate.h"
+#import "PFFieldOperation.h"
 #import "PFURLSession.h"
 #import "PFURLSessionCommandRunner_Private.h"
 
@@ -321,6 +322,55 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
     XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId.");
+}
+
+- (void)testLocalIdResolutionWithArray {
+    PFObject *object = [PFObject objectWithClassName:@"Yolo"];
+    id command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"values":@[@(1), object]} sessionToken:nil error:nil];
+    NSError *error;
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId.");
+}
+
+- (void)testLocalIdResolutionWithArrayAndMutlipleErrors {
+    PFObject *objectWithLocalId = [PFObject objectWithoutDataWithClassName:@"Yolo" localId:@"localId"];
+    PFObject *object = [PFObject objectWithClassName:@"Yolo"];
+    id command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"values":@[objectWithLocalId, object]} sessionToken:nil error:nil];
+    NSError *error;
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+}
+
+- (void)testLocalIdResolutionWithOperations {
+    NSError *error;
+    PFObject *objectWithLocalId = [PFObject objectWithoutDataWithClassName:@"Yolo" localId:@"localId"];
+    PFObject *object = [PFObject objectWithClassName:@"Yolo"];
+    PFAddOperation *addOperation = [PFAddOperation addWithObjects:@[objectWithLocalId, object]];
+    id command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"values":addOperation} sessionToken:nil error:nil];
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+
+    error = nil;
+
+    PFAddUniqueOperation *addUniqueOperation = [PFAddUniqueOperation addUniqueWithObjects:@[objectWithLocalId, object]];
+    command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"values":addUniqueOperation} sessionToken:nil error:nil];
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+
+    PFRemoveOperation *removeOperation = [PFRemoveOperation removeWithObjects:@[objectWithLocalId, object]];
+    command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"values":removeOperation} sessionToken:nil error:nil];
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
 }
 
 @end

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -64,7 +64,7 @@
 
     NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://foo.bar"]];
 
-    OCMStub([mockedCommand resolveLocalIds]);
+    OCMStub([mockedCommand resolveLocalIds:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andReturn(YES);
 
     OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
     [OCMExpect([mockedSession performDataURLRequestAsync:urlRequest
@@ -135,7 +135,7 @@
 
     __block int performDataURLRequestCount = 0;
 
-    OCMStub([mockedCommand resolveLocalIds]);
+    OCMStub([mockedCommand resolveLocalIds:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andReturn(YES);
     OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
 
     [OCMStub([mockedSession performDataURLRequestAsync:urlRequest
@@ -228,7 +228,7 @@
         lastProgress = progress;
     } copy];
 
-    OCMStub([mockedCommand resolveLocalIds]);
+    OCMStub([mockedCommand resolveLocalIds:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andReturn(YES);
 
     OCMExpect([mockedRequestConstructor getFileUploadURLRequestAsyncForCommand:mockedCommand
                                                                withContentType:@"content-type"
@@ -275,7 +275,7 @@
 
     NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://foo.bar"]];
 
-    OCMExpect([mockedCommand resolveLocalIds]);
+    OCMExpect([mockedCommand resolveLocalIds:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andReturn(YES);
 
     OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
     [OCMStub([mockedSession performDataURLRequestAsync:urlRequest

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -183,7 +183,7 @@
                                                  code:kPFErrorInvalidSessionToken
                                              userInfo:nil];
 
-    OCMStub([mockedCommand resolveLocalIds]);
+    OCMStub([mockedCommand resolveLocalIds:(NSError * __autoreleasing *)[OCMArg anyPointer]]);
     OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
 
     [OCMStub([mockedSession performDataURLRequestAsync:urlRequest
@@ -311,7 +311,7 @@
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object. (Yolo)");
 }
 
 - (void)testLocalIdResolutionFailureWithNoLocalId {
@@ -321,7 +321,7 @@
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId.");
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId. (Yolo)");
 }
 
 - (void)testLocalIdResolutionWithArray {
@@ -331,7 +331,7 @@
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId.");
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to resolve a localId for an object with no localId. (Yolo)");
 }
 
 - (void)testLocalIdResolutionWithArrayAndMutlipleErrors {
@@ -342,12 +342,12 @@
     [command resolveLocalIds:&error];
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object. (Yolo)");
 }
 
 - (void)testLocalIdResolutionWithOperations {
-    NSArray *possibleErrors = @[@"Tried to save an object with a pointer to a new, unsaved object.",
-                                @"Tried to resolve a localId for an object with no localId."];
+    NSArray *possibleErrors = @[@"Tried to save an object with a pointer to a new, unsaved object. (Yolo)",
+                                @"Tried to resolve a localId for an object with no localId. (Yolo)"];
     NSError *error;
     PFObject *objectWithLocalId = [PFObject objectWithoutDataWithClassName:@"Yolo" localId:@"localId"];
     PFObject *object = [PFObject objectWithClassName:@"Yolo"];

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -17,6 +17,8 @@
 #import "PFCommandURLRequestConstructor.h"
 #import "PFRESTCommand.h"
 #import "PFTestCase.h"
+#import "PFObject.h"
+#import "PFObjectPrivate.h"
 #import "PFURLSession.h"
 #import "PFURLSessionCommandRunner_Private.h"
 
@@ -299,6 +301,16 @@
     [self waitForTestExpectations];
 
     OCMVerifyAll(mockedCommand);
+}
+
+- (void)testLocalIdResolutionFailure {
+    PFObject *object = [PFObject objectWithoutDataWithClassName:@"Yolo" localId:@"localId"];
+    id command = [PFRESTCommand commandWithHTTPPath:@"" httpMethod:@"" parameters:@{@"object": object} sessionToken:nil error:nil];
+    NSError *error;
+    [command resolveLocalIds:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a pointer to a new, unsaved object.");
 }
 
 @end

--- a/Parse/Tests/Unit/UserCommandTests.m
+++ b/Parse/Tests/Unit/UserCommandTests.m
@@ -20,7 +20,8 @@
 - (void)testLogInCommand {
     PFRESTUserCommand *command = [PFRESTUserCommand logInUserCommandWithUsername:@"a"
                                                                         password:@"b"
-                                                                revocableSession:YES];
+                                                                revocableSession:YES
+                                                                           error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"login");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodGET);
@@ -33,7 +34,8 @@
 
     command = [PFRESTUserCommand logInUserCommandWithUsername:@"a"
                                                      password:@"b"
-                                             revocableSession:NO];
+                                             revocableSession:NO
+                                                        error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqual(command.additionalRequestHeaders.count, 0);
     XCTAssertFalse(command.revocableSessionEnabled);
@@ -42,7 +44,8 @@
 - (void)testServiceLoginCommandWithAuthTypeData {
     PFRESTUserCommand *command = [PFRESTUserCommand serviceLoginUserCommandWithAuthenticationType:@"a"
                                                                                authenticationData:@{ @"b" : @"c" }
-                                                                                 revocableSession:YES];
+                                                                                 revocableSession:YES
+                                                                                            error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"users");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -55,7 +58,8 @@
 
     command = [PFRESTUserCommand serviceLoginUserCommandWithAuthenticationType:@"a"
                                                             authenticationData:@{ @"b" : @"c" }
-                                                              revocableSession:NO];
+                                                              revocableSession:NO
+                                                                         error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqual(command.additionalRequestHeaders.count, 0);
     XCTAssertFalse(command.revocableSessionEnabled);
@@ -64,7 +68,8 @@
 - (void)testServiceLoginCommandWithParameters {
     PFRESTUserCommand *command = [PFRESTUserCommand serviceLoginUserCommandWithParameters:@{ @"authData" : @{@"b" : @"c"} }
                                                                          revocableSession:YES
-                                                                             sessionToken:@"Yarr"];
+                                                                             sessionToken:@"Yarr"
+                                                                                    error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"users");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -77,7 +82,8 @@
 
     command = [PFRESTUserCommand serviceLoginUserCommandWithParameters:@{ @"authData" : @{@"b" : @"c"} }
                                                       revocableSession:NO
-                                                          sessionToken:@"Yarr!"];
+                                                          sessionToken:@"Yarr!"
+                                                                 error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqual(command.additionalRequestHeaders.count, 0);
     XCTAssertFalse(command.revocableSessionEnabled);
@@ -86,7 +92,8 @@
 - (void)testSignUpCommand {
     PFRESTUserCommand *command = [PFRESTUserCommand signUpUserCommandWithParameters:@{ @"k" : @"v" }
                                                                    revocableSession:YES
-                                                                       sessionToken:@"Boom"];
+                                                                       sessionToken:@"Boom"
+                                                                              error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"users");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -97,14 +104,15 @@
 
     command = [PFRESTUserCommand signUpUserCommandWithParameters:@{ @"k" : @"v" }
                                                 revocableSession:NO
-                                                    sessionToken:@"Boom"];
+                                                    sessionToken:@"Boom"
+                                                           error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqual(command.additionalRequestHeaders.count, 0);
     XCTAssertFalse(command.revocableSessionEnabled);
 }
 
 - (void)testGetCurrentUserCommand {
-    PFRESTUserCommand *command = [PFRESTUserCommand getCurrentUserCommandWithSessionToken:@"yolo"];
+    PFRESTUserCommand *command = [PFRESTUserCommand getCurrentUserCommandWithSessionToken:@"yolo" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"users/me");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodGET);
@@ -113,7 +121,7 @@
 }
 
 - (void)testUpgradeToRevocableSessionCommand {
-    PFRESTUserCommand *command = [PFRESTUserCommand upgradeToRevocableSessionCommandWithSessionToken:@"yolo"];
+    PFRESTUserCommand *command = [PFRESTUserCommand upgradeToRevocableSessionCommandWithSessionToken:@"yolo" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"upgradeToRevocableSession");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -122,7 +130,7 @@
 }
 
 - (void)testLogOutUserCommand {
-    PFRESTUserCommand *command = [PFRESTUserCommand logOutUserCommandWithSessionToken:@"yolo"];
+    PFRESTUserCommand *command = [PFRESTUserCommand logOutUserCommandWithSessionToken:@"yolo" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"logout");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
@@ -131,7 +139,7 @@
 }
 
 - (void)testResetPasswordCommand {
-    PFRESTUserCommand *command = [PFRESTUserCommand resetPasswordCommandForUserWithEmail:@"nlutsenko@me.com"];
+    PFRESTUserCommand *command = [PFRESTUserCommand resetPasswordCommandForUserWithEmail:@"nlutsenko@me.com" error:nil];
     XCTAssertNotNil(command);
     XCTAssertEqualObjects(command.httpPath, @"requestPasswordReset");
     XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);

--- a/ParseFacebookUtils/Resources/Info-iOS.plist
+++ b/ParseFacebookUtils/Resources/Info-iOS.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseFacebookUtils/Resources/Info-iOS.plist
+++ b/ParseFacebookUtils/Resources/Info-iOS.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseFacebookUtils/Resources/Info-iOS.plist
+++ b/ParseFacebookUtils/Resources/Info-iOS.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseFacebookUtils/Resources/Info-iOS.plist
+++ b/ParseFacebookUtils/Resources/Info-iOS.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseFacebookUtils/Resources/Info-tvOS.plist
+++ b/ParseFacebookUtils/Resources/Info-tvOS.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 </dict>
 </plist>

--- a/ParseFacebookUtils/Resources/Info-tvOS.plist
+++ b/ParseFacebookUtils/Resources/Info-tvOS.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 </dict>
 </plist>

--- a/ParseFacebookUtils/Resources/Info-tvOS.plist
+++ b/ParseFacebookUtils/Resources/Info-tvOS.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 </dict>
 </plist>

--- a/ParseFacebookUtils/Resources/Info-tvOS.plist
+++ b/ParseFacebookUtils/Resources/Info-tvOS.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 </dict>
 </plist>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject/Resources/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
+++ b/ParseStarterProject/iOS/ParseStarterProject/Resources/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/ParseTwitterUtils/Resources/Info.plist
+++ b/ParseTwitterUtils/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseTwitterUtils/Resources/Info.plist
+++ b/ParseTwitterUtils/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseTwitterUtils/Resources/Info.plist
+++ b/ParseTwitterUtils/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseTwitterUtils/Resources/Info.plist
+++ b/ParseTwitterUtils/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.16.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 </dict>

--- a/ParseUI/Resources/Info.plist
+++ b/ParseUI/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.2.0</string>
+	<string>1.17.0-alpha.2</string>
 	<key>MinimumOSVersion</key>
 	<string>7.0</string>
 </dict>

--- a/ParseUI/Resources/Info.plist
+++ b/ParseUI/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.4</string>
+	<string>1.17.0-alpha.5</string>
 	<key>MinimumOSVersion</key>
 	<string>7.0</string>
 </dict>

--- a/ParseUI/Resources/Info.plist
+++ b/ParseUI/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.2</string>
+	<string>1.17.0-alpha.3</string>
 	<key>MinimumOSVersion</key>
 	<string>7.0</string>
 </dict>

--- a/ParseUI/Resources/Info.plist
+++ b/ParseUI/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.17.0-alpha.3</string>
+	<string>1.17.0-alpha.4</string>
 	<key>MinimumOSVersion</key>
 	<string>7.0</string>
 </dict>

--- a/Rakefile
+++ b/Rakefile
@@ -302,6 +302,12 @@ namespace :package do
     Constants.update_version(version)
   end
 
+  desc 'Build all frameworks and starters'
+  task :release do |_|
+    Rake::Task['package:frameworks'].invoke
+    Rake::Task['package:starters'].invoke
+  end
+
   desc 'Build and package all frameworks for the release'
   task :frameworks, [:version] => :prepare do |_, args|
     version = args[:version] || Constants.current_version
@@ -622,12 +628,6 @@ namespace :test do
         exit(1)
       end
     end
-  end
-
-  desc 'Run Deployment Tests'
-  task :deployment do |_|
-    Rake::Task['package:frameworks'].invoke
-    Rake::Task['package:starters'].invoke
   end
 
   desc 'Run Starter Project Tests'

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ module Constants
     File.join(script_folder, 'ParseFacebookUtils', 'Resources', 'Info-iOS.plist'),
     File.join(script_folder, 'ParseFacebookUtils', 'Resources', 'Info-tvOS.plist'),
     File.join(script_folder, 'ParseTwitterUtils', 'Resources', 'Info.plist'),
+    File.join(script_folder, 'ParseUI', 'Resources', 'Info.plist'),
     File.join(script_folder, 'ParseStarterProject', 'iOS', 'ParseStarterProject', 'Resources', 'Info.plist'),
     File.join(script_folder, 'ParseStarterProject', 'iOS', 'ParseStarterProject-Swift', 'Resources', 'Info.plist'),
     File.join(script_folder, 'ParseStarterProject', 'OSX', 'ParseOSXStarterProject', 'Resources', 'Info.plist'),

--- a/Scripts/publish.sh
+++ b/Scripts/publish.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 gem install bundler
 bundle install
-bundle exec pod trunk push Parse.podspec
+bundle exec pod trunk push Parse.podspec --verbose


### PR DESCRIPTION
This PR addresses those crashes that started happening since bumping to Bolts 1.9.0.

Starting Bolts 1.9.0, the NSExceptions are not caught by Bolts anymore, and need to be handled differently.

The best way to handle errors is to go the old style objective-c error pointer passing strategy.

This impact a large portion of the codebase as we need to forward errors from the coder / decoder.

On the public side, this should not change anything, as all failable calls will be caught by an errored BFTask.
