### PR TITLE
Add PFFile to PFFileObject rename warning

### DIFF
--- a/Parse/Parse/PFFileObject.h
+++ b/Parse/Parse/PFFileObject.h
@@ -15,6 +15,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+ /**
+ `PFFile` was renamed to `PFFileObject`.
+ This class is just for warning developer what the right class is, in case they are migrating from SDKs before 1.17.2.
+ */
+__attribute__((unavailable("PFFile was renamed to PFFileObject. Please use it instead.")))
+@interface PFFile : NSObject
+@end
+ 
 /**
  `PFFileObject` representes a file of binary data stored on the Parse servers.
  This can be a image, video, or anything else that an application needs to reference in a non-relational way.


### PR DESCRIPTION
I updated from 1.17.1 to 1.17.2 and started getting the error `Unknown type name 'PFFile'`.
This PR should point users who eventually update to use the new `PFFileObject` class.

<img width="849" alt="captura de tela 2018-12-17 as 17 48 39" src="https://user-images.githubusercontent.com/1164565/50098179-17a0c080-0224-11e9-8f20-fe79d2733b02.png">
