### PR TITLE
Fix capitalization in OCKMock

### DIFF
--- a/Parse/Tests/Other/OCMock/OCMock+Parse.m
+++ b/Parse/Tests/Other/OCMock/OCMock+Parse.m
@@ -14,7 +14,7 @@
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"
 
-@implementation OCMockObject (PFCOmmandRunning)
+@implementation OCMockObject (PFCommandRunning)
 
 - (void)mockCommandResult:(id)result forCommandsPassingTest:(BOOL (^)(PFRESTCommand *command))block {
     PFCommandResult *commandResult = [PFCommandResult commandResultWithResult:result


### PR DESCRIPTION
Small catch I found while looking through code to port to Parse-Swift. Not sure if it effects anything, but if I see things that are quick fixes, I'll submit them.