### PR TITLE
Fix wrong precondition bail on REST encoding

### DIFF
--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -953,7 +953,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
         id operationDict = [operation RESTDictionaryUsingObjectEncoder:objectEncoder
                                                      operationSetUUIDs:&ooSetUUIDs
                                                                  error:error];
-        PFPreconditionBailOnError(operation, error, nil);
+        PFPreconditionBailOnError(operationDict, error, nil);
         [operations addObject:operationDict];
         [mutableOperationSetUUIDs addObjectsFromArray:ooSetUUIDs];
     }

--- a/Parse/Tests/Unit/ObjectUnitTests.m
+++ b/Parse/Tests/Unit/ObjectUnitTests.m
@@ -327,5 +327,34 @@
     XCTAssertEqualObjects(error.localizedDescription, @"Found a circular dependency when saving.");
 }
 
+-(void)testRESTEncoding {
+    PFObject *objectA = [PFObject objectWithClassName:@"A"];
+    PFObject *objectB = [PFObject objectWithClassName:@"B"];
+    objectA[@"B"] = objectB;
+    
+    PFEncoder *encoder = [PFPointerObjectEncoder objectEncoder];
+    NSError *error = nil;
+    NSArray *operationSetUUIDs = nil;
+    XCTAssertNil([objectA RESTDictionaryWithObjectEncoder:encoder
+                                        operationSetUUIDs:&operationSetUUIDs
+                                                    error:&error]);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
+    XCTAssertEqualObjects(error.localizedDescription, @"Tried to save an object with a new, unsaved child.");
+}
+
+-(void)testLocalRESTEncoding {
+    PFObject *objectA = [PFObject objectWithClassName:@"A"];
+    PFObject *objectB = [PFObject objectWithClassName:@"B"];
+    objectA[@"B"] = objectB;
+    
+    PFEncoder *encoder = [PFPointerOrLocalIdObjectEncoder objectEncoder];
+    NSError *error = nil;
+    NSArray *operationSetUUIDs = nil;
+    XCTAssertNotNil([objectA RESTDictionaryWithObjectEncoder:encoder
+                                           operationSetUUIDs:&operationSetUUIDs
+                                                       error:&error]);
+    XCTAssertNil(error);
+}
 
 @end


### PR DESCRIPTION
REST encoding is checking the wrong object, causing a crash on error.