### PR TITLE
Rename PFFile and PFLogger

### DIFF
--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 		810155771BB3832700D7C7BD /* PFCachedQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E6621AFC1C7D008C4E06 /* PFCachedQueryController.m */; };
 		810155781BB3832700D7C7BD /* PFInstallationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C6BDED1B4DB16500553A83 /* PFInstallationConstants.m */; };
 		810155791BB3832700D7C7BD /* PFOfflineQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E65C1AFC1BA5008C4E06 /* PFOfflineQueryController.m */; };
-		8101557A1BB3832700D7C7BD /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
+		8101557A1BB3832700D7C7BD /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
 		8101557B1BB3832700D7C7BD /* PFHTTPURLRequestConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE93B19FA56D20076FE5D /* PFHTTPURLRequestConstructor.m */; };
 		8101557C1BB3832700D7C7BD /* PFObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A715A31B423A4100A504FC /* PFObjectUtilities.m */; };
 		8101557D1BB3832700D7C7BD /* PFURLSessionJSONDataTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB4C11B744626006659CB /* PFURLSessionJSONDataTaskDelegate.m */; };
@@ -267,7 +267,7 @@
 		810155FB1BB3832700D7C7BD /* PFMutableFileState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C7F4A01AF4220A007B5418 /* PFMutableFileState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810155FC1BB3832700D7C7BD /* PFSessionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8124C8AA1B27D5D600758E00 /* PFSessionUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810155FD1BB3832700D7C7BD /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		810155FE1BB3832700D7C7BD /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		810155FE1BB3832700D7C7BD /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810155FF1BB3832700D7C7BD /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		810156001BB3832700D7C7BD /* PFSQLiteDatabaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FCAC1B503886003841A2 /* PFSQLiteDatabaseResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810156011BB3832700D7C7BD /* PFAnalytics_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC571B503741003841A2 /* PFAnalytics_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -672,10 +672,10 @@
 		81493AA51A0D6DE0008D5504 /* PFRESTObjectBatchCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 81493AA21A0D6DE0008D5504 /* PFRESTObjectBatchCommand.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81493AA61A0D6DE0008D5504 /* PFRESTObjectBatchCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81493AA31A0D6DE0008D5504 /* PFRESTObjectBatchCommand.m */; };
 		81493AA71A0D6DE0008D5504 /* PFRESTObjectBatchCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81493AA31A0D6DE0008D5504 /* PFRESTObjectBatchCommand.m */; };
-		814B64111A769EF500213055 /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		814B64121A769EF500213055 /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		814B64131A769EF500213055 /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
-		814B64141A769EF500213055 /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
+		814B64111A769EF500213055 /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		814B64121A769EF500213055 /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		814B64131A769EF500213055 /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
+		814B64141A769EF500213055 /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
 		814B64151A769EF500213055 /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		814B64161A769EF500213055 /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		814BCDF11B4DF63600007B7F /* PFUserState.h in Headers */ = {isa = PBXBuildFile; fileRef = 814BCDEF1B4DF63600007B7F /* PFUserState.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -836,7 +836,7 @@
 		815F23221BD04D150054659F /* PFCachedQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E6621AFC1C7D008C4E06 /* PFCachedQueryController.m */; };
 		815F23231BD04D150054659F /* PFInstallationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C6BDED1B4DB16500553A83 /* PFInstallationConstants.m */; };
 		815F23241BD04D150054659F /* PFOfflineQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E65C1AFC1BA5008C4E06 /* PFOfflineQueryController.m */; };
-		815F23251BD04D150054659F /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
+		815F23251BD04D150054659F /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
 		815F23261BD04D150054659F /* PFHTTPURLRequestConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE93B19FA56D20076FE5D /* PFHTTPURLRequestConstructor.m */; };
 		815F23271BD04D150054659F /* PFObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A715A31B423A4100A504FC /* PFObjectUtilities.m */; };
 		815F23281BD04D150054659F /* PFURLSessionJSONDataTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB4C11B744626006659CB /* PFURLSessionJSONDataTaskDelegate.m */; };
@@ -954,7 +954,7 @@
 		815F23A71BD04D150054659F /* PFMutableFileState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C7F4A01AF4220A007B5418 /* PFMutableFileState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23A81BD04D150054659F /* PFSessionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8124C8AA1B27D5D600758E00 /* PFSessionUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23A91BD04D150054659F /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		815F23AA1BD04D150054659F /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		815F23AA1BD04D150054659F /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23AB1BD04D150054659F /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		815F23AC1BD04D150054659F /* PFSQLiteDatabaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FCAC1B503886003841A2 /* PFSQLiteDatabaseResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23AD1BD04D150054659F /* PFAnalytics_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC571B503741003841A2 /* PFAnalytics_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1455,7 +1455,7 @@
 		81C583571C3B0A98000063C6 /* PFCachedQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E6621AFC1C7D008C4E06 /* PFCachedQueryController.m */; };
 		81C583581C3B0A98000063C6 /* PFInstallationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C6BDED1B4DB16500553A83 /* PFInstallationConstants.m */; };
 		81C583591C3B0A98000063C6 /* PFOfflineQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E65C1AFC1BA5008C4E06 /* PFOfflineQueryController.m */; };
-		81C5835A1C3B0A98000063C6 /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
+		81C5835A1C3B0A98000063C6 /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
 		81C5835B1C3B0A98000063C6 /* PFHTTPURLRequestConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE93B19FA56D20076FE5D /* PFHTTPURLRequestConstructor.m */; };
 		81C5835C1C3B0A98000063C6 /* PFObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A715A31B423A4100A504FC /* PFObjectUtilities.m */; };
 		81C5835D1C3B0A98000063C6 /* PFURLSessionJSONDataTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB4C11B744626006659CB /* PFURLSessionJSONDataTaskDelegate.m */; };
@@ -1595,7 +1595,7 @@
 		81C583E91C3B0A98000063C6 /* PFMutableFileState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C7F4A01AF4220A007B5418 /* PFMutableFileState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583EA1C3B0A98000063C6 /* PFSessionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8124C8AA1B27D5D600758E00 /* PFSessionUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583EB1C3B0A98000063C6 /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C583EC1C3B0A98000063C6 /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81C583EC1C3B0A98000063C6 /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583ED1C3B0A98000063C6 /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C583EE1C3B0A98000063C6 /* PFSQLiteDatabaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FCAC1B503886003841A2 /* PFSQLiteDatabaseResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583EF1C3B0A98000063C6 /* PFAnalytics_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC571B503741003841A2 /* PFAnalytics_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1808,7 +1808,7 @@
 		81C584CA1C3B0AA1000063C6 /* PFCachedQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E6621AFC1C7D008C4E06 /* PFCachedQueryController.m */; };
 		81C584CB1C3B0AA1000063C6 /* PFInstallationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C6BDED1B4DB16500553A83 /* PFInstallationConstants.m */; };
 		81C584CC1C3B0AA1000063C6 /* PFOfflineQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E65C1AFC1BA5008C4E06 /* PFOfflineQueryController.m */; };
-		81C584CD1C3B0AA1000063C6 /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
+		81C584CD1C3B0AA1000063C6 /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
 		81C584CE1C3B0AA1000063C6 /* PFHTTPURLRequestConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE93B19FA56D20076FE5D /* PFHTTPURLRequestConstructor.m */; };
 		81C584CF1C3B0AA1000063C6 /* PFObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A715A31B423A4100A504FC /* PFObjectUtilities.m */; };
 		81C584D01C3B0AA1000063C6 /* PFURLSessionJSONDataTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB4C11B744626006659CB /* PFURLSessionJSONDataTaskDelegate.m */; };
@@ -1936,7 +1936,7 @@
 		81C585501C3B0AA1000063C6 /* PFMutableFileState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C7F4A01AF4220A007B5418 /* PFMutableFileState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585511C3B0AA1000063C6 /* PFSessionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8124C8AA1B27D5D600758E00 /* PFSessionUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585521C3B0AA1000063C6 /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C585531C3B0AA1000063C6 /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81C585531C3B0AA1000063C6 /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585541C3B0AA1000063C6 /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585551C3B0AA1000063C6 /* PFObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64701C29DC000029B197 /* PFObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585561C3B0AA1000063C6 /* PFSQLiteDatabaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FCAC1B503886003841A2 /* PFSQLiteDatabaseResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2141,7 +2141,7 @@
 		81C586291C3B0AA9000063C6 /* PFCachedQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E6621AFC1C7D008C4E06 /* PFCachedQueryController.m */; };
 		81C5862A1C3B0AA9000063C6 /* PFInstallationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C6BDED1B4DB16500553A83 /* PFInstallationConstants.m */; };
 		81C5862B1C3B0AA9000063C6 /* PFOfflineQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8143E65C1AFC1BA5008C4E06 /* PFOfflineQueryController.m */; };
-		81C5862C1C3B0AA9000063C6 /* PFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFLogger.m */; };
+		81C5862C1C3B0AA9000063C6 /* PFSystemLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 814B640F1A769EF500213055 /* PFSystemLogger.m */; };
 		81C5862D1C3B0AA9000063C6 /* PFHTTPURLRequestConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE93B19FA56D20076FE5D /* PFHTTPURLRequestConstructor.m */; };
 		81C5862E1C3B0AA9000063C6 /* PFObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A715A31B423A4100A504FC /* PFObjectUtilities.m */; };
 		81C5862F1C3B0AA9000063C6 /* PFURLSessionJSONDataTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB4C11B744626006659CB /* PFURLSessionJSONDataTaskDelegate.m */; };
