### PR TITLE
Don't use NSURLCache API not available in Catalyst

### DIFF
--- a/Parse/Configurations/Parse-macOS.xcconfig
+++ b/Parse/Configurations/Parse-macOS.xcconfig
@@ -18,4 +18,5 @@ INFOPLIST_FILE = $(PROJECT_DIR)/Parse/Resources/Parse-OSX.Info.plist
 // TODO: (nlutsenko) Cleanup source code so we can safely ignore local variable shadow warnings.
 GCC_WARN_SHADOW = NO
 
+CONFIGURATION_BUILD_DIR=$(BUILD_DIR)/$(CONFIGURATION)
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/../Carthage/Build/Mac

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -275,18 +275,10 @@
                                                            directoryURL:nil];
 #else
     // Completely disable caching of responses for security reasons.
-    NSURLCache *cache;
-
-#if TARGET_OS_MACCATALYST
-    cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                          diskCapacity:0
-                                          directoryURL:nil];
-#else
-    cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                          diskCapacity:0
-                                              diskPath:nil];
+    configuration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                                            diskCapacity:0
+                                                                diskPath:nil];
 #endif
-    configuration.URLCache = cache;
 
     NSBundle *bundle = [NSBundle mainBundle];
     NSDictionary *headers = [PFCommandURLRequestConstructor defaultURLRequestHeadersForApplicationId:applicationId

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -277,14 +277,14 @@
     // Completely disable caching of responses for security reasons.
     NSURLCache *cache;
 
-#ifndef __MAC_10_15
-    cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                          diskCapacity:0
-                                         directoryPath:nil];
-#else
+#if TARGET_OS_MACCATALYST
     cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                           diskCapacity:0
                                           directoryURL:nil];
+#else
+    cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                          diskCapacity:0
+                                         directoryPath:nil];
 #endif
     configuration.URLCache = cache;
 

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -277,22 +277,18 @@
     // Completely disable caching of responses for security reasons.
     NSURLCache *cache;
 
-    if (@available(iOS 13.0, *)
-        || @available(tvOS 13.0, *)
-        || @available(macOS 10.15, *)
-        || @available(watchOS 6.0, *)
-        || @available(macCatalyst 13.0, *)) {
+#ifdef __IPHONE_13_0 || __TVOS_13 || __WATCHOS_6_0 || __MAC_10_15
         cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                               diskCapacity:0
                                               directoryURL:nil];
-    } else {
-#if !TARGET_OS_MACCATALYST
+
+#else
         cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                               diskCapacity:0
                                              directoryPath:nil];
-#endif
-    }
 
+
+#endif
     configuration.URLCache = cache;
 
     NSBundle *bundle = [NSBundle mainBundle];

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -275,10 +275,25 @@
                                                            directoryURL:nil];
 #else
     // Completely disable caching of responses for security reasons.
-    configuration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                                           diskCapacity:0
-                                                               diskPath:nil];
+    NSURLCache *cache;
+
+    if (@available(iOS 13.0, *)
+        || @available(tvOS 13.0, *)
+        || @available(macOS 10.15, *)
+        || @available(watchOS 6.0, *)
+        || @available(macCatalyst 13.0, *)) {
+        cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                              diskCapacity:0
+                                              directoryURL:nil];
+    } else {
+#if !TARGET_OS_MACCATALYST
+        cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                              diskCapacity:0
+                                             directoryPath:nil];
 #endif
+    }
+
+    configuration.URLCache = cache;
 
     NSBundle *bundle = [NSBundle mainBundle];
     NSDictionary *headers = [PFCommandURLRequestConstructor defaultURLRequestHeadersForApplicationId:applicationId

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -277,17 +277,14 @@
     // Completely disable caching of responses for security reasons.
     NSURLCache *cache;
 
-#ifdef __IPHONE_13_0 || __TVOS_13 || __WATCHOS_6_0 || __MAC_10_15
-        cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                              diskCapacity:0
-                                              directoryURL:nil];
-
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
+    cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                          diskCapacity:0
+                                         directoryPath:nil];
 #else
