### PR TITLE
Fix for failing to build for pod 'FBSDKCoreKit'

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -105,6 +105,8 @@ Pod::Spec.new do |s|
     s.dependency 'Parse/Core'
     s.dependency 'Bolts', '~> 1.9'
     s.dependency 'FBSDKLoginKit', '~> 4.33'
+    s.dependency 'FBSDKCoreKit', '~> 4.44.0'
+
   end
 
   s.subspec 'FacebookUtils-tvOS' do |s|
@@ -128,6 +130,8 @@ Pod::Spec.new do |s|
     s.dependency 'Bolts', '~> 1.9'
     s.dependency 'FBSDKTVOSKit', '~> 4.33'
     s.dependency 'FBSDKShareKit', '~> 4.33'
+    s.dependency 'FBSDKCoreKit', '~> 4.44.0'
+
   end
 
   s.subspec 'TwitterUtils' do |s|


### PR DESCRIPTION
updating pods gets
FBSDKCoreKit -> 5.0.0
FBSDKShareKit -> 5.0.0
FBSDKLoginKit -> 4.44.1

this fails to compile since internal APIs changed in FBSDKCoreKit and FBSDKLoginKit can't find the old APIs it's using.
staying in 4.44.1 on FB Kits generates numerous warnings, fixed on version 5.0.0.

