### PR TITLE
Updated to 1.17.2

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.17.1'
+  s.version          = '1.17.2'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'http://parseplatform.org/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse/Parse/Internal/File/PFFileObject_Private.h
+++ b/Parse/Parse/Internal/File/PFFileObject_Private.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) PFFileState *state;
 
-+ (instancetype)fileWithName:(nullable NSString *)name url:(nullable NSString *)url;
++ (instancetype)fileObjectWithName:(nullable NSString *)name url:(nullable NSString *)url;
 
 - (nullable NSString *)_cachedFilePath;
 

--- a/Parse/Parse/PFDecoder.m
+++ b/Parse/Parse/PFDecoder.m
@@ -64,7 +64,7 @@
             return [PFRelation relationFromDictionary:dictionary withDecoder:self];
 
         } else if ([type isEqualToString:@"File"]) {
-            return [PFFileObject fileWithName:dictionary[@"name"]
+            return [PFFileObject fileObjectWithName:dictionary[@"name"]
                                     url:dictionary[@"url"]];
 
         } else if ([type isEqualToString:@"Pointer"]) {

--- a/Parse/Parse/PFFileObject.h
+++ b/Parse/Parse/PFFileObject.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject`.
  */
-+ (nullable instancetype)fileWithData:(NSData *)data;
++ (nullable instancetype)fileObjectWithData:(NSData *)data;
 
 /**
  Creates a file with given data and name.
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject` object.
  */
-+ (nullable instancetype)fileWithName:(nullable NSString *)name data:(NSData *)data;
++ (nullable instancetype)fileObjectWithName:(nullable NSString *)name data:(NSData *)data;
 
 /**
  Creates a file with the contents of another file.
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject` instance.
  */
-+ (nullable instancetype)fileWithName:(nullable NSString *)name
++ (nullable instancetype)fileObjectWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path PF_SWIFT_UNAVAILABLE;
 
 /**
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject` instance or `nil` if the error occured.
  */
-+ (nullable instancetype)fileWithName:(nullable NSString *)name
++ (nullable instancetype)fileObjectWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path
                                 error:(NSError **)error;
 
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject` instance.
  */
-+ (nullable instancetype)fileWithName:(nullable NSString *)name
++ (nullable instancetype)fileObjectWithName:(nullable NSString *)name
                                  data:(NSData *)data
                           contentType:(nullable NSString *)contentType PF_SWIFT_UNAVAILABLE;
 
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject` instance or `nil` if the error occured.
  */
-+ (nullable instancetype)fileWithName:(nullable NSString *)name
++ (nullable instancetype)fileObjectWithName:(nullable NSString *)name
                                  data:(NSData *)data
                           contentType:(nullable NSString *)contentType
                                 error:(NSError **)error;
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A new `PFFileObject` object.
  */
-+ (instancetype)fileWithData:(NSData *)data contentType:(nullable NSString *)contentType;
++ (instancetype)fileObjectWithData:(NSData *)data contentType:(nullable NSString *)contentType;
 
 ///--------------------------------------
 #pragma mark - File Properties

--- a/Parse/Parse/PFFileObject.m
+++ b/Parse/Parse/PFFileObject.m
@@ -53,22 +53,22 @@
 
 #pragma mark Init
 
-+ (instancetype)fileWithData:(NSData *)data {
-    return [self fileWithName:nil data:data contentType:nil];
++ (instancetype)fileObjectWithData:(NSData *)data {
+    return [self fileObjectWithName:nil data:data contentType:nil];
 }
 
-+ (instancetype)fileWithName:(NSString *)name data:(NSData *)data {
-    return [self fileWithName:name data:data contentType:nil];
++ (instancetype)fileObjectWithName:(NSString *)name data:(NSData *)data {
+    return [self fileObjectWithName:name data:data contentType:nil];
 }
 
-+ (instancetype)fileWithName:(NSString *)name contentsAtPath:(NSString *)path {
++ (instancetype)fileObjectWithName:(NSString *)name contentsAtPath:(NSString *)path {
     NSError *error = nil;
-    PFFileObject *file = [self fileWithName:name contentsAtPath:path error:&error];
+    PFFileObject *file = [self fileObjectWithName:name contentsAtPath:path error:&error];
     PFParameterAssert(!error, @"Could not access file at %@: %@", path, error);
     return file;
 }
 
-+ (instancetype)fileWithName:(NSString *)name contentsAtPath:(NSString *)path error:(NSError **)error {
++ (instancetype)fileObjectWithName:(NSString *)name contentsAtPath:(NSString *)path error:(NSError **)error {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     BOOL directory = NO;
 
@@ -82,23 +82,23 @@
         return nil;
     }
 
-    PFFileObject *file = [self fileWithName:name url:nil];
+    PFFileObject *file = [self fileObjectWithName:name url:nil];
     if (![file _stageWithPath:path error:error]) {
         return nil;
     }
     return file;
 }
 
-+ (instancetype)fileWithName:(NSString *)name
++ (instancetype)fileObjectWithName:(NSString *)name
                         data:(NSData *)data
                  contentType:(NSString *)contentType {
     NSError *error = nil;
-    PFFileObject *file = [self fileWithName:name data:data contentType:contentType error:&error];
+    PFFileObject *file = [self fileObjectWithName:name data:data contentType:contentType error:&error];
     PFConsistencyAssert(!error, @"Could not save file data for %@ : %@", name, error);
     return file;
 }
 
-+ (instancetype)fileWithName:(NSString *)name
++ (instancetype)fileObjectWithName:(NSString *)name
                         data:(NSData *)data
                  contentType:(NSString *)contentType
                        error:(NSError **)error {
@@ -119,8 +119,8 @@
     return file;
 }
 
-+ (instancetype)fileWithData:(NSData *)data contentType:(NSString *)contentType {
-    return [self fileWithName:nil data:data contentType:contentType];
++ (instancetype)fileObjectWithData:(NSData *)data contentType:(NSString *)contentType {
+    return [self fileObjectWithName:nil data:data contentType:contentType];
 }
 
 #pragma mark Uploading
@@ -249,7 +249,7 @@
     return self;
 }
 
-+ (instancetype)fileWithName:(NSString *)name url:(NSString *)url {
++ (instancetype)fileObjectWithName:(NSString *)name url:(NSString *)url {
     return [[self alloc] initWithName:name urlString:url mimeType:nil];
 }
 

--- a/Parse/Tests/Unit/FileUnitTests.m
+++ b/Parse/Tests/Unit/FileUnitTests.m
@@ -137,28 +137,28 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
 
 - (void)testContructors {
     [self clearStagingAndTemporaryFiles];
-    PFFileObject *file = [PFFileObject fileWithData:[NSData data]];
+    PFFileObject *file = [PFFileObject fileObjectWithData:[NSData data]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFileObject fileWithData:[NSData data] contentType:@"content-type"];
+    file = [PFFileObject fileObjectWithData:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFileObject fileWithName:@"name" data:[NSData data]];
+    file = [PFFileObject fileObjectWithName:@"name" data:[NSData data]];
     XCTAssertEqualObjects(file.name, @"name");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFileObject fileWithName:nil contentsAtPath:[self sampleFilePath]];
+    file = [PFFileObject fileObjectWithName:nil contentsAtPath:[self sampleFilePath]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
@@ -166,7 +166,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
 
     [self clearStagingAndTemporaryFiles];
     NSError *error = nil;
-    file = [PFFileObject fileWithName:nil contentsAtPath:[self sampleFilePath] error:&error];
+    file = [PFFileObject fileObjectWithName:nil contentsAtPath:[self sampleFilePath] error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
@@ -174,14 +174,14 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFileObject fileWithName:nil data:[NSData data] contentType:@"content-type"];
+    file = [PFFileObject fileObjectWithName:nil data:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
-    file = [PFFileObject fileWithName:nil data:[NSData data] contentType:@"content-type" error:&error];
+    file = [PFFileObject fileObjectWithName:nil data:[NSData data] contentType:@"content-type" error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
@@ -193,7 +193,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     NSMutableData *data = nil;
 
     NSError *error = nil;
-    PFFileObject *file = [PFFileObject fileWithName:@"testFile"
+    PFFileObject *file = [PFFileObject fileObjectWithName:@"testFile"
                                    data:data
                             contentType:nil
                                   error:&error];
@@ -231,7 +231,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     NSError *error = nil;
     XCTestExpectation *expectation = nil;
 
-    PFFileObject *file = [PFFileObject fileWithData:[self sampleData] contentType:@"application/octet-stream"];
+    PFFileObject *file = [PFFileObject fileObjectWithData:[self sampleData] contentType:@"application/octet-stream"];
 
     XCTAssertTrue([file save]);
     XCTAssertTrue([file save:&error]);
@@ -325,7 +325,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTestExpectation *expectation = nil;
 
     NSData *expectedData = [self sampleData];
-    PFFileObject *file = [PFFileObject fileWithName:@"file" url:@"http://some.place"];
+    PFFileObject *file = [PFFileObject fileObjectWithName:@"file" url:@"http://some.place"];
 
     XCTAssertEqualObjects([file getData], expectedData);
 
@@ -493,7 +493,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     });
 
     XCTestExpectation *expectation = nil;
-    PFFileObject *file = [PFFileObject fileWithName:@"file" url:@"http://some.place"];
+    PFFileObject *file = [PFFileObject fileObjectWithName:@"file" url:@"http://some.place"];
 
     [[NSFileManager defaultManager] removeItemAtPath:cachedPath error:NULL];
     expectation = [self currentSelectorTestExpectation];
@@ -511,7 +511,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
 - (void)testClearCachedData {
     id mockedFileController = [Parse _currentManager].coreManager.fileController;
 
-    PFFileObject *file = [PFFileObject fileWithName:@"a" data:[NSData data]];
+    PFFileObject *file = [PFFileObject fileObjectWithName:@"a" data:[NSData data]];
     OCMExpect([mockedFileController clearFileCacheAsyncForFileWithState:file.state]).andReturn([BFTask taskWithResult:nil]);
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];

--- a/Parse/Tests/Unit/PurchaseControllerTests.m
+++ b/Parse/Tests/Unit/PurchaseControllerTests.m
@@ -221,7 +221,7 @@
     OCMStub([bundle appStoreReceiptURL]).andReturn([NSURL fileURLWithPath:receiptFile]);
     [[self sampleData] writeToFile:receiptFile atomically:YES];
 
-    PFFileObject *mockedFile = PFPartialMock([PFFileObject fileWithName:@"testData" data:[self sampleData]]);
+    PFFileObject *mockedFile = PFPartialMock([PFFileObject fileObjectWithName:@"testData" data:[self sampleData]]);
 
     // lol. Probably should just stick this in the PFFile_Private header.
     NSString *stagedPath = [mockedFile valueForKey:@"stagedFilePath"];

--- a/ParseUI/Generated/PFResources.h
+++ b/ParseUI/Generated/PFResources.h
@@ -1,13 +1,13 @@
 // This is an auto-generated file.
 #import <Foundation/Foundation.h>
 @interface PFResources : NSObject
-+ (NSData *)twitter_icon3x_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)facebook_icon2x_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)parse_logo_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)facebook_icon3x_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)twitter_icon2x_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)parse_logo2x_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)parse_logo3x_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)facebook_icon_png;//modified:2018-02-05 08:25:40 -0500
-+ (NSData *)twitter_icon_png;//modified:2018-02-05 08:25:40 -0500
++ (NSData *)twitter_icon3x_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)facebook_icon2x_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)parse_logo_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)facebook_icon3x_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)twitter_icon2x_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)parse_logo2x_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)parse_logo3x_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)facebook_icon_png;//modified:2018-11-08 12:38:47 +0700
++ (NSData *)twitter_icon_png;//modified:2018-11-08 12:38:47 +0700
 @end

--- a/ParseUI/ParseUIDemo/Classes/AppDelegate.m
+++ b/ParseUI/ParseUIDemo/Classes/AppDelegate.m
@@ -108,7 +108,7 @@
             NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"png"];
             NSData *data = [NSData dataWithContentsOfFile:path];
 
-            PFFileObject *file = [PFFileObject fileWithName:[path lastPathComponent] data:data];
+            PFFileObject *file = [PFFileObject fileObjectWithName:[path lastPathComponent] data:data];
 
             PFObject *object = [[PFObject alloc] initWithClassName:@"App"];
             object[@"icon"] = file;


### PR DESCRIPTION
- Fixed "Argument passed to call that takes no arguments" when declaring PFFileObject(data:contentType) (or so)
- Updated pod to 1.17.2