-        cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                              diskCapacity:0
-                                             directoryPath:nil];
-
-
+    cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
+                                          diskCapacity:0
+                                          directoryURL:nil];
 #endif
     configuration.URLCache = cache;
 

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -284,7 +284,7 @@
 #else
     cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                           diskCapacity:0
-                                         directoryPath:nil];
+                                              diskPath:nil];
 #endif
     configuration.URLCache = cache;
 

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -276,8 +276,8 @@
 #else
     // Completely disable caching of responses for security reasons.
     configuration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
-                                                            diskCapacity:0
-                                                                diskPath:nil];
+                                                           diskCapacity:0
+                                                               diskPath:nil];
 #endif
 
     NSBundle *bundle = [NSBundle mainBundle];

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -277,7 +277,7 @@
     // Completely disable caching of responses for security reasons.
     NSURLCache *cache;
 
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
+#ifndef __MAC_10_15
     cache = [[NSURLCache alloc] initWithMemoryCapacity:[NSURLCache sharedURLCache].memoryCapacity
                                           diskCapacity:0
                                          directoryPath:nil];

--- a/Parse/Parse/PFInstallation.m
+++ b/Parse/Parse/PFInstallation.m
@@ -293,6 +293,17 @@ static NSSet *protectedKeys;
     NSString *appName = appInfo[(__bridge NSString *)kCFBundleNameKey];
     NSString *appVersion = appInfo[(__bridge NSString *)kCFBundleVersionKey];
     NSString *appIdentifier = appInfo[(__bridge NSString *)kCFBundleIdentifierKey];
+
+    // Mac Catalyst Apps use a prefix to the bundle ID. This should not be transmitted
+    // to the parse backend. Catalyst apps should look like iOS apps otherwise
+    // push and other services don't work properly.
+    if (@available(macCatalyst 13.0, *) && appIdentifier) {
+        NSRange macCatalystPrefix = [appIdentifier rangeOfString:@"maccatalyst."];
+        if (macCatalystPrefix.location == 0) {
+            appIdentifier = [appIdentifier stringByReplacingCharactersInRange:macCatalystPrefix
+                                                                   withString:@""];
+        }
+    }
     // It's possible that the app was created without an info.plist and we just
     // cannot get the data we need.
     // Note: it's important to make the possibly nil string the message receptor for

--- a/Parse/Parse/PFInstallation.m
+++ b/Parse/Parse/PFInstallation.m
@@ -33,7 +33,7 @@
 
 // The prefix removed from the CFBundleIdentifier sent with the installation
 // for macOS Catalyst apps for installations;
-const NSString * kMacCatalystBundleIdPrefix = @"maccatalyst.";
+static const NSString * kMacCatalystBundleIdPrefix = @"maccatalyst.";
 
 
 @implementation PFInstallation (Private)

--- a/Parse/Parse/PFInstallation.m
+++ b/Parse/Parse/PFInstallation.m
@@ -31,6 +31,11 @@
 #import "PFObjectState_Private.h"
 #import "PFObjectConstants.h"
 
+// The prefix removed from the CFBundleIdentifier sent with the installation
+// for macOS Catalyst apps for installations;
+const NSString * kMacCatalystBundleIdPrefix = @"maccatalyst.";
+
+
 @implementation PFInstallation (Private)
 
 static NSSet *protectedKeys;
