### PR TITLE
Bandaid for empty operationSetQueue during _mergeAfterSaveWithResult:

### DIFF
--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -1326,6 +1326,10 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (void)_mergeAfterSaveWithResult:(NSDictionary *)result decoder:(PFDecoder *)decoder {
     @synchronized (lock) {
+        if (operationSetQueue.count == 0)
+        { // it should never be empty at this point. if it is, add a dummy:
+            [operationSetQueue addObject:[[PFOperationSet alloc] init]];
+        }
         PFOperationSet *operationsBeforeSave = operationSetQueue[0];
         [operationSetQueue removeObjectAtIndex:0];
 


### PR DESCRIPTION
Seen in the wild: many repeated crashes, by just a few users, where `_mergeAfterSaveWithResult` crashes due to `operationSetQueue` being empty and assuming that it has at least one item to pop.

No idea what triggers it.

Band-aid: pre-check and, if the queue is empty at this point, add a dummy empty `PFOperationSet`.

Results: that particular crash no longer appears in our Crashlytics reports. Whether the people in question are now having other difficulties, we don't know. This is obviously a state that shouldn't be reached in the first place, so the band-aid is covering a deeper problem.

ref issue #1262