### PR TITLE
Bumps macOS deployment target to match Bolts

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.platform = :ios, :osx, :tvos, :watchos
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.8'
+  s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '2.0'
 

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.platform = :ios, :osx, :tvos, :watchos
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.2'
+  s.osx.deployment_target = '10.8'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '2.0'
 


### PR DESCRIPTION
This should fix the failing nightly Cocoapods build