@@ -298,7 +303,7 @@ static NSSet *protectedKeys;
     // to the parse backend. Catalyst apps should look like iOS apps otherwise
     // push and other services don't work properly.
     if (@available(macCatalyst 13.0, *) && appIdentifier) {
-        NSRange macCatalystPrefix = [appIdentifier rangeOfString:@"maccatalyst."];
+        NSRange macCatalystPrefix = [appIdentifier rangeOfString:(NSString *)kMacCatalystBundleIdPrefix];
         if (macCatalystPrefix.location == 0) {
             appIdentifier = [appIdentifier stringByReplacingCharactersInRange:macCatalystPrefix
                                                                    withString:@""];

--- a/Parse/Parse/PFInstallation.m
+++ b/Parse/Parse/PFInstallation.m
@@ -300,15 +300,17 @@ static NSSet *protectedKeys;
     NSString *appIdentifier = appInfo[(__bridge NSString *)kCFBundleIdentifierKey];
 
 #ifdef TARGET_OS_MACCATALYST
-    // If using an Xcode new enough to know about Mac Catalyst:
-    // Mac Catalyst Apps use a prefix to the bundle ID. This should not be transmitted
-    // to the parse backend. Catalyst apps should look like iOS apps otherwise
-    // push and other services don't work properly.
-    if (@available(macCatalyst 13.0, *) && appIdentifier) {
-        NSRange macCatalystPrefix = [appIdentifier rangeOfString:(NSString *)kMacCatalystBundleIdPrefix];
-        if (macCatalystPrefix.location == 0) {
-            appIdentifier = [appIdentifier stringByReplacingCharactersInRange:macCatalystPrefix
-                                                                   withString:@""];
+        // If using an Xcode new enough to know about Mac Catalyst:
+        // Mac Catalyst Apps use a prefix to the bundle ID. This should not be transmitted
+        // to the parse backend. Catalyst apps should look like iOS apps otherwise
+        // push and other services don't work properly.
+    if (@available(macCatalyst 13.0, *)) {
+        if (appIdentifier) {
+            NSRange macCatalystPrefix = [appIdentifier rangeOfString:(NSString *)kMacCatalystBundleIdPrefix];
+            if (macCatalystPrefix.location == 0) {
+                appIdentifier = [appIdentifier stringByReplacingCharactersInRange:macCatalystPrefix
+                                                                       withString:@""];
+            }
         }
     }
 #endif

--- a/Parse/Parse/PFInstallation.m
+++ b/Parse/Parse/PFInstallation.m
@@ -299,6 +299,8 @@ static NSSet *protectedKeys;
     NSString *appVersion = appInfo[(__bridge NSString *)kCFBundleVersionKey];
     NSString *appIdentifier = appInfo[(__bridge NSString *)kCFBundleIdentifierKey];
 
+#ifdef TARGET_OS_MACCATALYST
+    // If using an Xcode new enough to know about Mac Catalyst:
     // Mac Catalyst Apps use a prefix to the bundle ID. This should not be transmitted
     // to the parse backend. Catalyst apps should look like iOS apps otherwise
     // push and other services don't work properly.
@@ -309,6 +311,7 @@ static NSSet *protectedKeys;
                                                                    withString:@""];
         }
     }
+#endif
     // It's possible that the app was created without an info.plist and we just
     // cannot get the data we need.
     // Note: it's important to make the possibly nil string the message receptor for

--- a/Parse/Tests/Unit/PinningObjectStoreTests.m
+++ b/Parse/Tests/Unit/PinningObjectStoreTests.m
@@ -36,6 +36,13 @@
 #pragma mark - Tests
 ///--------------------------------------
 
+- (void)setUp
+{
+    [PFPin registerSubclass];
+
+    [super setUp];
+}
+
 - (void)testConstructors {
     id dataSource = [self mockedDataSource];
 


### PR DESCRIPTION
# Changes

- [x] Remove deprecated API for `NSURLCache` on catalyst
- [x] Remove `maccatalyst.` prefix from bundle ID before registering `PFInstallation`

The deprecated API allows the parse SDK to be linked for Mac Catalyst apps and the Xcode 11 SDKs (iOS 13, macOS 10.15, etc.) in general.

In addition to this it also removes the `maccatalyst.` prefix added by Catalyst from the bundle ID. The reasoning is that a Catalyst app should be treated as a iOS App just running on the Mac in all regards. If this is not done some things will not work (e.g. sending push notifications fails since the `topic` is wrong (using `maccatalyst.com.example.app` instead of `com.example.app` which is correct. If the SDK user wants to distinguish Catalyst installations `channels` are a better choice.  


