### PR TITLE
Add support for using URLCache on macCatalyst

### DIFF
--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -268,10 +268,17 @@
     configuration.HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
     configuration.HTTPShouldSetCookies = NO;
 
+#if TARGET_OS_UIKITFORMAC
+    // Completely disable caching of responses for security reasons.
+    configuration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                                           diskCapacity:0
+                                                           directoryURL:nil];
+#else
     // Completely disable caching of responses for security reasons.
     configuration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                                            diskCapacity:0
                                                                diskPath:nil];
+#endif
 
     NSBundle *bundle = [NSBundle mainBundle];
     NSDictionary *headers = [PFCommandURLRequestConstructor defaultURLRequestHeadersForApplicationId:applicationId

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -268,7 +268,7 @@
     configuration.HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
     configuration.HTTPShouldSetCookies = NO;
 
-#if TARGET_OS_UIKITFORMAC
+#if TARGET_OS_MACCATALYST
     // Completely disable caching of responses for security reasons.
     configuration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                                            diskCapacity:0


### PR DESCRIPTION
This simple pull request makes it possible to compile Parse-SDK-iOS-OSX for Catalyst. It also requires the following patch to Bolts-ObjC https://github.com/parse-community/Bolts-ObjC/pull/1.