### PR TITLE
Add get and set server

### DIFF
--- a/Parse/Parse/Parse.h
+++ b/Parse/Parse/Parse.h
@@ -107,9 +107,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly, class) ParseClientConfiguration *currentConfiguration;
 
 /**
- Sets the server URL to connect to Parse Server. This can be used to update the server URL after this client has been
- initialized, without having to destroy this client.
- 
+ Sets the server URL to connect to Parse Server. The local client cache is not cleared.
+ @discussion This can be used to update the server URL after this client has been initialized, without having to destroy this client. An example use case is
+ server connection failover, where the clients connects to another URL if the server becomes unreachable at the current URL.
+ @warning The new server URL must point to a Parse Server that connects to the same database. Otherwise, issues may arise
+ related to locally cached data or delayed methods such as saveEventually.
  @param server  The server URL to set.
  */
 + (void)setServer:(nonnull NSString *)server;

--- a/Parse/Parse/Parse.h
+++ b/Parse/Parse/Parse.h
@@ -107,6 +107,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly, class) ParseClientConfiguration *currentConfiguration;
 
 /**
+ Sets the server URL to connect to Parse Server. This can be used to update the server URL after this client has been
+ initialized, without having to destroy this client.
+ 
+ @param server  The server URL to set.
+ */
++ (void)setServer:(nonnull NSString *)server;
+
+/**
  The current application id that was used to configure Parse framework.
  */
 @property (nonatomic, nonnull, readonly, class) NSString *applicationId;
@@ -119,6 +127,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly, class) NSString *clientKey;
 
 + (nullable NSString *)getClientKey PARSE_DEPRECATED("Use clientKey property.");
+
+/**
+ The current server URL to connect to Parse Server.
+ */
+@property (nonatomic, nullable, readonly, class) NSString *server;
 
 ///--------------------------------------
 #pragma mark - Enabling Local Datastore

--- a/Parse/Parse/Parse.m
+++ b/Parse/Parse/Parse.m
@@ -89,6 +89,11 @@ static ParseClientConfiguration *currentParseConfiguration_;
     [[self parseModulesCollection] parseDidInitializeWithApplicationId:configuration.applicationId clientKey:configuration.clientKey];
 }
 
++ (void)setServer:(nonnull NSString *)server {
+    PFConsistencyAssert([self currentConfiguration], @"Parse is not initialized.");
+    [PFInternalUtils setParseServer:[server copy]];
+}
+
 + (nullable ParseClientConfiguration *)currentConfiguration {
     return currentParseManager_.configuration;
 }
@@ -111,6 +116,10 @@ static ParseClientConfiguration *currentParseConfiguration_;
 
 + (nullable NSString *)getClientKey {
     return [self clientKey];
+}
+
++ (nullable NSString *)server {
+    return [[PFInternalUtils parseServerURLString] copy];
 }
 
 ///--------------------------------------

--- a/Parse/Parse/Parse.m
+++ b/Parse/Parse/Parse.m
@@ -90,8 +90,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
 }
 
 + (void)setServer:(nonnull NSString *)server {
-    PFConsistencyAssert([self currentConfiguration], @"Parse is not initialized.");
-    [PFInternalUtils setParseServer:[server copy]];
+    [PFInternalUtils setParseServer:server];
 }
 
 + (nullable ParseClientConfiguration *)currentConfiguration {


### PR DESCRIPTION
Added the possibility to set and get the current server URL without having to destroy and re-initialize the client. Example use case: domain failover handling.

Analogous to https://github.com/parse-community/Parse-SDK-Android/pull/985