### PR TITLE
Remove iPhoneSimulator

### DIFF
--- a/ParseFacebookUtils/Resources/Info-iOS.plist
+++ b/ParseFacebookUtils/Resources/Info-iOS.plist
@@ -18,7 +18,6 @@
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
-		<string>iPhoneSimulator</string>
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>

--- a/ParseTwitterUtils/Resources/Info.plist
+++ b/ParseTwitterUtils/Resources/Info.plist
@@ -18,7 +18,6 @@
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
-		<string>iPhoneSimulator</string>
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>

--- a/ParseUI/Resources/Info.plist
+++ b/ParseUI/Resources/Info.plist
@@ -18,7 +18,6 @@
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
-		<string>iPhoneSimulator</string>
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR follows on from #1496 by removing `iPhoneSimulator` from the `CFBundleSupportedPlatforms` array of all the framework `info.plist`s.

This addresses the issue brought up in #1491 #1495.