@@ -2260,7 +2260,7 @@
 		81C586A61C3B0AA9000063C6 /* PFMutableFileState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C7F4A01AF4220A007B5418 /* PFMutableFileState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586A71C3B0AA9000063C6 /* PFSessionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8124C8AA1B27D5D600758E00 /* PFSessionUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586A81C3B0AA9000063C6 /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C586A91C3B0AA9000063C6 /* PFLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81C586A91C3B0AA9000063C6 /* PFSystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B640E1A769EF500213055 /* PFSystemLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586AA1C3B0AA9000063C6 /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C586AB1C3B0AA9000063C6 /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C586AC1C3B0AA9000063C6 /* PFSQLiteDatabaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FCAC1B503886003841A2 /* PFSQLiteDatabaseResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3162,8 +3162,8 @@
 		814916281B66D44500EFD14F /* UserUnitTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserUnitTests.m; sourceTree = "<group>"; };
 		81493AA21A0D6DE0008D5504 /* PFRESTObjectBatchCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFRESTObjectBatchCommand.h; sourceTree = "<group>"; };
 		81493AA31A0D6DE0008D5504 /* PFRESTObjectBatchCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRESTObjectBatchCommand.m; sourceTree = "<group>"; };
-		814B640E1A769EF500213055 /* PFLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PFLogger.h; path = Parse/Internal/PFLogger.h; sourceTree = SOURCE_ROOT; };
-		814B640F1A769EF500213055 /* PFLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PFLogger.m; path = Parse/Internal/PFLogger.m; sourceTree = SOURCE_ROOT; };
+		814B640E1A769EF500213055 /* PFSystemLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PFSystemLogger.h; path = Parse/Internal/PFSystemLogger.h; sourceTree = SOURCE_ROOT; };
+		814B640F1A769EF500213055 /* PFSystemLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PFSystemLogger.m; path = Parse/Internal/PFSystemLogger.m; sourceTree = SOURCE_ROOT; };
 		814B64101A769EF500213055 /* PFLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PFLogging.h; path = Parse/Internal/PFLogging.h; sourceTree = SOURCE_ROOT; };
 		814BCDEF1B4DF63600007B7F /* PFUserState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFUserState.h; sourceTree = "<group>"; };
 		814BCDF01B4DF63600007B7F /* PFUserState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFUserState.m; sourceTree = "<group>"; };
@@ -4346,8 +4346,8 @@
 		814B64171A769EF900213055 /* Logging */ = {
 			isa = PBXGroup;
 			children = (
-				814B640E1A769EF500213055 /* PFLogger.h */,
-				814B640F1A769EF500213055 /* PFLogger.m */,
+				814B640E1A769EF500213055 /* PFSystemLogger.h */,
+				814B640F1A769EF500213055 /* PFSystemLogger.m */,
 				814B64101A769EF500213055 /* PFLogging.h */,
 			);
 			name = Logging;
@@ -5313,7 +5313,7 @@
 				810155F81BB3832700D7C7BD /* PFMutableQueryState.h in Headers */,
 				810155FB1BB3832700D7C7BD /* PFMutableFileState.h in Headers */,
 				810155FC1BB3832700D7C7BD /* PFSessionUtilities.h in Headers */,
-				810155FE1BB3832700D7C7BD /* PFLogger.h in Headers */,
+				810155FE1BB3832700D7C7BD /* PFSystemLogger.h in Headers */,
 				810156001BB3832700D7C7BD /* PFSQLiteDatabaseResult.h in Headers */,
 				810156011BB3832700D7C7BD /* PFAnalytics_Private.h in Headers */,
 				810156021BB3832700D7C7BD /* PFConfigController.h in Headers */,
@@ -5519,7 +5519,7 @@
 				815F23A41BD04D150054659F /* PFMutableQueryState.h in Headers */,
 				815F23A71BD04D150054659F /* PFMutableFileState.h in Headers */,
 				815F23A81BD04D150054659F /* PFSessionUtilities.h in Headers */,
-				815F23AA1BD04D150054659F /* PFLogger.h in Headers */,
+				815F23AA1BD04D150054659F /* PFSystemLogger.h in Headers */,
 				815F23AC1BD04D150054659F /* PFSQLiteDatabaseResult.h in Headers */,
 				815F23AD1BD04D150054659F /* PFAnalytics_Private.h in Headers */,
 				815F23AE1BD04D150054659F /* PFConfigController.h in Headers */,
@@ -5738,7 +5738,7 @@
 				81CB7F991B17970400DC601D /* PFPushState_Private.h in Headers */,
 				81C7F4A21AF4220A007B5418 /* PFMutableFileState.h in Headers */,
 				8124C8AC1B27D5D600758E00 /* PFSessionUtilities.h in Headers */,
-				814B64111A769EF500213055 /* PFLogger.h in Headers */,
+				814B64111A769EF500213055 /* PFSystemLogger.h in Headers */,
 				8166FCC01B503886003841A2 /* PFSQLiteDatabaseResult.h in Headers */,
 				8166FC581B503741003841A2 /* PFAnalytics_Private.h in Headers */,
 				81BF4AB61B0BF3E500A3D75B /* PFConfigController.h in Headers */,
@@ -5963,7 +5963,7 @@
 				81C583E81C3B0A98000063C6 /* PFPushState_Private.h in Headers */,
 				81C583E91C3B0A98000063C6 /* PFMutableFileState.h in Headers */,
 				81C583EA1C3B0A98000063C6 /* PFSessionUtilities.h in Headers */,
-				81C583EC1C3B0A98000063C6 /* PFLogger.h in Headers */,
+				81C583EC1C3B0A98000063C6 /* PFSystemLogger.h in Headers */,
 				81C583EE1C3B0A98000063C6 /* PFSQLiteDatabaseResult.h in Headers */,
 				81C583EF1C3B0A98000063C6 /* PFAnalytics_Private.h in Headers */,
 				81C583F01C3B0A98000063C6 /* PFConfigController.h in Headers */,
@@ -6184,7 +6184,7 @@
 				81C5854E1C3B0AA1000063C6 /* PFMutableQueryState.h in Headers */,
 				81C585501C3B0AA1000063C6 /* PFMutableFileState.h in Headers */,
 				81C585511C3B0AA1000063C6 /* PFSessionUtilities.h in Headers */,
-				81C585531C3B0AA1000063C6 /* PFLogger.h in Headers */,
+				81C585531C3B0AA1000063C6 /* PFSystemLogger.h in Headers */,
 				81C585561C3B0AA1000063C6 /* PFSQLiteDatabaseResult.h in Headers */,
 				81C585571C3B0AA1000063C6 /* PFAnalytics_Private.h in Headers */,
 				81C585581C3B0AA1000063C6 /* PFConfigController.h in Headers */,
@@ -6389,7 +6389,7 @@
 				81C586A41C3B0AA9000063C6 /* PFMutableQueryState.h in Headers */,
 				81C586A61C3B0AA9000063C6 /* PFMutableFileState.h in Headers */,
 				81C586A71C3B0AA9000063C6 /* PFSessionUtilities.h in Headers */,
-				81C586A91C3B0AA9000063C6 /* PFLogger.h in Headers */,
+				81C586A91C3B0AA9000063C6 /* PFSystemLogger.h in Headers */,
 				81C586AC1C3B0AA9000063C6 /* PFSQLiteDatabaseResult.h in Headers */,
 				81C586AD1C3B0AA9000063C6 /* PFAnalytics_Private.h in Headers */,
 				81C586AF1C3B0AA9000063C6 /* PFConfigController.h in Headers */,
@@ -6657,7 +6657,7 @@
 				F51535051B57240900C49F56 /* PFACLPrivate.h in Headers */,
 				F5B0C4F51BA248F7000AB0D5 /* PFFileDataStream.h in Headers */,
 				8124C8A01B27BF0900758E00 /* PFSessionController.h in Headers */,
-				814B64121A769EF500213055 /* PFLogger.h in Headers */,
+				814B64121A769EF500213055 /* PFSystemLogger.h in Headers */,
 				8124C8AD1B27D5D600758E00 /* PFSessionUtilities.h in Headers */,
 				814881561B795CAC008763BF /* PFPropertyInfo_Runtime.h in Headers */,
 				81BCB4C91B744626006659CB /* PFURLSessionDataTaskDelegate_Private.h in Headers */,
@@ -7367,7 +7367,7 @@
 				810155771BB3832700D7C7BD /* PFCachedQueryController.m in Sources */,
 				810155781BB3832700D7C7BD /* PFInstallationConstants.m in Sources */,
 				810155791BB3832700D7C7BD /* PFOfflineQueryController.m in Sources */,
-				8101557A1BB3832700D7C7BD /* PFLogger.m in Sources */,
+				8101557A1BB3832700D7C7BD /* PFSystemLogger.m in Sources */,
 				8101557B1BB3832700D7C7BD /* PFHTTPURLRequestConstructor.m in Sources */,
 				8101557C1BB3832700D7C7BD /* PFObjectUtilities.m in Sources */,
 				8101557D1BB3832700D7C7BD /* PFURLSessionJSONDataTaskDelegate.m in Sources */,
@@ -7512,7 +7512,7 @@
 				815F23221BD04D150054659F /* PFCachedQueryController.m in Sources */,
 				815F23231BD04D150054659F /* PFInstallationConstants.m in Sources */,
 				815F23241BD04D150054659F /* PFOfflineQueryController.m in Sources */,
-				815F23251BD04D150054659F /* PFLogger.m in Sources */,
+				815F23251BD04D150054659F /* PFSystemLogger.m in Sources */,
 				815F23261BD04D150054659F /* PFHTTPURLRequestConstructor.m in Sources */,
 				815F23271BD04D150054659F /* PFObjectUtilities.m in Sources */,
 				815F23281BD04D150054659F /* PFURLSessionJSONDataTaskDelegate.m in Sources */,
@@ -7912,7 +7912,7 @@
 				8143E6651AFC1C7D008C4E06 /* PFCachedQueryController.m in Sources */,
 				81C6BDF01B4DB16500553A83 /* PFInstallationConstants.m in Sources */,
 				8143E65F1AFC1BA5008C4E06 /* PFOfflineQueryController.m in Sources */,
-				814B64131A769EF500213055 /* PFLogger.m in Sources */,
+				814B64131A769EF500213055 /* PFSystemLogger.m in Sources */,
 				815EE93D19FA56D20076FE5D /* PFHTTPURLRequestConstructor.m in Sources */,
 				81A715A61B423A4100A504FC /* PFObjectUtilities.m in Sources */,
 				81BCB4CC1B744626006659CB /* PFURLSessionJSONDataTaskDelegate.m in Sources */,
@@ -8074,7 +8074,7 @@
 				81C583571C3B0A98000063C6 /* PFCachedQueryController.m in Sources */,
 				81C583581C3B0A98000063C6 /* PFInstallationConstants.m in Sources */,
 				81C583591C3B0A98000063C6 /* PFOfflineQueryController.m in Sources */,
-				81C5835A1C3B0A98000063C6 /* PFLogger.m in Sources */,
+				81C5835A1C3B0A98000063C6 /* PFSystemLogger.m in Sources */,
 				81C5835B1C3B0A98000063C6 /* PFHTTPURLRequestConstructor.m in Sources */,
 				81C5835C1C3B0A98000063C6 /* PFObjectUtilities.m in Sources */,
 				81C5835D1C3B0A98000063C6 /* PFURLSessionJSONDataTaskDelegate.m in Sources */,
@@ -8226,7 +8226,7 @@
 				81C584CA1C3B0AA1000063C6 /* PFCachedQueryController.m in Sources */,
 				81C584CB1C3B0AA1000063C6 /* PFInstallationConstants.m in Sources */,
 				81C584CC1C3B0AA1000063C6 /* PFOfflineQueryController.m in Sources */,
-				81C584CD1C3B0AA1000063C6 /* PFLogger.m in Sources */,
+				81C584CD1C3B0AA1000063C6 /* PFSystemLogger.m in Sources */,
 				81C584CE1C3B0AA1000063C6 /* PFHTTPURLRequestConstructor.m in Sources */,
 				81C584CF1C3B0AA1000063C6 /* PFObjectUtilities.m in Sources */,
 				81C584D01C3B0AA1000063C6 /* PFURLSessionJSONDataTaskDelegate.m in Sources */,
@@ -8374,7 +8374,7 @@
 				81C586291C3B0AA9000063C6 /* PFCachedQueryController.m in Sources */,
 				81C5862A1C3B0AA9000063C6 /* PFInstallationConstants.m in Sources */,
 				81C5862B1C3B0AA9000063C6 /* PFOfflineQueryController.m in Sources */,
-				81C5862C1C3B0AA9000063C6 /* PFLogger.m in Sources */,
+				81C5862C1C3B0AA9000063C6 /* PFSystemLogger.m in Sources */,
 				81C5862D1C3B0AA9000063C6 /* PFHTTPURLRequestConstructor.m in Sources */,
 				81C5862E1C3B0AA9000063C6 /* PFObjectUtilities.m in Sources */,
 				81C5862F1C3B0AA9000063C6 /* PFURLSessionJSONDataTaskDelegate.m in Sources */,
@@ -8505,7 +8505,7 @@
 				81EB6637198A7FA600851598 /* PFConfig.m in Sources */,
 				8166FCC71B503886003841A2 /* PFSQLiteStatement.m in Sources */,
 				81C76EEC1B4B218C0031C2FD /* PFObjectConstants.m in Sources */,
-				814B64141A769EF500213055 /* PFLogger.m in Sources */,
+				814B64141A769EF500213055 /* PFSystemLogger.m in Sources */,
 				F5E8DE1C1B29100000EEA594 /* PFRelationState.m in Sources */,
 				815619031A1F79AC0076504A /* PFDateFormatter.m in Sources */,
 				8166FCC31B503886003841A2 /* PFSQLiteDatabaseResult.m in Sources */,

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -113,7 +113,7 @@
 		810155451BB3832700D7C7BD /* PFRESTAnalyticsCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BBE1341A0062B800622646 /* PFRESTAnalyticsCommand.m */; };
 		810155461BB3832700D7C7BD /* PFQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 812B7AB71AF2FA4800D15FF5 /* PFQueryController.m */; };
 		810155471BB3832700D7C7BD /* PFRESTCloudCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE91C19F987910076FE5D /* PFRESTCloudCommand.m */; };
-		810155481BB3832700D7C7BD /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		810155481BB3832700D7C7BD /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		810155491BB3832700D7C7BD /* PFAnalyticsUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8196D5601B0AB661000465A1 /* PFAnalyticsUtilities.m */; };
 		8101554A1BB3832700D7C7BD /* PFRESTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE8EF19F976D50076FE5D /* PFRESTCommand.m */; };
 		8101554B1BB3832700D7C7BD /* PFFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81EB595D1AF46434001EA1FC /* PFFileController.m */; };
@@ -203,7 +203,7 @@
 		810155B01BB3832700D7C7BD /* Parse.h in Headers */ = {isa = PBXBuildFile; fileRef = 09EEA12D1434FB1F00E3A3FA /* Parse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		810155B11BB3832700D7C7BD /* PFHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 819A4B061A67330200D01241 /* PFHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810155B21BB3832700D7C7BD /* PFEventuallyQueue_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24981A0B0FF200CFC7D4 /* PFEventuallyQueue_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		810155B31BB3832700D7C7BD /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		810155B31BB3832700D7C7BD /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		810155B41BB3832700D7C7BD /* PFApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 816AC9B81A3F48250031D94C /* PFApplication.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810155B51BB3832700D7C7BD /* BFTask+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA33198FC190000BAE3F /* BFTask+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810155B61BB3832700D7C7BD /* PFCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA35198FC190000BAE3F /* PFCategoryLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -312,7 +312,7 @@
 		810156321BB3832700D7C7BD /* PFPinningEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24941A09BAF100CFC7D4 /* PFPinningEventuallyQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810156331BB3832700D7C7BD /* PFCoreManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8196D58B1B0BD23B000465A1 /* PFCoreManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810156341BB3832700D7C7BD /* ParseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 812714861AE6F1270076AE8D /* ParseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		810156351BB3832700D7C7BD /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		810156351BB3832700D7C7BD /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810156361BB3832700D7C7BD /* PFFileController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EB595C1AF46434001EA1FC /* PFFileController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810156371BB3832700D7C7BD /* PFKeyValueCache_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 814881441B795C63008763BF /* PFKeyValueCache_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		810156381BB3832700D7C7BD /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -790,7 +790,7 @@
 		815F22F01BD04D150054659F /* PFRESTAnalyticsCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BBE1341A0062B800622646 /* PFRESTAnalyticsCommand.m */; };
 		815F22F11BD04D150054659F /* PFQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 812B7AB71AF2FA4800D15FF5 /* PFQueryController.m */; };
 		815F22F21BD04D150054659F /* PFRESTCloudCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE91C19F987910076FE5D /* PFRESTCloudCommand.m */; };
-		815F22F31BD04D150054659F /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		815F22F31BD04D150054659F /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		815F22F41BD04D150054659F /* PFAnalyticsUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8196D5601B0AB661000465A1 /* PFAnalyticsUtilities.m */; };
 		815F22F51BD04D150054659F /* PFRESTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE8EF19F976D50076FE5D /* PFRESTCommand.m */; };
 		815F22F61BD04D150054659F /* PFFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81EB595D1AF46434001EA1FC /* PFFileController.m */; };
