### PR TITLE
Update facebook dependency name to match current repo name

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "BoltsFramework/Bolts-ObjC" ~> 1.9
-github "facebook/facebook-ios-sdk" ~> 4.29
+github "facebook/facebook-objc-sdk" ~> 4.29
 


### PR DESCRIPTION
Update facebook dependency name to the current one `facebook/facebook-objc-sdk` to avoid having duplicated lines in Cartfile.resolved when importing `facebook/facebook-objc-sdk`.

Without this change I end up having this in my Carthage resolved file:
```
...
github "facebook/facebook-ios-sdk" "v4.42.0"
github "facebook/facebook-objc-sdk" "v4.42.0"
...
```
