### PR TITLE
Class properties

### DIFF
--- a/Parse/Parse/Parse.h
+++ b/Parse/Parse/Parse.h
@@ -104,17 +104,21 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return The current configuration in use by the SDK. Returns nil if the SDK has not been initialized yet.
  */
-+ (nullable ParseClientConfiguration *)currentConfiguration;
+@property (nonatomic, nullable, readonly, class) ParseClientConfiguration *currentConfiguration;
 
 /**
  The current application id that was used to configure Parse framework.
  */
-+ (NSString *)getApplicationId;
+@property (nonatomic, nonnull, readonly, class) NSString *applicationId;
+
++ (NSString *)getApplicationId PARSE_DEPRECATED("Use applicationId property.");
 
 /**
  The current client key that was used to configure Parse framework.
  */
-+ (nullable NSString *)getClientKey;
+@property (nonatomic, nullable, readonly, class) NSString *clientKey;
+
++ (nullable NSString *)getClientKey PARSE_DEPRECATED("Use clientKey property.");
 
 ///--------------------------------------
 #pragma mark - Enabling Local Datastore
@@ -128,10 +132,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Flag that indicates whether Local Datastore is enabled.
-
+ 
  @return `YES` if Local Datastore is enabled, otherwise `NO`.
  */
-+ (BOOL)isLocalDatastoreEnabled PF_TV_UNAVAILABLE;
+@property (nonatomic, readonly, class) BOOL isLocalDatastoreEnabled PF_TV_UNAVAILABLE;
 
 ///--------------------------------------
 #pragma mark - Enabling Extensions Data Sharing
@@ -211,29 +215,16 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- Sets the level of logging to display.
+ Gets or sets the level of logging to display.
 
  By default:
- - If running inside an app that was downloaded from iOS App Store - it is set to `PFLogLevelNone`
- - All other cases - it is set to `PFLogLevelWarning`
-
- @param logLevel Log level to set.
- @see PFLogLevel
- */
-+ (void)setLogLevel:(PFLogLevel)logLevel;
-
-/**
- Log level that will be displayed.
-
- By default:
-
  - If running inside an app that was downloaded from iOS App Store - it is set to `PFLogLevelNone`
  - All other cases - it is set to `PFLogLevelWarning`
 
  @return A `PFLogLevel` value.
  @see PFLogLevel
  */
-+ (PFLogLevel)logLevel;
+@property (nonatomic, readwrite, class) PFLogLevel logLevel;
 
 @end
 

--- a/Parse/Parse/Parse.m
+++ b/Parse/Parse/Parse.m
@@ -93,16 +93,24 @@ static ParseClientConfiguration *currentParseConfiguration_;
     return currentParseManager_.configuration;
 }
 
-+ (NSString *)getApplicationId {
++ (NSString *)applicationId {
     PFConsistencyAssert(currentParseManager_,
                         @"You have to call setApplicationId:clientKey: on Parse to configure Parse.");
     return currentParseManager_.configuration.applicationId;
 }
 
-+ (nullable NSString *)getClientKey {
++ (NSString *)getApplicationId {
+    return [self applicationId];
+}
+
++ (nullable NSString *)clientKey {
     PFConsistencyAssert(currentParseManager_,
                         @"You have to call setApplicationId:clientKey: on Parse to configure Parse.");
     return currentParseManager_.configuration.clientKey;
+}
+
++ (nullable NSString *)getClientKey {
+    return [self clientKey];
 }
 
 ///--------------------------------------

--- a/Parse/Tests/Other/StoreKitMocking/PFTestSKProductsRequest.m
+++ b/Parse/Tests/Other/StoreKitMocking/PFTestSKProductsRequest.m
@@ -57,8 +57,9 @@ static NSSet *_validProducts;
                                                                       invalidProductIdentifiers:[invalidProductIdentifiers allObjects]];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate productsRequest:self didReceiveResponse:response];
-            [self.delegate requestDidFinish:self];
+            id<SKProductsRequestDelegate> delegate = self.delegate;
+            [delegate productsRequest:self didReceiveResponse:response];
+            [delegate requestDidFinish:self];
         });
     });
 }

--- a/Parse/Tests/Unit/CommandUnitTests.m
+++ b/Parse/Tests/Unit/CommandUnitTests.m
@@ -55,8 +55,8 @@
 
     NSError *error = nil;
     PFURLSessionCommandRunner *commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:[Parse _currentManager]
-                                                                                        applicationId:[Parse getApplicationId]
-                                                                                            clientKey:[Parse getClientKey]
+                                                                                        applicationId:[Parse applicationId]
+                                                                                            clientKey:[Parse clientKey]
                                                                                             serverURL:[NSURL URLWithString:_ParseDefaultServerURLString]];
     [[commandRunner runCommandAsync:command
                         withOptions:PFCommandRunningOptionRetryIfFailed] waitForResult:&error];
@@ -86,8 +86,8 @@
 
     NSError *error = nil;
     PFURLSessionCommandRunner *commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:[Parse _currentManager]
-                                                                                        applicationId:[Parse getApplicationId]
-                                                                                            clientKey:[Parse getClientKey]
+                                                                                        applicationId:[Parse applicationId]
+                                                                                            clientKey:[Parse clientKey]
                                                                                             serverURL:[NSURL URLWithString:_ParseDefaultServerURLString]];
     commandRunner.initialRetryDelay = DBL_MIN;
     [[commandRunner runCommandAsync:command

--- a/Parse/Tests/Unit/ExtensionDataSharingTests.m
+++ b/Parse/Tests/Unit/ExtensionDataSharingTests.m
@@ -103,7 +103,7 @@
 
     // Paths are different on iOS and OSX.
     NSString *containerPath = [PFExtensionDataSharingTestHelper sharedTestDirectoryPathForGroupIdentifier:@"yolo"];
-    [self assertDirectory:containerPath hasContents:@{ @"Parse" : @{ [Parse getApplicationId] : @{ @"applicationId" : [NSNull null] } } } only:NO];
+    [self assertDirectory:containerPath hasContents:@{ @"Parse" : @{ [Parse applicationId] : @{ @"applicationId" : [NSNull null] } } } only:NO];
 }
 
 - (void)testExtensionUsesSharedContainer {
@@ -116,7 +116,7 @@
 
     // Paths are different on iOS and OSX.
     NSString *containerPath = [PFExtensionDataSharingTestHelper sharedTestDirectoryPathForGroupIdentifier:@"yolo"];
-    [self assertDirectory:containerPath hasContents:@{ @"Parse" : @{ [Parse getApplicationId] : @{ @"applicationId" : [NSNull null] } } } only:NO];
+    [self assertDirectory:containerPath hasContents:@{ @"Parse" : @{ [Parse applicationId] : @{ @"applicationId" : [NSNull null] } } } only:NO];
 }
 
 - (void)testMigratingDataFromMainSandbox {


### PR DESCRIPTION
This changes the declaration of class properties in the headers from `+ (Type)property` and `+ (void)setProperty:(Type)value;` to the more modern `@property (class) Type property` where appropriate. 

This has the main advantage of allowing the Swift compiler to differentiate between a property and a method, removing errors like `foo.bar` instead of `foo.bar()` in Swift. 

This should not affect ObjC behaviour in any way. 

In the wake of this I renamed some class methods from `getFoo` to `foo` to keep in line with property naming. The old names are now marked as deprecated.  