@@ -886,7 +886,7 @@
 		815F235C1BD04D150054659F /* Parse.h in Headers */ = {isa = PBXBuildFile; fileRef = 09EEA12D1434FB1F00E3A3FA /* Parse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		815F235D1BD04D150054659F /* PFHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 819A4B061A67330200D01241 /* PFHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F235E1BD04D150054659F /* PFEventuallyQueue_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24981A0B0FF200CFC7D4 /* PFEventuallyQueue_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		815F235F1BD04D150054659F /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		815F235F1BD04D150054659F /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		815F23601BD04D150054659F /* PFApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 816AC9B81A3F48250031D94C /* PFApplication.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23611BD04D150054659F /* BFTask+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA33198FC190000BAE3F /* BFTask+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23621BD04D150054659F /* PFCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA35198FC190000BAE3F /* PFCategoryLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1003,7 +1003,7 @@
 		815F23DE1BD04D150054659F /* PFPinningEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24941A09BAF100CFC7D4 /* PFPinningEventuallyQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23DF1BD04D150054659F /* PFCoreManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8196D58B1B0BD23B000465A1 /* PFCoreManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23E01BD04D150054659F /* ParseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 812714861AE6F1270076AE8D /* ParseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		815F23E11BD04D150054659F /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		815F23E11BD04D150054659F /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23E21BD04D150054659F /* PFFileController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EB595C1AF46434001EA1FC /* PFFileController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23E31BD04D150054659F /* PFKeyValueCache_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 814881441B795C63008763BF /* PFKeyValueCache_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		815F23E41BD04D150054659F /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1074,8 +1074,8 @@
 		8166FC781B50376D003841A2 /* PFObjectController_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC6D1B50376D003841A2 /* PFObjectController_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8166FC791B50376D003841A2 /* PFObjectControlling.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC6E1B50376D003841A2 /* PFObjectControlling.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8166FC7A1B50376D003841A2 /* PFObjectControlling.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC6E1B50376D003841A2 /* PFObjectControlling.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8166FC7C1B503787003841A2 /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8166FC7D1B503787003841A2 /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8166FC7C1B503787003841A2 /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8166FC7D1B503787003841A2 /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8166FC831B503794003841A2 /* PFInstallationIdentifierStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7F1B503794003841A2 /* PFInstallationIdentifierStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8166FC841B503794003841A2 /* PFInstallationIdentifierStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7F1B503794003841A2 /* PFInstallationIdentifierStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8166FC851B503794003841A2 /* PFInstallationIdentifierStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 8166FC801B503794003841A2 /* PFInstallationIdentifierStore.m */; };
@@ -1140,10 +1140,10 @@
 		816A64641C29D2820029B197 /* PFConfig+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64621C29D2820029B197 /* PFConfig+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		816A64651C29D2820029B197 /* PFConfig+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64621C29D2820029B197 /* PFConfig+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		816A64661C29D2820029B197 /* PFConfig+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64621C29D2820029B197 /* PFConfig+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		816A646C1C29DA680029B197 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		816A646D1C29DA680029B197 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		816A646E1C29DA680029B197 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		816A646F1C29DA680029B197 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		816A646C1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		816A646D1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		816A646E1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		816A646F1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		816A64711C29DC000029B197 /* PFObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64701C29DC000029B197 /* PFObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		816A64721C29DC000029B197 /* PFObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64701C29DC000029B197 /* PFObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		816A64731C29DC000029B197 /* PFObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64701C29DC000029B197 /* PFObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1165,7 +1165,7 @@
 		816F44771A8E8933009CDB32 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 6393F38B15D3018400C4F78D /* libsqlite3.dylib */; };
 		816F44781A8E8933009CDB32 /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63CA84EA1612660F002E09F8 /* Accounts.framework */; };
 		816F44791A8E8933009CDB32 /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63CBA36B1612829C0062C84A /* Social.framework */; };
-		8171E99F19AE091000EAE6C1 /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		8171E99F19AE091000EAE6C1 /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		8171E9BA19AE37F000EAE6C1 /* PFThreadsafety.h in Headers */ = {isa = PBXBuildFile; fileRef = 818D049919A3B84500BEE20F /* PFThreadsafety.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8171E9BB19AE37F500EAE6C1 /* PFThreadsafety.m in Sources */ = {isa = PBXBuildFile; fileRef = 818D049A19A3B84500BEE20F /* PFThreadsafety.m */; };
 		818AAA6F19D36B1C00FC1B3C /* Parse.h in Headers */ = {isa = PBXBuildFile; fileRef = 09EEA12D1434FB1F00E3A3FA /* Parse.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1175,7 +1175,7 @@
 		818AAA7319D36B1C00FC1B3C /* PFCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 805D3D9F15E31241007E8D10 /* PFCloud.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		818AAA7419D36B1C00FC1B3C /* PFConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EB6632198A7FA600851598 /* PFConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		818AAA7519D36B1C00FC1B3C /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		818AAA7619D36B1C00FC1B3C /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		818AAA7619D36B1C00FC1B3C /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		818AAA7719D36B1C00FC1B3C /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		818AAA7819D36B1C00FC1B3C /* PFInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B78E11157D21B000A5E97F /* PFInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		818AAA7919D36B1C00FC1B3C /* PFObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABED13D791770095FEFA /* PFObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1316,7 +1316,7 @@
 		81C3824219CCAD2C0066284A /* PFAnonymousUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 638CBBB515191435004F54E4 /* PFAnonymousUtils.m */; };
 		81C3824319CCAD2C0066284A /* PFCloud.m in Sources */ = {isa = PBXBuildFile; fileRef = 805D3DA015E31241007E8D10 /* PFCloud.m */; };
 		81C3824419CCAD2C0066284A /* PFConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 81EB6633198A7FA600851598 /* PFConfig.m */; };
-		81C3824519CCAD2C0066284A /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		81C3824519CCAD2C0066284A /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		81C3824619CCAD2C0066284A /* PFGeoPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 09B119F714880776002B5594 /* PFGeoPoint.m */; };
 		81C3824719CCAD2C0066284A /* PFInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = 44B78E12157D21B000A5E97F /* PFInstallation.m */; };
 		81C3824819CCAD2C0066284A /* PFObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0925ABEE13D791770095FEFA /* PFObject.m */; };
@@ -1405,7 +1405,7 @@
 		81C583241C3B0A98000063C6 /* PFRESTAnalyticsCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BBE1341A0062B800622646 /* PFRESTAnalyticsCommand.m */; };
 		81C583251C3B0A98000063C6 /* PFQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 812B7AB71AF2FA4800D15FF5 /* PFQueryController.m */; };
 		81C583261C3B0A98000063C6 /* PFRESTCloudCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE91C19F987910076FE5D /* PFRESTCloudCommand.m */; };
-		81C583271C3B0A98000063C6 /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		81C583271C3B0A98000063C6 /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		81C583281C3B0A98000063C6 /* PFAnalyticsUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8196D5601B0AB661000465A1 /* PFAnalyticsUtilities.m */; };
 		81C583291C3B0A98000063C6 /* PFRESTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE8EF19F976D50076FE5D /* PFRESTCommand.m */; };
 		81C5832A1C3B0A98000063C6 /* PFFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81EB595D1AF46434001EA1FC /* PFFileController.m */; };
@@ -1515,7 +1515,7 @@
 		81C583961C3B0A98000063C6 /* PFHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 819A4B061A67330200D01241 /* PFHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583971C3B0A98000063C6 /* PFObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64701C29DC000029B197 /* PFObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C583981C3B0A98000063C6 /* PFEventuallyQueue_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24981A0B0FF200CFC7D4 /* PFEventuallyQueue_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C583991C3B0A98000063C6 /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C583991C3B0A98000063C6 /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C5839A1C3B0A98000063C6 /* PFApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 816AC9B81A3F48250031D94C /* PFApplication.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5839B1C3B0A98000063C6 /* BFTask+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA33198FC190000BAE3F /* BFTask+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5839C1C3B0A98000063C6 /* PFCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA35198FC190000BAE3F /* PFCategoryLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1581,7 +1581,7 @@
 		81C583DA1C3B0A98000063C6 /* PFRESTCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 815EE8EE19F976D50076FE5D /* PFRESTCommand.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583DB1C3B0A98000063C6 /* PFCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 805D3D9F15E31241007E8D10 /* PFCloud.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C583DC1C3B0A98000063C6 /* PFObjectUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 81A715A21B423A4100A504FC /* PFObjectUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C583DD1C3B0A98000063C6 /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C583DD1C3B0A98000063C6 /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C583DE1C3B0A98000063C6 /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C583DF1C3B0A98000063C6 /* PFObjectConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C76EE71B4B201E0031C2FD /* PFObjectConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C583E01C3B0A98000063C6 /* PFMutableObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F731B166FF500DC601D /* PFMutableObjectState.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1655,8 +1655,8 @@
 		81C584251C3B0A98000063C6 /* PFPinningEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24941A09BAF100CFC7D4 /* PFPinningEventuallyQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C584261C3B0A98000063C6 /* PFCoreManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8196D58B1B0BD23B000465A1 /* PFCoreManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C584271C3B0A98000063C6 /* ParseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 812714861AE6F1270076AE8D /* ParseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C584281C3B0A98000063C6 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C584291C3B0A98000063C6 /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81C584281C3B0A98000063C6 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C584291C3B0A98000063C6 /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5842A1C3B0A98000063C6 /* PFFileController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EB595C1AF46434001EA1FC /* PFFileController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5842B1C3B0A98000063C6 /* PFKeyValueCache_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 814881441B795C63008763BF /* PFKeyValueCache_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5842C1C3B0A98000063C6 /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1762,7 +1762,7 @@
 		81C5849B1C3B0AA1000063C6 /* PFRESTAnalyticsCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BBE1341A0062B800622646 /* PFRESTAnalyticsCommand.m */; };
 		81C5849C1C3B0AA1000063C6 /* PFQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 812B7AB71AF2FA4800D15FF5 /* PFQueryController.m */; };
 		81C5849D1C3B0AA1000063C6 /* PFRESTCloudCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE91C19F987910076FE5D /* PFRESTCloudCommand.m */; };
-		81C5849E1C3B0AA1000063C6 /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		81C5849E1C3B0AA1000063C6 /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		81C5849F1C3B0AA1000063C6 /* PFAnalyticsUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8196D5601B0AB661000465A1 /* PFAnalyticsUtilities.m */; };
 		81C584A01C3B0AA1000063C6 /* PFRESTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE8EF19F976D50076FE5D /* PFRESTCommand.m */; };
 		81C584A11C3B0AA1000063C6 /* PFFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81EB595D1AF46434001EA1FC /* PFFileController.m */; };
@@ -1861,7 +1861,7 @@
 		81C585021C3B0AA1000063C6 /* Parse.h in Headers */ = {isa = PBXBuildFile; fileRef = 09EEA12D1434FB1F00E3A3FA /* Parse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585031C3B0AA1000063C6 /* PFHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 819A4B061A67330200D01241 /* PFHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585041C3B0AA1000063C6 /* PFEventuallyQueue_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24981A0B0FF200CFC7D4 /* PFEventuallyQueue_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C585051C3B0AA1000063C6 /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C585051C3B0AA1000063C6 /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585061C3B0AA1000063C6 /* PFApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 816AC9B81A3F48250031D94C /* PFApplication.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585071C3B0AA1000063C6 /* BFTask+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA33198FC190000BAE3F /* BFTask+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585081C3B0AA1000063C6 /* PFCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA35198FC190000BAE3F /* PFCategoryLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1920,10 +1920,10 @@
 		81C5853F1C3B0AA1000063C6 /* PFURLSession_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F5556A171B66F47900410837 /* PFURLSession_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585401C3B0AA1000063C6 /* PFRESTCommand_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 815EE8F019F976D50076FE5D /* PFRESTCommand_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585411C3B0AA1000063C6 /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C585421C3B0AA1000063C6 /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C585421C3B0AA1000063C6 /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585431C3B0AA1000063C6 /* PFHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 815EE93F19FA5A390076FE5D /* PFHTTPRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585441C3B0AA1000063C6 /* PFRESTCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 815EE8EE19F976D50076FE5D /* PFRESTCommand.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C585451C3B0AA1000063C6 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C585451C3B0AA1000063C6 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585461C3B0AA1000063C6 /* PFCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 805D3D9F15E31241007E8D10 /* PFCloud.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C585471C3B0AA1000063C6 /* PFPersistenceGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 818ADC731BE1A8BA00C8006C /* PFPersistenceGroup.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585481C3B0AA1000063C6 /* PFObjectUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 81A715A21B423A4100A504FC /* PFObjectUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1990,7 +1990,7 @@
 		81C585861C3B0AA1000063C6 /* PFPinningEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24941A09BAF100CFC7D4 /* PFPinningEventuallyQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585871C3B0AA1000063C6 /* PFCoreManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8196D58B1B0BD23B000465A1 /* PFCoreManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C585881C3B0AA1000063C6 /* ParseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 812714861AE6F1270076AE8D /* ParseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C585891C3B0AA1000063C6 /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81C585891C3B0AA1000063C6 /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5858A1C3B0AA1000063C6 /* PFFileController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EB595C1AF46434001EA1FC /* PFFileController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5858B1C3B0AA1000063C6 /* PFKeyValueCache_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 814881441B795C63008763BF /* PFKeyValueCache_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5858C1C3B0AA1000063C6 /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2097,7 +2097,7 @@
 		81C585FC1C3B0AA9000063C6 /* PFRESTAnalyticsCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BBE1341A0062B800622646 /* PFRESTAnalyticsCommand.m */; };
 		81C585FD1C3B0AA9000063C6 /* PFQueryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 812B7AB71AF2FA4800D15FF5 /* PFQueryController.m */; };
 		81C585FE1C3B0AA9000063C6 /* PFRESTCloudCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE91C19F987910076FE5D /* PFRESTCloudCommand.m */; };
-		81C585FF1C3B0AA9000063C6 /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
+		81C585FF1C3B0AA9000063C6 /* PFFileObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFileObject.m */; };
 		81C586001C3B0AA9000063C6 /* PFAnalyticsUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8196D5601B0AB661000465A1 /* PFAnalyticsUtilities.m */; };
 		81C586011C3B0AA9000063C6 /* PFRESTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EE8EF19F976D50076FE5D /* PFRESTCommand.m */; };
 		81C586021C3B0AA9000063C6 /* PFFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81EB595D1AF46434001EA1FC /* PFFileController.m */; };
@@ -2174,7 +2174,7 @@
 		81C5864D1C3B0AA9000063C6 /* PFPinningObjectStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 8124C8711B26B9E700758E00 /* PFPinningObjectStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5864E1C3B0AA9000063C6 /* PFMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 810B7D751A0291FF003C0909 /* PFMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5864F1C3B0AA9000063C6 /* PFRESTAnalyticsCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 81BBE1331A0062B800622646 /* PFRESTAnalyticsCommand.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C586501C3B0AA9000063C6 /* PFFile+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFile+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C586501C3B0AA9000063C6 /* PFFileObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C586511C3B0AA9000063C6 /* PFHTTPURLRequestConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 815EE93A19FA56D20076FE5D /* PFHTTPURLRequestConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586521C3B0AA9000063C6 /* PFDefaultACLController.h in Headers */ = {isa = PBXBuildFile; fileRef = F51535571B57573700C49F56 /* PFDefaultACLController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586531C3B0AA9000063C6 /* PFACL.h in Headers */ = {isa = PBXBuildFile; fileRef = 64C47802147336C70092082F /* PFACL.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2189,7 +2189,7 @@
 		81C5865C1C3B0AA9000063C6 /* Parse.h in Headers */ = {isa = PBXBuildFile; fileRef = 09EEA12D1434FB1F00E3A3FA /* Parse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C5865D1C3B0AA9000063C6 /* PFHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 819A4B061A67330200D01241 /* PFHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5865E1C3B0AA9000063C6 /* PFEventuallyQueue_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24981A0B0FF200CFC7D4 /* PFEventuallyQueue_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C5865F1C3B0AA9000063C6 /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C5865F1C3B0AA9000063C6 /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C586601C3B0AA9000063C6 /* PFApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 816AC9B81A3F48250031D94C /* PFApplication.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586611C3B0AA9000063C6 /* BFTask+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA33198FC190000BAE3F /* BFTask+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586621C3B0AA9000063C6 /* PFObject+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = 816A64701C29DC000029B197 /* PFObject+Synchronous.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2201,7 +2201,7 @@
 		81C586681C3B0AA9000063C6 /* ParseModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DDB90B199A3EC200B50F35 /* ParseModule.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586691C3B0AA9000063C6 /* PFAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 81E2D5AF19DDAAB5009053A1 /* PFAssert.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5866A1C3B0AA9000063C6 /* PFUserState.h in Headers */ = {isa = PBXBuildFile; fileRef = 814BCDEF1B4DF63600007B7F /* PFUserState.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C5866B1C3B0AA9000063C6 /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81C5866B1C3B0AA9000063C6 /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81C5866D1C3B0AA9000063C6 /* PFGeoPointPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119FB1488429D002B5594 /* PFGeoPointPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5866E1C3B0AA9000063C6 /* PFURLSessionFileDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 810749AC1B74662B00682EEB /* PFURLSessionFileDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C5866F1C3B0AA9000063C6 /* PFInternalUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 09809FB11434F98C00EC3E74 /* PFInternalUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2309,7 +2309,7 @@
 		81C586D71C3B0AA9000063C6 /* PFPinningEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24941A09BAF100CFC7D4 /* PFPinningEventuallyQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586D81C3B0AA9000063C6 /* PFCoreManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8196D58B1B0BD23B000465A1 /* PFCoreManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586D91C3B0AA9000063C6 /* ParseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 812714861AE6F1270076AE8D /* ParseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81C586DA1C3B0AA9000063C6 /* PFFile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFile_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		81C586DA1C3B0AA9000063C6 /* PFFileObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC7B1B503787003841A2 /* PFFileObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586DB1C3B0AA9000063C6 /* PFFileController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EB595C1AF46434001EA1FC /* PFFileController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586DC1C3B0AA9000063C6 /* PFKeyValueCache_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 814881441B795C63008763BF /* PFKeyValueCache_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		81C586DD1C3B0AA9000063C6 /* PFLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 814B64101A769EF500213055 /* PFLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2425,10 +2425,10 @@
 		81CA29D91C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29DA1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29DB1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81CA29E11C28EB2000C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81CA29E21C28EB2200C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81CA29E31C28EB2300C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81CA29E41C28EB2400C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E11C28EB2000C4F34A /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E21C28EB2200C4F34A /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E31C28EB2300C4F34A /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E41C28EB2400C4F34A /* PFFileObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29E61C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29EB1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2524,7 +2524,7 @@
 		81F0E89219E6F83E00812A88 /* PFAnonymousUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 638CBBB415191435004F54E4 /* PFAnonymousUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81F0E89319E6F83E00812A88 /* PFCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 805D3D9F15E31241007E8D10 /* PFCloud.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81F0E89419E6F83E00812A88 /* PFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABEB13D791770095FEFA /* PFConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81F0E89519E6F83E00812A88 /* PFFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81F0E89519E6F83E00812A88 /* PFFileObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF07D199C42A300D86A21 /* PFFileObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81F0E89619E6F83E00812A88 /* PFGeoPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B119F614880776002B5594 /* PFGeoPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81F0E89719E6F83E00812A88 /* PFObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABED13D791770095FEFA /* PFObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81F0E89819E6F83E00812A88 /* PFQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 0925ABF313D791770095FEFA /* PFQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3207,7 +3207,7 @@
 		8166FC6C1B50376D003841A2 /* PFObjectController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectController.m; sourceTree = "<group>"; };
 		8166FC6D1B50376D003841A2 /* PFObjectController_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectController_Private.h; sourceTree = "<group>"; };
 		8166FC6E1B50376D003841A2 /* PFObjectControlling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectControlling.h; sourceTree = "<group>"; };
-		8166FC7B1B503787003841A2 /* PFFile_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFile_Private.h; sourceTree = "<group>"; };
+		8166FC7B1B503787003841A2 /* PFFileObject_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileObject_Private.h; sourceTree = "<group>"; };
 		8166FC7F1B503794003841A2 /* PFInstallationIdentifierStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFInstallationIdentifierStore.h; sourceTree = "<group>"; };
 		8166FC801B503794003841A2 /* PFInstallationIdentifierStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFInstallationIdentifierStore.m; sourceTree = "<group>"; };
 		8166FC811B503794003841A2 /* PFInstallationIdentifierStore_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFInstallationIdentifierStore_Private.h; sourceTree = "<group>"; };
@@ -3242,7 +3242,7 @@
 		8166FCE61B504083003841A2 /* PFPushManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPushManager.h; sourceTree = "<group>"; };
 		8166FCE71B504083003841A2 /* PFPushManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPushManager.m; sourceTree = "<group>"; };
 		816A64621C29D2820029B197 /* PFConfig+Synchronous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFConfig+Synchronous.h"; sourceTree = "<group>"; };
-		816A646B1C29DA680029B197 /* PFFile+Synchronous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFile+Synchronous.h"; sourceTree = "<group>"; };
+		816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFileObject+Synchronous.h"; sourceTree = "<group>"; };
 		816A64701C29DC000029B197 /* PFObject+Synchronous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFObject+Synchronous.h"; sourceTree = "<group>"; };
 		816A647B1C29E19A0029B197 /* PFPush+Synchronous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFPush+Synchronous.h"; sourceTree = "<group>"; };
 		816A64821C29E3B60029B197 /* PFQuery+Synchronous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFQuery+Synchronous.h"; sourceTree = "<group>"; };
@@ -3357,7 +3357,7 @@
 		81C9CA0519FECF5F00D514C5 /* PFRESTFileCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRESTFileCommand.m; sourceTree = "<group>"; };
 		81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFAnonymousUtils+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFCloud+Deprecated.h"; sourceTree = "<group>"; };
-		81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFile+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFileObject+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFPush+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFQuery+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFUser+Deprecated.h"; sourceTree = "<group>"; };
@@ -3397,8 +3397,8 @@
 		81DCD14B1D2DA080002501A2 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		81DDB90B199A3EC200B50F35 /* ParseModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseModule.h; sourceTree = "<group>"; };
 		81DDB90C199A3EC200B50F35 /* ParseModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ParseModule.m; sourceTree = "<group>"; };
-		81DEF07D199C42A300D86A21 /* PFFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFile.h; sourceTree = "<group>"; };
-		81DEF07E199C42A300D86A21 /* PFFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFFile.m; sourceTree = "<group>"; };
+		81DEF07D199C42A300D86A21 /* PFFileObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileObject.h; sourceTree = "<group>"; };
+		81DEF07E199C42A300D86A21 /* PFFileObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFFileObject.m; sourceTree = "<group>"; };
 		81DEF089199D555800D86A21 /* PFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
 		81DEF08A199D555800D86A21 /* PFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
 		81E033561B573F3E00B25168 /* PFMockURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMockURLProtocol.h; sourceTree = "<group>"; };
@@ -3657,10 +3657,10 @@
 				96FAF79F1D8443E300EAB299 /* PFDecoder.m */,
 				96FAF7B61D84461D00EAB299 /* PFEncoder.h */,
 				96FAF7B71D84461D00EAB299 /* PFEncoder.m */,
-				81DEF07D199C42A300D86A21 /* PFFile.h */,
-				816A646B1C29DA680029B197 /* PFFile+Synchronous.h */,
-				81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */,
-				81DEF07E199C42A300D86A21 /* PFFile.m */,
+				81DEF07D199C42A300D86A21 /* PFFileObject.h */,
+				816A646B1C29DA680029B197 /* PFFileObject+Synchronous.h */,
+				81CA29DC1C28EA7400C4F34A /* PFFileObject+Deprecated.h */,
+				81DEF07E199C42A300D86A21 /* PFFileObject.m */,
 				B141170A1E5D081500F70D7A /* PFFileUploadResult.h */,
 				B141169D1E5BC24B00F70D7A /* PFFileUploadController.h */,
 				09B119F614880776002B5594 /* PFGeoPoint.h */,
@@ -4811,7 +4811,7 @@
 		81C7F48F1AF4215B007B5418 /* File */ = {
 			isa = PBXGroup;
 			children = (
-				8166FC7B1B503787003841A2 /* PFFile_Private.h */,
+				8166FC7B1B503787003841A2 /* PFFileObject_Private.h */,
 				F5B0C4ED1BA24708000AB0D5 /* FileDataStream */,
 				81EB595B1AF46429001EA1FC /* Controller */,
 				81C7F4961AF42187007B5418 /* State */,
@@ -5229,15 +5229,15 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				816A646F1C29DA680029B197 /* PFFile+Synchronous.h in Headers */,
+				816A646F1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */,
 				810155A51BB3832700D7C7BD /* PFACL.h in Headers */,
 				810155A91BB3832700D7C7BD /* PFConfig.h in Headers */,
 				810155AA1BB3832700D7C7BD /* PFAnalytics.h in Headers */,
 				96FAF7C21D84462900EAB299 /* PFEncoder.h in Headers */,
 				810155B01BB3832700D7C7BD /* Parse.h in Headers */,
-				810155B31BB3832700D7C7BD /* PFFile.h in Headers */,
+				810155B31BB3832700D7C7BD /* PFFileObject.h in Headers */,
 				816A64741C29DC000029B197 /* PFObject+Synchronous.h in Headers */,
-				81CA29E11C28EB2000C4F34A /* PFFile+Deprecated.h in Headers */,
+				81CA29E11C28EB2000C4F34A /* PFFileObject+Deprecated.h in Headers */,
 				8101559F1BB3832700D7C7BD /* PFPinningObjectStore.h in Headers */,
 				707095491F170FFC000C50EA /* PFPolygon.h in Headers */,
 				810155A01BB3832700D7C7BD /* PFMacros.h in Headers */,
@@ -5354,7 +5354,7 @@
 				810156321BB3832700D7C7BD /* PFPinningEventuallyQueue.h in Headers */,
 				810156331BB3832700D7C7BD /* PFCoreManager.h in Headers */,
 				810156341BB3832700D7C7BD /* ParseManager.h in Headers */,
-				810156351BB3832700D7C7BD /* PFFile_Private.h in Headers */,
+				810156351BB3832700D7C7BD /* PFFileObject_Private.h in Headers */,
 				810156361BB3832700D7C7BD /* PFFileController.h in Headers */,
 				810156371BB3832700D7C7BD /* PFKeyValueCache_Private.h in Headers */,
 				810156381BB3832700D7C7BD /* PFLogging.h in Headers */,
@@ -5434,7 +5434,7 @@
 				815F23561BD04D150054659F /* PFAnalytics.h in Headers */,
 				B14116F61E5D076000F70D7A /* PFFileUploadController.h in Headers */,
 				815F235C1BD04D150054659F /* Parse.h in Headers */,
-				815F235F1BD04D150054659F /* PFFile.h in Headers */,
+				815F235F1BD04D150054659F /* PFFileObject.h in Headers */,
 				816A648A1C29E5A00029B197 /* PFUser+Synchronous.h in Headers */,
 				815F234A1BD04D150054659F /* PFPinningObjectStore.h in Headers */,
 				815F234B1BD04D150054659F /* PFMacros.h in Headers */,
@@ -5563,7 +5563,7 @@
 				815F23DE1BD04D150054659F /* PFPinningEventuallyQueue.h in Headers */,
 				815F23DF1BD04D150054659F /* PFCoreManager.h in Headers */,
 				815F23E01BD04D150054659F /* ParseManager.h in Headers */,
-				815F23E11BD04D150054659F /* PFFile_Private.h in Headers */,
+				815F23E11BD04D150054659F /* PFFileObject_Private.h in Headers */,
 				815F23E21BD04D150054659F /* PFFileController.h in Headers */,
 				815F23E31BD04D150054659F /* PFKeyValueCache_Private.h in Headers */,
 				815F23E41BD04D150054659F /* PFLogging.h in Headers */,
@@ -5607,8 +5607,8 @@
 				B141170E1E5D081500F70D7A /* PFFileUploadResult.h in Headers */,
 				81CA29ED1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */,
 				96FAF7BE1D84462800EAB299 /* PFEncoder.h in Headers */,
-				81CA29E21C28EB2200C4F34A /* PFFile+Deprecated.h in Headers */,
-				816A646E1C29DA680029B197 /* PFFile+Synchronous.h in Headers */,
+				81CA29E21C28EB2200C4F34A /* PFFileObject+Deprecated.h in Headers */,
+				816A646E1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */,
 				815F239D1BD04D150054659F /* PFCloud.h in Headers */,
 				815F23A91BD04D150054659F /* PFGeoPoint.h in Headers */,
 				815F23AB1BD04D150054659F /* PFConstants.h in Headers */,
@@ -5649,7 +5649,7 @@
 				81CA29F51C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */,
 				818AAA6F19D36B1C00FC1B3C /* Parse.h in Headers */,
 				816A64711C29DC000029B197 /* PFObject+Synchronous.h in Headers */,
-				818AAA7619D36B1C00FC1B3C /* PFFile.h in Headers */,
+				818AAA7619D36B1C00FC1B3C /* PFFileObject.h in Headers */,
 				B141169E1E5BC24B00F70D7A /* PFFileUploadController.h in Headers */,
 				B141170B1E5D081500F70D7A /* PFFileUploadResult.h in Headers */,
 				8124C8731B26B9E700758E00 /* PFPinningObjectStore.h in Headers */,
@@ -5788,7 +5788,7 @@
 				91DF24961A09BAF100CFC7D4 /* PFPinningEventuallyQueue.h in Headers */,
 				8196D58D1B0BD23B000465A1 /* PFCoreManager.h in Headers */,
 				812714881AE6F1270076AE8D /* ParseManager.h in Headers */,
-				8166FC7C1B503787003841A2 /* PFFile_Private.h in Headers */,
+				8166FC7C1B503787003841A2 /* PFFileObject_Private.h in Headers */,
 				81EB595E1AF46434001EA1FC /* PFFileController.h in Headers */,
 				814881491B795C63008763BF /* PFKeyValueCache_Private.h in Headers */,
 				814B64151A769EF500213055 /* PFLogging.h in Headers */,
@@ -5835,7 +5835,7 @@
 				81CA29EB1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */,
 				816A64831C29E3B60029B197 /* PFQuery+Synchronous.h in Headers */,
 				818AAA7319D36B1C00FC1B3C /* PFCloud.h in Headers */,
-				81CA29E41C28EB2400C4F34A /* PFFile+Deprecated.h in Headers */,
+				81CA29E41C28EB2400C4F34A /* PFFileObject+Deprecated.h in Headers */,
 				81CA29CF1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				815BE6C01C29D17C00738638 /* PFCloud+Synchronous.h in Headers */,
 				81CA29F01C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */,
@@ -5850,7 +5850,7 @@
 				81CA29D81C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */,
 				818AAA7F19D36B1C00FC1B3C /* PFRole.h in Headers */,
 				812145771AA4A4C1000B23F5 /* PFSession.h in Headers */,
-				816A646C1C29DA680029B197 /* PFFile+Synchronous.h in Headers */,
+				816A646C1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */,
 				818AAA7219D36B1C00FC1B3C /* PFAnonymousUtils.h in Headers */,
 				818AAA8319D36B1C00FC1B3C /* PFSubclassing.h in Headers */,
 				816A64881C29E5A00029B197 /* PFUser+Synchronous.h in Headers */,
@@ -5877,7 +5877,7 @@
 				81C583941C3B0A98000063C6 /* PFObject+Deprecated.h in Headers */,
 				81C583951C3B0A98000063C6 /* Parse.h in Headers */,
 				81C583971C3B0A98000063C6 /* PFObject+Synchronous.h in Headers */,
-				81C583991C3B0A98000063C6 /* PFFile.h in Headers */,
+				81C583991C3B0A98000063C6 /* PFFileObject.h in Headers */,
 				81C583801C3B0A98000063C6 /* PFPinningObjectStore.h in Headers */,
 				81C583811C3B0A98000063C6 /* PFMacros.h in Headers */,
 				81C583821C3B0A98000063C6 /* PFPersistenceController.h in Headers */,
@@ -6014,7 +6014,7 @@
 				81C584251C3B0A98000063C6 /* PFPinningEventuallyQueue.h in Headers */,
 				81C584261C3B0A98000063C6 /* PFCoreManager.h in Headers */,
 				81C584271C3B0A98000063C6 /* ParseManager.h in Headers */,
-				81C584291C3B0A98000063C6 /* PFFile_Private.h in Headers */,
+				81C584291C3B0A98000063C6 /* PFFileObject_Private.h in Headers */,
 				81C5842A1C3B0A98000063C6 /* PFFileController.h in Headers */,
 				81C5842B1C3B0A98000063C6 /* PFKeyValueCache_Private.h in Headers */,
 				81C5842C1C3B0A98000063C6 /* PFLogging.h in Headers */,
@@ -6060,7 +6060,7 @@
 				81C583C71C3B0A98000063C6 /* PFQuery+Deprecated.h in Headers */,
 				81C583D91C3B0A98000063C6 /* PFQuery+Synchronous.h in Headers */,
 				81C583DB1C3B0A98000063C6 /* PFCloud.h in Headers */,
-				81C583DD1C3B0A98000063C6 /* PFFile+Deprecated.h in Headers */,
+				81C583DD1C3B0A98000063C6 /* PFFileObject+Deprecated.h in Headers */,
 				81C583DE1C3B0A98000063C6 /* PFAnonymousUtils+Deprecated.h in Headers */,
 				81C583E31C3B0A98000063C6 /* PFCloud+Synchronous.h in Headers */,
 				81C583E51C3B0A98000063C6 /* PFUser+Deprecated.h in Headers */,
@@ -6076,7 +6076,7 @@
 				81C5841F1C3B0A98000063C6 /* PFCloud+Deprecated.h in Headers */,
 				81C584201C3B0A98000063C6 /* PFRole.h in Headers */,
 				81C584231C3B0A98000063C6 /* PFSession.h in Headers */,
-				81C584281C3B0A98000063C6 /* PFFile+Synchronous.h in Headers */,
+				81C584281C3B0A98000063C6 /* PFFileObject+Synchronous.h in Headers */,
 				96FAF7BA1D84462700EAB299 /* PFEncoder.h in Headers */,
 				81C584381C3B0A98000063C6 /* PFAnonymousUtils.h in Headers */,
 				81C584441C3B0A98000063C6 /* PFSubclassing.h in Headers */,
@@ -6099,7 +6099,7 @@
 				81C584FC1C3B0AA1000063C6 /* PFAnalytics.h in Headers */,
 				B14116F71E5D076100F70D7A /* PFFileUploadController.h in Headers */,
 				81C585021C3B0AA1000063C6 /* Parse.h in Headers */,
-				81C585051C3B0AA1000063C6 /* PFFile.h in Headers */,
+				81C585051C3B0AA1000063C6 /* PFFileObject.h in Headers */,
 				81C585101C3B0AA1000063C6 /* PFUser+Synchronous.h in Headers */,
 				81C584F21C3B0AA1000063C6 /* PFPinningObjectStore.h in Headers */,
 				707095471F170FB0000C50EA /* PFPolygon.h in Headers */,
@@ -6228,7 +6228,7 @@
 				81C585861C3B0AA1000063C6 /* PFPinningEventuallyQueue.h in Headers */,
 				81C585871C3B0AA1000063C6 /* PFCoreManager.h in Headers */,
 				81C585881C3B0AA1000063C6 /* ParseManager.h in Headers */,
-				81C585891C3B0AA1000063C6 /* PFFile_Private.h in Headers */,
+				81C585891C3B0AA1000063C6 /* PFFileObject_Private.h in Headers */,
 				81C5858A1C3B0AA1000063C6 /* PFFileController.h in Headers */,
 				81C5858B1C3B0AA1000063C6 /* PFKeyValueCache_Private.h in Headers */,
 				81C5858C1C3B0AA1000063C6 /* PFLogging.h in Headers */,
@@ -6272,8 +6272,8 @@
 				B141170F1E5D081500F70D7A /* PFFileUploadResult.h in Headers */,
 				81C585251C3B0AA1000063C6 /* PFQuery+Deprecated.h in Headers */,
 				96FAF7C01D84462900EAB299 /* PFEncoder.h in Headers */,
-				81C585421C3B0AA1000063C6 /* PFFile+Deprecated.h in Headers */,
-				81C585451C3B0AA1000063C6 /* PFFile+Synchronous.h in Headers */,
+				81C585421C3B0AA1000063C6 /* PFFileObject+Deprecated.h in Headers */,
+				81C585451C3B0AA1000063C6 /* PFFileObject+Synchronous.h in Headers */,
 				81C585461C3B0AA1000063C6 /* PFCloud.h in Headers */,
 				81C585521C3B0AA1000063C6 /* PFGeoPoint.h in Headers */,
 				81C585541C3B0AA1000063C6 /* PFConstants.h in Headers */,
@@ -6306,15 +6306,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				7070954D1F171038000C50EA /* PFPolygon.h in Headers */,
-				81C586501C3B0AA9000063C6 /* PFFile+Synchronous.h in Headers */,
+				81C586501C3B0AA9000063C6 /* PFFileObject+Synchronous.h in Headers */,
 				81C586531C3B0AA9000063C6 /* PFACL.h in Headers */,
 				81C586561C3B0AA9000063C6 /* PFConfig.h in Headers */,
 				81C586571C3B0AA9000063C6 /* PFAnalytics.h in Headers */,
 				96FAF7C41D84462900EAB299 /* PFEncoder.h in Headers */,
 				81C5865C1C3B0AA9000063C6 /* Parse.h in Headers */,
-				81C5865F1C3B0AA9000063C6 /* PFFile.h in Headers */,
+				81C5865F1C3B0AA9000063C6 /* PFFileObject.h in Headers */,
 				81C586621C3B0AA9000063C6 /* PFObject+Synchronous.h in Headers */,
-				81C5866B1C3B0AA9000063C6 /* PFFile+Deprecated.h in Headers */,
+				81C5866B1C3B0AA9000063C6 /* PFFileObject+Deprecated.h in Headers */,
 				81C5864D1C3B0AA9000063C6 /* PFPinningObjectStore.h in Headers */,
 				81C5864E1C3B0AA9000063C6 /* PFMacros.h in Headers */,
 				81C5864F1C3B0AA9000063C6 /* PFRESTAnalyticsCommand.h in Headers */,
@@ -6430,7 +6430,7 @@
 				81C586D71C3B0AA9000063C6 /* PFPinningEventuallyQueue.h in Headers */,
 				81C586D81C3B0AA9000063C6 /* PFCoreManager.h in Headers */,
 				81C586D91C3B0AA9000063C6 /* ParseManager.h in Headers */,
-				81C586DA1C3B0AA9000063C6 /* PFFile_Private.h in Headers */,
+				81C586DA1C3B0AA9000063C6 /* PFFileObject_Private.h in Headers */,
 				81C586DB1C3B0AA9000063C6 /* PFFileController.h in Headers */,
 				81C586DC1C3B0AA9000063C6 /* PFKeyValueCache_Private.h in Headers */,
 				81C586DD1C3B0AA9000063C6 /* PFLogging.h in Headers */,
@@ -6509,7 +6509,7 @@
 				707095401F170F1B000C50EA /* PFPolygon.h in Headers */,
 				81F0E88E19E6F7D600812A88 /* Parse.h in Headers */,
 				815BE6C11C29D17C00738638 /* PFCloud+Synchronous.h in Headers */,
-				81F0E89519E6F83E00812A88 /* PFFile.h in Headers */,
+				81F0E89519E6F83E00812A88 /* PFFileObject.h in Headers */,
 				816A647D1C29E19A0029B197 /* PFPush+Synchronous.h in Headers */,
 				81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */,
 				816A64891C29E5A00029B197 /* PFUser+Synchronous.h in Headers */,
@@ -6609,7 +6609,7 @@
 				8166FC9B1B503830003841A2 /* PFSession_Private.h in Headers */,
 				818ADC831BE1A8BA00C8006C /* PFUserDefaultsPersistenceGroup.h in Headers */,
 				8166FC641B50375D003841A2 /* PFOperationSet.h in Headers */,
-				8166FC7D1B503787003841A2 /* PFFile_Private.h in Headers */,
+				8166FC7D1B503787003841A2 /* PFFileObject_Private.h in Headers */,
 				814BCDF81B4DF66500007B7F /* PFMutableUserState.h in Headers */,
 				F590194B1B7992E700F763EF /* PFSQLiteDatabaseController.h in Headers */,
 				81951F171ACB90DA00E142EB /* PFJSONSerialization.h in Headers */,
@@ -6688,7 +6688,7 @@
 				96FAF7A31D8443F600EAB299 /* PFDecoder.h in Headers */,
 				81EBF3401B33E7B100991947 /* PFPush.h in Headers */,
 				81EBF33F1B33E7A800991947 /* PFInstallation.h in Headers */,
-				816A646D1C29DA680029B197 /* PFFile+Synchronous.h in Headers */,
+				816A646D1C29DA680029B197 /* PFFileObject+Synchronous.h in Headers */,
 				81F0E89A19E6F83E00812A88 /* PFRole.h in Headers */,
 				812145781AA4A4C1000B23F5 /* PFSession.h in Headers */,
 				81F0E89619E6F83E00812A88 /* PFGeoPoint.h in Headers */,
@@ -6707,7 +6707,7 @@
 				816A64641C29D2820029B197 /* PFConfig+Synchronous.h in Headers */,
 				81F0E89119E6F83E00812A88 /* PFAnalytics.h in Headers */,
 				81F0E89319E6F83E00812A88 /* PFCloud.h in Headers */,
-				81CA29E31C28EB2300C4F34A /* PFFile+Deprecated.h in Headers */,
+				81CA29E31C28EB2300C4F34A /* PFFileObject+Deprecated.h in Headers */,
 				B141170D1E5D081500F70D7A /* PFFileUploadResult.h in Headers */,
 				96FAF7BC1D84462700EAB299 /* PFEncoder.h in Headers */,
 				81CA29F11C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */,
@@ -7322,7 +7322,7 @@
 				810155451BB3832700D7C7BD /* PFRESTAnalyticsCommand.m in Sources */,
 				810155461BB3832700D7C7BD /* PFQueryController.m in Sources */,
 				810155471BB3832700D7C7BD /* PFRESTCloudCommand.m in Sources */,
-				810155481BB3832700D7C7BD /* PFFile.m in Sources */,
+				810155481BB3832700D7C7BD /* PFFileObject.m in Sources */,
 				810155491BB3832700D7C7BD /* PFAnalyticsUtilities.m in Sources */,
 				8101554A1BB3832700D7C7BD /* PFRESTCommand.m in Sources */,
 				8101554B1BB3832700D7C7BD /* PFFileController.m in Sources */,
@@ -7466,7 +7466,7 @@
 				815F22F01BD04D150054659F /* PFRESTAnalyticsCommand.m in Sources */,
 				815F22F11BD04D150054659F /* PFQueryController.m in Sources */,
 				815F22F21BD04D150054659F /* PFRESTCloudCommand.m in Sources */,
-				815F22F31BD04D150054659F /* PFFile.m in Sources */,
+				815F22F31BD04D150054659F /* PFFileObject.m in Sources */,
 				815F22F41BD04D150054659F /* PFAnalyticsUtilities.m in Sources */,
 				815F22F51BD04D150054659F /* PFRESTCommand.m in Sources */,
 				815F22F61BD04D150054659F /* PFFileController.m in Sources */,
@@ -7861,7 +7861,7 @@
 				81BBE1371A0062B800622646 /* PFRESTAnalyticsCommand.m in Sources */,
 				812B7ABA1AF2FA4800D15FF5 /* PFQueryController.m in Sources */,
 				815EE91F19F987910076FE5D /* PFRESTCloudCommand.m in Sources */,
-				81C3824519CCAD2C0066284A /* PFFile.m in Sources */,
+				81C3824519CCAD2C0066284A /* PFFileObject.m in Sources */,
 				8196D5631B0AB661000465A1 /* PFAnalyticsUtilities.m in Sources */,
 				815EE8F719F976D50076FE5D /* PFRESTCommand.m in Sources */,
 				81EB59601AF46434001EA1FC /* PFFileController.m in Sources */,
@@ -8023,7 +8023,7 @@
 				81C583241C3B0A98000063C6 /* PFRESTAnalyticsCommand.m in Sources */,
 				81C583251C3B0A98000063C6 /* PFQueryController.m in Sources */,
 				81C583261C3B0A98000063C6 /* PFRESTCloudCommand.m in Sources */,
-				81C583271C3B0A98000063C6 /* PFFile.m in Sources */,
+				81C583271C3B0A98000063C6 /* PFFileObject.m in Sources */,
 				81C583281C3B0A98000063C6 /* PFAnalyticsUtilities.m in Sources */,
 				81C583291C3B0A98000063C6 /* PFRESTCommand.m in Sources */,
 				81C5832A1C3B0A98000063C6 /* PFFileController.m in Sources */,
@@ -8180,7 +8180,7 @@
 				81C5849B1C3B0AA1000063C6 /* PFRESTAnalyticsCommand.m in Sources */,
 				81C5849C1C3B0AA1000063C6 /* PFQueryController.m in Sources */,
 				81C5849D1C3B0AA1000063C6 /* PFRESTCloudCommand.m in Sources */,
-				81C5849E1C3B0AA1000063C6 /* PFFile.m in Sources */,
+				81C5849E1C3B0AA1000063C6 /* PFFileObject.m in Sources */,
 				81C5849F1C3B0AA1000063C6 /* PFAnalyticsUtilities.m in Sources */,
 				81C584A01C3B0AA1000063C6 /* PFRESTCommand.m in Sources */,
 				81C584A11C3B0AA1000063C6 /* PFFileController.m in Sources */,
@@ -8329,7 +8329,7 @@
 				81C585FC1C3B0AA9000063C6 /* PFRESTAnalyticsCommand.m in Sources */,
 				81C585FD1C3B0AA9000063C6 /* PFQueryController.m in Sources */,
 				81C585FE1C3B0AA9000063C6 /* PFRESTCloudCommand.m in Sources */,
-				81C585FF1C3B0AA9000063C6 /* PFFile.m in Sources */,
+				81C585FF1C3B0AA9000063C6 /* PFFileObject.m in Sources */,
 				81C586001C3B0AA9000063C6 /* PFAnalyticsUtilities.m in Sources */,
 				81C586011C3B0AA9000063C6 /* PFRESTCommand.m in Sources */,
 				81C586021C3B0AA9000063C6 /* PFFileController.m in Sources */,
@@ -8439,7 +8439,7 @@
 				8124C8761B26B9E700758E00 /* PFPinningObjectStore.m in Sources */,
 				8143E6601AFC1BA5008C4E06 /* PFOfflineQueryController.m in Sources */,
 				81BCB4D11B744626006659CB /* PFURLSessionUploadTaskDelegate.m in Sources */,
-				8171E99F19AE091000EAE6C1 /* PFFile.m in Sources */,
+				8171E99F19AE091000EAE6C1 /* PFFileObject.m in Sources */,
 				81443B361A27838500F3FD17 /* PFDevice.m in Sources */,
 				81EBF3451B33E7D800991947 /* PFMutablePushState.m in Sources */,
 				815E76521BDF168A00E1DF8E /* PFPersistenceController.m in Sources */,

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -294,7 +294,7 @@
 
 - (void)urlSession:(PFURLSession *)session willPerformURLRequest:(NSURLRequest *)request {
     [[BFExecutor defaultPriorityBackgroundExecutor] execute:^{
-        NSDictionary *userInfo = ([PFLogger sharedLogger].logLevel == PFLogLevelDebug ?
+        NSDictionary *userInfo = ([PFSystemLogger sharedLogger].logLevel == PFLogLevelDebug ?
                                   @{ PFNetworkNotificationURLRequestUserInfoKey : request } : nil);
         [self.notificationCenter postNotificationName:PFNetworkWillSendURLRequestNotification
                                                object:self
@@ -308,7 +308,7 @@ didPerformURLRequest:(NSURLRequest *)request
     responseString:(nullable NSString *)responseString {
     [[BFExecutor defaultPriorityBackgroundExecutor] execute:^{
         NSMutableDictionary *userInfo = nil;
-        if ([PFLogger sharedLogger].logLevel == PFLogLevelDebug) {
+        if ([PFSystemLogger sharedLogger].logLevel == PFLogLevelDebug) {
             userInfo = [NSMutableDictionary dictionaryWithObject:request
                                                           forKey:PFNetworkNotificationURLRequestUserInfoKey];
             if (response) {

--- a/Parse/Parse/Internal/File/FileDataStream/PFFileDataStream.h
+++ b/Parse/Parse/Internal/File/FileDataStream/PFFileDataStream.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  PFFileDataStream is an NSStream proxy which won't read the last byte of a file until the downlaod has finished.
 
- When downloading a file stream via `-[PFFile getDataDownloadStreamInBackground]`, we need to be able to read and write 
+ When downloading a file stream via `-[PFFileObject getDataDownloadStreamInBackground]`, we need to be able to read and write 
  to the same file on disk concurrently.
  
  NSInputStream closes itself as soon as it hits EOF, so this class wraps an underlying NSInputStream and stops the 

--- a/Parse/Parse/Internal/File/PFFileObject_Private.h
+++ b/Parse/Parse/Internal/File/PFFileObject_Private.h
@@ -10,13 +10,13 @@
 #import <Foundation/Foundation.h>
 
 #import <Parse/PFConstants.h>
-#import <Parse/PFFile.h>
+#import <Parse/PFFileObject.h>
 
 #import "PFFileState.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PFFile (Private)
+@interface PFFileObject (Private)
 
 @property (nonatomic, strong, readonly) PFFileState *state;
 

--- a/Parse/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Parse/Internal/PFInternalUtils.m
@@ -19,7 +19,7 @@
 #import "PFDateFormatter.h"
 #import "BFTask+Private.h"
 #import "PFFieldOperation.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFGeoPointPrivate.h"
 #import "PFKeyValueCache.h"
 #import "PFKeychainStore.h"

--- a/Parse/Parse/Internal/PFLogging.h
+++ b/Parse/Parse/Internal/PFLogging.h
@@ -12,13 +12,13 @@
 
 # import <Parse/PFConstants.h>
 
-#import "PFLogger.h"
+#import "PFSystemLogger.h"
 
 static const PFLoggingTag PFLoggingTagCommon = 0;
 static const PFLoggingTag PFLoggingTagCrashReporting = 100;
 
 #define PFLog(level, loggingTag, frmt, ...) \
-[[PFLogger sharedLogger] logMessageWithLevel:level tag:loggingTag format:(frmt), ##__VA_ARGS__]
+[[PFSystemLogger sharedLogger] logMessageWithLevel:level tag:loggingTag format:(frmt), ##__VA_ARGS__]
 
 #define PFLogError(tag, frmt, ...) \
 PFLog(PFLogLevelError, (tag), (frmt), ##__VA_ARGS__)

--- a/Parse/Parse/Internal/PFSystemLogger.h
+++ b/Parse/Parse/Internal/PFSystemLogger.h
@@ -13,7 +13,7 @@
 
 typedef uint8_t PFLoggingTag;
 
-@interface PFLogger : NSObject
+@interface PFSystemLogger : NSObject
 
 @property (atomic, assign) PFLogLevel logLevel;
 
@@ -22,9 +22,9 @@ typedef uint8_t PFLoggingTag;
 ///--------------------------------------
 
 /**
-A shared instance of `PFLogger` that should be used for all logging.
+A shared instance of `PFSystemLogger` that should be used for all logging.
 
-@return An shared singleton instance of `PFLogger`.
+@return An shared singleton instance of `PFSystemLogger`.
 */
 + (instancetype)sharedLogger; //TODO: (nlutsenko) Convert to use an instance everywhere instead of a shared singleton.
 

--- a/Parse/Parse/Internal/PFSystemLogger.m
+++ b/Parse/Parse/Internal/PFSystemLogger.m
@@ -7,12 +7,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "PFLogger.h"
+#import "PFSystemLogger.h"
 
 #import "PFApplication.h"
 #import "PFLogging.h"
 
-@implementation PFLogger
+@implementation PFSystemLogger
 
 ///--------------------------------------
 #pragma mark - Class
@@ -58,10 +58,10 @@
 ///--------------------------------------
 
 + (instancetype)sharedLogger {
-    static PFLogger *logger;
+    static PFSystemLogger *logger;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        logger = [[PFLogger alloc] init];
+        logger = [[PFSystemLogger alloc] init];
     });
     return logger;
 }

--- a/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
+++ b/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
@@ -20,7 +20,7 @@
 #import "PFConstants.h"
 #import "PFDecoder.h"
 #import "PFFileManager.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFHTTPRequest.h"
 #import "PFMacros.h"
 #import "PFPaymentTransactionObserver.h"
@@ -169,8 +169,8 @@
         @strongify(self);
 
         PFCommandResult *result = task.result;
-        PFFile *file = [[PFDecoder objectDecoder] decodeObject:result.result];
-        if (![file isKindOfClass:[PFFile class]]) {
+        PFFileObject *file = [[PFDecoder objectDecoder] decodeObject:result.result];
+        if (![file isKindOfClass:[PFFileObject class]]) {
             return [BFTask taskWithError:[NSError errorWithDomain:PFParseErrorDomain
                                                              code:kPFErrorInvalidPurchaseReceipt
                                                          userInfo:result.result]];

--- a/Parse/Parse/PFDecoder.m
+++ b/Parse/Parse/PFDecoder.m
@@ -13,7 +13,7 @@
 #import "PFDateFormatter.h"
 #import "PFFieldOperation.h"
 #import "PFFieldOperationDecoder.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFGeoPointPrivate.h"
 #import "PFPolygonPrivate.h"
 #import "PFInternalUtils.h"
@@ -64,7 +64,7 @@
             return [PFRelation relationFromDictionary:dictionary withDecoder:self];
 
         } else if ([type isEqualToString:@"File"]) {
-            return [PFFile fileWithName:dictionary[@"name"]
+            return [PFFileObject fileWithName:dictionary[@"name"]
                                     url:dictionary[@"url"]];
 
         } else if ([type isEqualToString:@"Pointer"]) {

--- a/Parse/Parse/PFEncoder.m
+++ b/Parse/Parse/PFEncoder.m
@@ -14,7 +14,7 @@
 #import "PFBase64Encoder.h"
 #import "PFDateFormatter.h"
 #import "PFFieldOperation.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFGeoPointPrivate.h"
 #import "PFPolygonPrivate.h"
 #import "PFObjectPrivate.h"
@@ -48,8 +48,8 @@
                  @"iso" : [[PFDateFormatter sharedFormatter] preciseStringFromDate:object]
                  };
 
-    } else if ([object isKindOfClass:[PFFile class]]) {
-        if (((PFFile *)object).dirty) {
+    } else if ([object isKindOfClass:[PFFileObject class]]) {
+        if (((PFFileObject *)object).dirty) {
             // TODO: (nlutsenko) Figure out what to do with things like an unsaved file
             // in a mutable container, where we don't normally want to allow serializing
             // such a thing inside an object.
@@ -61,8 +61,8 @@
         }
         return @{
                  @"__type" : @"File",
-                 @"url" : ((PFFile *)object).state.urlString,
-                 @"name" : ((PFFile *)object).name
+                 @"url" : ((PFFileObject *)object).state.urlString,
+                 @"name" : ((PFFileObject *)object).name
                  };
 
     } else if ([object isKindOfClass:[PFFieldOperation class]]) {

--- a/Parse/Parse/PFFileObject+Deprecated.h
+++ b/Parse/Parse/PFFileObject+Deprecated.h
@@ -8,14 +8,14 @@
  */
 
 #import <Parse/PFConstants.h>
-#import <Parse/PFFile.h>
+#import <Parse/PFFileObject.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- This category lists all methods of `PFFile` that are deprecated and will be removed in the near future.
+ This category lists all methods of `PFFileObject` that are deprecated and will be removed in the near future.
  */
-@interface PFFile (Deprecated)
+@interface PFFileObject (Deprecated)
 
 ///--------------------------------------
 #pragma mark - Saving Files
@@ -30,10 +30,10 @@ NS_ASSUME_NONNULL_BEGIN
  `error` will be `nil` on success and set if there was an error.
  `[result boolValue]` will tell you whether the call succeeded or not.
 
- @deprecated Please use `PFFile.-saveInBackgroundWithBlock:` instead.
+ @deprecated Please use `PFFileObject.-saveInBackgroundWithBlock:` instead.
  */
 - (void)saveInBackgroundWithTarget:(nullable id)target
-                          selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFile.-saveInBackgroundWithBlock:` instead.");
+                          selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFileObject.-saveInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
 #pragma mark - Getting Files
@@ -47,10 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
  It should have the following signature: `(void)callbackWithResult:(NSData *)result error:(NSError *)error`.
  `error` will be `nil` on success and set if there was an error.
 
- @deprecated Please use `PFFile.-getDataInBackgroundWithBlock:` instead.
+ @deprecated Please use `PFFileObject.-getDataInBackgroundWithBlock:` instead.
  */
 - (void)getDataInBackgroundWithTarget:(nullable id)target
-                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFile.-getDataInBackgroundWithBlock:` instead.");
+                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFileObject.-getDataInBackgroundWithBlock:` instead.");
 
 @end
 

--- a/Parse/Parse/PFFileObject+Synchronous.h
+++ b/Parse/Parse/PFFileObject+Synchronous.h
@@ -8,16 +8,16 @@
  */
 
 #import <Parse/PFConstants.h>
-#import <Parse/PFFile.h>
+#import <Parse/PFFileObject.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- This category lists all methods of `PFFile` class that are synchronous, but have asynchronous counterpart,
+ This category lists all methods of `PFFileObject` class that are synchronous, but have asynchronous counterpart,
  Calling one of these synchronous methods could potentially block the current thread for a large amount of time,
  since it might be fetching from network or saving/loading data from disk.
  */
-@interface PFFile (Synchronous)
+@interface PFFileObject (Synchronous)
 
 ///--------------------------------------
 #pragma mark - Storing Data with Parse
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)getData:(NSError **)error;
 
 /**
- This method is like `-getData` but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getData` but avoids ever holding the entire `PFFileObject` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSInputStream *)getDataStream PF_SWIFT_UNAVAILABLE;
 
 /**
- This method is like `-getData` but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getData` but avoids ever holding the entire `PFFileObject` contents in memory at once.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 

--- a/Parse/Parse/PFFileObject.h
+++ b/Parse/Parse/PFFileObject.h
@@ -16,13 +16,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- `PFFile` representes a file of binary data stored on the Parse servers.
+ `PFFileObject` representes a file of binary data stored on the Parse servers.
  This can be a image, video, or anything else that an application needs to reference in a non-relational way.
  */
-@interface PFFile : NSObject
+@interface PFFileObject : NSObject
 
 ///--------------------------------------
-#pragma mark - Creating a PFFile
+#pragma mark - Creating a PFFileObject
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -31,21 +31,21 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a file with given data. A name will be assigned to it by the server.
 
- @param data The contents of the new `PFFile`.
+ @param data The contents of the new `PFFileObject`.
 
- @return A new `PFFile`.
+ @return A new `PFFileObject`.
  */
 + (nullable instancetype)fileWithData:(NSData *)data;
 
 /**
  Creates a file with given data and name.
 
- @param name The name of the new PFFile. The file name must begin with and
+ @param name The name of the new PFFileObject. The file name must begin with and
  alphanumeric character, and consist of alphanumeric characters, periods,
  spaces, underscores, or dashes.
- @param data The contents of the new `PFFile`.
+ @param data The contents of the new `PFFileObject`.
 
- @return A new `PFFile` object.
+ @return A new `PFFileObject` object.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name data:(NSData *)data;
 
@@ -55,11 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
  @warning This method raises an exception if the file at path is not accessible
  or if there is not enough disk space left.
 
- @param name  The name of the new `PFFile`. The file name must begin with and alphanumeric character,
+ @param name  The name of the new `PFFileObject`. The file name must begin with and alphanumeric character,
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
  @param path  The path to the file that will be uploaded to Parse.
 
- @return A new `PFFile` instance.
+ @return A new `PFFileObject` instance.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path PF_SWIFT_UNAVAILABLE;
@@ -67,14 +67,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a file with the contents of another file.
 
- @param name  The name of the new `PFFile`. The file name must begin with and alphanumeric character,
+ @param name  The name of the new `PFFileObject`. The file name must begin with and alphanumeric character,
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
  @param path  The path to the file that will be uploaded to Parse.
  @param error On input, a pointer to an error object.
  If an error occurs, this pointer is set to an actual error object containing the error information.
  You may specify `nil` for this parameter if you do not want the error information.
 
- @return A new `PFFile` instance or `nil` if the error occured.
+ @return A new `PFFileObject` instance or `nil` if the error occured.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path
@@ -85,12 +85,12 @@ NS_ASSUME_NONNULL_BEGIN
 
  @warning This method raises an exception if the data supplied is not accessible or could not be saved.
 
- @param name        The name of the new `PFFile`. The file name must begin with and alphanumeric character,
+ @param name        The name of the new `PFFileObject`. The file name must begin with and alphanumeric character,
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
- @param data        The contents of the new `PFFile`.
+ @param data        The contents of the new `PFFileObject`.
  @param contentType Represents MIME type of the data.
 
- @return A new `PFFile` instance.
+ @return A new `PFFileObject` instance.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                                  data:(NSData *)data
@@ -99,15 +99,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a file with given data, name and content type.
 
- @param name        The name of the new `PFFile`. The file name must begin with and alphanumeric character,
+ @param name        The name of the new `PFFileObject`. The file name must begin with and alphanumeric character,
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
- @param data        The contents of the new `PFFile`.
+ @param data        The contents of the new `PFFileObject`.
  @param contentType Represents MIME type of the data.
  @param error On input, a pointer to an error object.
  If an error occurs, this pointer is set to an actual error object containing the error information.
  You may specify `nil` for this parameter if you do not want the error information.
 
- @return A new `PFFile` instance or `nil` if the error occured.
+ @return A new `PFFileObject` instance or `nil` if the error occured.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                                  data:(NSData *)data
@@ -117,10 +117,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a file with given data and content type.
 
- @param data The contents of the new `PFFile`.
+ @param data The contents of the new `PFFileObject`.
  @param contentType Represents MIME type of the data.
 
- @return A new `PFFile` object.
+ @return A new `PFFileObject` object.
  */
 + (instancetype)fileWithData:(NSData *)data contentType:(nullable NSString *)contentType;
 
@@ -218,7 +218,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask<NSData *> *)getDataInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- This method is like `-getDataInBackground` but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getDataInBackground` but avoids ever holding the entire `PFFileObject` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -243,7 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  This method is like `-getDataInBackground` but avoids
- ever holding the entire `PFFile` contents in memory at once.
+ ever holding the entire `PFFileObject` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
  @param progressBlock The block should have the following argument signature: ^(int percentDone)
@@ -277,7 +277,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getDataInBackgroundWithBlock:(nullable PFDataResultBlock)block;
 
 /**
- This method is like `-getDataInBackgroundWithBlock:` but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getDataInBackgroundWithBlock:` but avoids ever holding the entire `PFFileObject` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -299,7 +299,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  This method is like `-getDataInBackgroundWithBlock:progressBlock:` but avoids
- ever holding the entire `PFFile` contents in memory at once.
+ ever holding the entire `PFFileObject` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 

--- a/Parse/Parse/PFFileObject.m
+++ b/Parse/Parse/PFFileObject.m
@@ -7,8 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "PFFile.h"
-#import "PFFile_Private.h"
+#import "PFFileObject.h"
+#import "PFFileObject_Private.h"
 
 #import <Bolts/BFCancellationTokenSource.h>
 
@@ -29,7 +29,7 @@
 #import "PFUserPrivate.h"
 #import "Parse_Private.h"
 
-@interface PFFile () {
+@interface PFFileObject () {
     dispatch_queue_t _synchronizationQueue;
 }
 
@@ -43,7 +43,7 @@
 
 @end
 
-@implementation PFFile
+@implementation PFFileObject
 
 @synthesize stagedFilePath = _stagedFilePath;
 
@@ -63,7 +63,7 @@
 
 + (instancetype)fileWithName:(NSString *)name contentsAtPath:(NSString *)path {
     NSError *error = nil;
-    PFFile *file = [self fileWithName:name contentsAtPath:path error:&error];
+    PFFileObject *file = [self fileWithName:name contentsAtPath:path error:&error];
     PFParameterAssert(!error, @"Could not access file at %@: %@", path, error);
     return file;
 }
@@ -73,7 +73,7 @@
     BOOL directory = NO;
 
     if (![fileManager fileExistsAtPath:path isDirectory:&directory] || directory) {
-        NSString *message = [NSString stringWithFormat:@"Failed to create PFFile at path '%@': file does not exist.", path];
+        NSString *message = [NSString stringWithFormat:@"Failed to create PFFileObject at path '%@': file does not exist.", path];
         if (error) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain
                                          code:NSFileNoSuchFileError
@@ -82,7 +82,7 @@
         return nil;
     }
 
-    PFFile *file = [self fileWithName:name url:nil];
+    PFFileObject *file = [self fileWithName:name url:nil];
     if (![file _stageWithPath:path error:error]) {
         return nil;
     }
@@ -93,7 +93,7 @@
                         data:(NSData *)data
                  contentType:(NSString *)contentType {
     NSError *error = nil;
-    PFFile *file = [self fileWithName:name data:data contentType:contentType error:&error];
+    PFFileObject *file = [self fileWithName:name data:data contentType:contentType error:&error];
     PFConsistencyAssert(!error, @"Could not save file data for %@ : %@", name, error);
     return file;
 }
@@ -103,7 +103,7 @@
                  contentType:(NSString *)contentType
                        error:(NSError **)error {
     if (!data) {
-        NSString *message = @"Cannot create a PFFile with nil data.";
+        NSString *message = @"Cannot create a PFFileObject with nil data.";
         if (error) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain
                                          code:NSFileNoSuchFileError
@@ -112,7 +112,7 @@
         return nil;
     }
 
-    PFFile *file = [[self alloc] initWithName:name urlString:nil mimeType:contentType];
+    PFFileObject *file = [[self alloc] initWithName:name urlString:nil mimeType:contentType];
     if (![file _stageWithData:data error:error]) {
         return nil;
     }
@@ -505,7 +505,7 @@
 #pragma mark - Synchronous
 ///--------------------------------------
 
-@implementation PFFile (Synchronous)
+@implementation PFFileObject (Synchronous)
 
 #pragma mark Storing Data with Parse
 
@@ -541,7 +541,7 @@
 #pragma mark - Deprecated
 ///--------------------------------------
 
-@implementation PFFile (Deprecated)
+@implementation PFFileObject (Deprecated)
 
 - (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
     [self saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {

--- a/Parse/Parse/PFFileUploadController.h
+++ b/Parse/Parse/PFFileUploadController.h
@@ -10,7 +10,7 @@
 #import <Bolts/BFTask.h>
 
 /**
- A policy interface for overriding the default upload behavior of uploading a PFFile
+ A policy interface for overriding the default upload behavior of uploading a PFFileObject
  to application's parse server. Allows for direct uploads to other file storage
  providers.
  */
@@ -20,8 +20,8 @@
  Uploads a file asynchronously from file path for a given file state.
  
  @param sourceFilePath    Path to the file to upload.
- @param fileName          The PFFile's fileName.
- @param mimeType          The PFFile's mime type.
+ @param fileName          The PFFileObject's fileName.
+ @param mimeType          The PFFileObject's mime type.
  @param sessionToken      The current users's session token.
  @param cancellationToken Cancellation token.
  @param progressBlock     Progress block to call (optional).

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -32,7 +32,7 @@
 #import "PFErrorUtilities.h"
 #import "PFEventuallyQueue_Private.h"
 #import "PFFileManager.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFJSONSerialization.h"
 #import "PFLogging.h"
 #import "PFMacros.h"
@@ -69,7 +69,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     dispatch_once(&onceToken, ^{
         classes = @[ [NSDictionary class], [NSArray class],
                      [NSString class], [NSNumber class], [NSNull class], [NSDate class], [NSData class],
-                     [PFObject class], [PFFile class], [PFACL class], [PFGeoPoint class] ];
+                     [PFObject class], [PFFileObject class], [PFACL class], [PFGeoPoint class] ];
     });
 
     for (Class class in classes) {
@@ -311,8 +311,8 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
         if ([object isDirty:NO]) {
             [dirtyChildren addObject:object];
         }
-    } else if ([node isKindOfClass:[PFFile class]]) {
-        PFFile *file = (PFFile *)node;
+    } else if ([node isKindOfClass:[PFFileObject class]]) {
+        PFFileObject *file = (PFFileObject *)node;
         if (!file.url) {
             [dirtyFiles addObject:node];
         }
@@ -427,7 +427,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 
     BFTask *task = [BFTask taskWithResult:@YES];
-    for (PFFile *file in uniqueFiles) {
+    for (PFFileObject *file in uniqueFiles) {
         task = [task continueAsyncWithSuccessBlock:^id(BFTask *task) {
             return [[file saveInBackground] continueAsyncWithBlock:^id(BFTask *task) {
                 // This is a stupid hack because our current behavior is to fail file
@@ -595,10 +595,10 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             return [BFTask taskWithError:error];
         }
 
-        for (PFFile *file in uniqueFiles) {
+        for (PFFileObject *file in uniqueFiles) {
             if (!file.url) {
                 NSError *error = [PFErrorUtilities errorWithCode:kPFErrorUnsavedFile
-                                                         message:@"Unable to saveEventually a PFObject with a relation to a new, unsaved PFFile."];
+                                                         message:@"Unable to saveEventually a PFObject with a relation to a new, unsaved PFFileObject."];
                 return [BFTask taskWithError:error];
             }
         }

--- a/Parse/Parse/PFProduct.h
+++ b/Parse/Parse/PFProduct.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Parse/PFFile.h>
+#import <Parse/PFFileObject.h>
 #import <Parse/PFObject.h>
 #import <Parse/PFSubclassing.h>
 
@@ -41,7 +41,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubcla
 /**
  The icon of the product.
  */
-@property (nullable, nonatomic, strong) PFFile *icon;
+@property (nullable, nonatomic, strong) PFFileObject *icon;
 
 /**
  The title of the product.

--- a/Parse/Parse/Parse.h
+++ b/Parse/Parse/Parse.h
@@ -22,9 +22,9 @@
 #import <Parse/PFConstants.h>
 #import <Parse/PFDecoder.h>
 #import <Parse/PFEncoder.h>
-#import <Parse/PFFile.h>
-#import <Parse/PFFile+Deprecated.h>
-#import <Parse/PFFile+Synchronous.h>
+#import <Parse/PFFileObject.h>
+#import <Parse/PFFileObject+Deprecated.h>
+#import <Parse/PFFileObject+Synchronous.h>
 #import <Parse/PFGeoPoint.h>
 #import <Parse/PFPolygon.h>
 #import <Parse/PFObject.h>

--- a/Parse/Parse/Parse.m
+++ b/Parse/Parse/Parse.m
@@ -18,7 +18,7 @@
 #import "PFPin.h"
 #import "PFPinningEventuallyQueue.h"
 #import "PFUserPrivate.h"
-#import "PFLogger.h"
+#import "PFSystemLogger.h"
 #import "PFSession.h"
 #import "PFFileManager.h"
 #import "PFApplication.h"
@@ -186,11 +186,11 @@ static ParseClientConfiguration *currentParseConfiguration_;
 ///--------------------------------------
 
 + (void)setLogLevel:(PFLogLevel)logLevel {
-    [PFLogger sharedLogger].logLevel = logLevel;
+    [PFSystemLogger sharedLogger].logLevel = logLevel;
 }
 
 + (PFLogLevel)logLevel {
-    return [PFLogger sharedLogger].logLevel;
+    return [PFSystemLogger sharedLogger].logLevel;
 }
 
 ///--------------------------------------

--- a/Parse/Tests/Unit/DecoderTests.m
+++ b/Parse/Tests/Unit/DecoderTests.m
@@ -9,7 +9,7 @@
 
 #import "PFDecoder.h"
 #import "PFFieldOperation.h"
-#import "PFFile.h"
+#import "PFFileObject.h"
 #import "PFGeoPoint.h"
 #import "PFPolygon.h"
 #import "PFObjectPrivate.h"
@@ -140,9 +140,9 @@
                                                                  @"url" : @"http://yarr.com/yolo.png"} }];
     XCTAssertNotNil(decoded);
 
-    PFFile *file = decoded[@"file"];
+    PFFileObject *file = decoded[@"file"];
     XCTAssertNotNil(file);
-    PFAssertIsKindOfClass(file, [PFFile class]);
+    PFAssertIsKindOfClass(file, [PFFileObject class]);
 
     XCTAssertEqualObjects(file.name, @"yolo.png");
     XCTAssertEqualObjects(file.url, @"http://yarr.com/yolo.png");

--- a/Parse/Tests/Unit/FileUnitTests.m
+++ b/Parse/Tests/Unit/FileUnitTests.m
@@ -15,7 +15,7 @@
 #import "PFFileController.h"
 #import "PFFileStagingController.h"
 #import "PFFileState.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFUnitTestCase.h"
 #import "Parse_Private.h"
 
@@ -137,28 +137,28 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
 
 - (void)testContructors {
     [self clearStagingAndTemporaryFiles];
-    PFFile *file = [PFFile fileWithData:[NSData data]];
+    PFFileObject *file = [PFFileObject fileWithData:[NSData data]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFile fileWithData:[NSData data] contentType:@"content-type"];
+    file = [PFFileObject fileWithData:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFile fileWithName:@"name" data:[NSData data]];
+    file = [PFFileObject fileWithName:@"name" data:[NSData data]];
     XCTAssertEqualObjects(file.name, @"name");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFile fileWithName:nil contentsAtPath:[self sampleFilePath]];
+    file = [PFFileObject fileWithName:nil contentsAtPath:[self sampleFilePath]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
@@ -166,7 +166,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
 
     [self clearStagingAndTemporaryFiles];
     NSError *error = nil;
-    file = [PFFile fileWithName:nil contentsAtPath:[self sampleFilePath] error:&error];
+    file = [PFFileObject fileWithName:nil contentsAtPath:[self sampleFilePath] error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
@@ -174,14 +174,14 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFile fileWithName:nil data:[NSData data] contentType:@"content-type"];
+    file = [PFFileObject fileWithName:nil data:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFile fileWithName:nil data:[NSData data] contentType:@"content-type" error:&error];
+    file = [PFFileObject fileWithName:nil data:[NSData data] contentType:@"content-type" error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
@@ -193,7 +193,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     NSMutableData *data = nil;
 
     NSError *error = nil;
-    PFFile *file = [PFFile fileWithName:@"testFile"
+    PFFileObject *file = [PFFileObject fileWithName:@"testFile"
                                    data:data
                             contentType:nil
                                   error:&error];
@@ -231,7 +231,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     NSError *error = nil;
     XCTestExpectation *expectation = nil;
 
-    PFFile *file = [PFFile fileWithData:[self sampleData] contentType:@"application/octet-stream"];
+    PFFileObject *file = [PFFileObject fileWithData:[self sampleData] contentType:@"application/octet-stream"];
 
     XCTAssertTrue([file save]);
     XCTAssertTrue([file save:&error]);
@@ -325,7 +325,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTestExpectation *expectation = nil;
 
     NSData *expectedData = [self sampleData];
-    PFFile *file = [PFFile fileWithName:@"file" url:@"http://some.place"];
+    PFFileObject *file = [PFFileObject fileWithName:@"file" url:@"http://some.place"];
 
     XCTAssertEqualObjects([file getData], expectedData);
 
@@ -493,7 +493,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     });
 
     XCTestExpectation *expectation = nil;
-    PFFile *file = [PFFile fileWithName:@"file" url:@"http://some.place"];
+    PFFileObject *file = [PFFileObject fileWithName:@"file" url:@"http://some.place"];
 
     [[NSFileManager defaultManager] removeItemAtPath:cachedPath error:NULL];
     expectation = [self currentSelectorTestExpectation];
@@ -511,7 +511,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
 - (void)testClearCachedData {
     id mockedFileController = [Parse _currentManager].coreManager.fileController;
 
-    PFFile *file = [PFFile fileWithName:@"a" data:[NSData data]];
+    PFFileObject *file = [PFFileObject fileWithName:@"a" data:[NSData data]];
     OCMExpect([mockedFileController clearFileCacheAsyncForFileWithState:file.state]).andReturn([BFTask taskWithResult:nil]);
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
@@ -532,7 +532,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     OCMExpect([mockedFileController clearAllFileCacheAsync]).andReturn([BFTask taskWithResult:nil]);
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
-    [[PFFile clearAllCachedDataInBackground] continueWithBlock:^id _Nullable(BFTask * _Nonnull task) {
+    [[PFFileObject clearAllCachedDataInBackground] continueWithBlock:^id _Nullable(BFTask * _Nonnull task) {
         XCTAssertNil(task.result);
         XCTAssertFalse(task.faulted);
         XCTAssertFalse(task.cancelled);

--- a/Parse/Tests/Unit/PurchaseControllerTests.m
+++ b/Parse/Tests/Unit/PurchaseControllerTests.m
@@ -18,7 +18,7 @@
 #import "PFCommandRunning.h"
 #import "PFEncoder.h"
 #import "PFFileManager.h"
-#import "PFFile_Private.h"
+#import "PFFileObject_Private.h"
 #import "PFMacros.h"
 #import "PFPaymentTransactionObserver.h"
 #import "PFProductsRequestHandler.h"
@@ -221,7 +221,7 @@
     OCMStub([bundle appStoreReceiptURL]).andReturn([NSURL fileURLWithPath:receiptFile]);
     [[self sampleData] writeToFile:receiptFile atomically:YES];
 
-    PFFile *mockedFile = PFPartialMock([PFFile fileWithName:@"testData" data:[self sampleData]]);
+    PFFileObject *mockedFile = PFPartialMock([PFFileObject fileWithName:@"testData" data:[self sampleData]]);
 
     // lol. Probably should just stick this in the PFFile_Private header.
     NSString *stagedPath = [mockedFile valueForKey:@"stagedFilePath"];

--- a/ParseUI/Classes/Views/PFImageView.h
+++ b/ParseUI/Classes/Views/PFImageView.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void(^PFImageViewImageResultBlock)(UIImage *__nullable image,  NSError *__nullable error);
 
 @class BFTask<__covariant BFGenericType>;
-@class PFFile;
+@class PFFileObject;
 
 /**
  An image view that downloads and displays remote image stored on Parse's server.
@@ -47,7 +47,7 @@ typedef void(^PFImageViewImageResultBlock)(UIImage *__nullable image,  NSError *
 
  @warning Note that the download does not start until `-loadInBackground:` is called.
  */
-@property (nullable, nonatomic, strong) PFFile *file;
+@property (nullable, nonatomic, strong) PFFileObject *file;
 
 /**
  Initiate downloading of the remote image.

--- a/ParseUI/Classes/Views/PFImageView.m
+++ b/ParseUI/Classes/Views/PFImageView.m
@@ -23,7 +23,7 @@
 
 #import <Bolts/BFTaskCompletionSource.h>
 
-#import <Parse/PFFile.h>
+#import <Parse/PFFileObject.h>
 
 #import "PFImageCache.h"
 
@@ -32,7 +32,7 @@
 #pragma mark -
 #pragma mark Accessors
 
-- (void)setFile:(PFFile *)otherFile {
+- (void)setFile:(PFFileObject *)otherFile {
     // Here we don't check (file != otherFile)
     // because self.image needs to be updated regardless.
     // setFile: could have altered self.image
@@ -101,7 +101,7 @@
     }
 
 
-    PFFile *file = _file;
+    PFFileObject *file = _file;
     [_file getDataInBackgroundWithBlock:^(NSData *data, NSError *error) {
         if (error) {
             if (completion) {

--- a/ParseUI/ParseUIDemo/Classes/AppDelegate.m
+++ b/ParseUI/ParseUIDemo/Classes/AppDelegate.m
@@ -108,7 +108,7 @@
             NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"png"];
             NSData *data = [NSData dataWithContentsOfFile:path];
 
-            PFFile *file = [PFFile fileWithName:[path lastPathComponent] data:data];
+            PFFileObject *file = [PFFileObject fileWithName:[path lastPathComponent] data:data];
 
             PFObject *object = [[PFObject alloc] initWithClassName:@"App"];
             object[@"icon"] = file;

--- a/ParseUI/ParseUIDemo/Swift/AppDelegate.swift
+++ b/ParseUI/ParseUIDemo/Swift/AppDelegate.swift
@@ -90,7 +90,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     let bundle = Bundle.main
                     if let fileURL = bundle.url(forResource: String(index), withExtension: "png") {
                         if let data = try? Data(contentsOf: fileURL) {
-                            let file = PFFile(name: fileURL.lastPathComponent, data: data)
+                            let file = PFFileObject(name: fileURL.lastPathComponent, data: data)
                             let object = PFObject(className: "App")
                             object["icon"] = file
                             object["name"] = appName

--- a/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryCollectionViewController/SubtitleImageCollectionViewController.swift
+++ b/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryCollectionViewController/SubtitleImageCollectionViewController.swift
@@ -59,7 +59,7 @@ class SubtitleImageCollectionViewController: PFQueryCollectionViewController {
         cell?.textLabel.textAlignment = .center
         cell?.textLabel.text = object?["name"] as? String
 
-        cell?.imageView.file = object?["icon"] as? PFFile
+        cell?.imageView.file = object?["icon"] as? PFFileObject
         if cell?.imageView.image == nil {
             cell?.imageView.image = UIImage(named: "Icon.png")
             cell?.imageView.loadInBackground()

--- a/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryTableViewController/SubtitleImageTableViewController.swift
+++ b/ParseUI/ParseUIDemo/Swift/CustomViewControllers/QueryTableViewController/SubtitleImageTableViewController.swift
@@ -38,7 +38,7 @@ class SubtitleImageTableViewController: PFQueryTableViewController {
         cell?.detailTextLabel?.text = "@parseit"
 
         cell?.imageView?.image = UIImage(named: "Icon.png")
-        cell?.imageView?.file = object?["icon"] as? PFFile
+        cell?.imageView?.file = object?["icon"] as? PFFileObject
 
         return cell
     }


### PR DESCRIPTION
I needed the fix for #1325 so I took the liberty to use @RyanBertrand's branch and submit it in this PR.

All I did is fix the path of a renamed file in the xcodeproj, change some comments and rewrite the commits history.

I'm not familiar with the development procedure of the Parse SDK, but it builds on my machine, tests are green and the SDK works in my app.