### PR TITLE
Fixing intermittent test failures

### DIFF
--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -2639,8 +2639,6 @@
 		B141170F1E5D081500F70D7A /* PFFileUploadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B141170A1E5D081500F70D7A /* PFFileUploadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14117101E5D081500F70D7A /* PFFileUploadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B141170A1E5D081500F70D7A /* PFFileUploadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14117111E5D081500F70D7A /* PFFileUploadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B141170A1E5D081500F70D7A /* PFFileUploadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B9312D5B23C4A6FC002D4A4C /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9312D5623C4A6FC002D4A4C /* OCMock.framework */; };
-		B9312D5D23C4A775002D4A4C /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9312D5C23C4A775002D4A4C /* OCMock.framework */; };
 		BC5511D6242E6E66008E5D9F /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCC5EAAC22D5F96600CF8900 /* Bolts.framework */; };
 		BCC5EAB322D5F97E00CF8900 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCC5EAB222D5F97D00CF8900 /* Bolts.framework */; };
 		BCC5EAB522D5F98F00CF8900 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCC5EAB422D5F98F00CF8900 /* Bolts.framework */; };
@@ -2926,6 +2924,69 @@
 			proxyType = 1;
 			remoteGlobalIDString = 81C3821B19CCA89E0066284A;
 			remoteInfo = "Parse-iOS";
+		};
+		BC105FC424C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 030EF0A814632FD000B04273;
+			remoteInfo = OCMock;
+		};
+		BC105FC624C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03565A3118F0566E003AE91E;
+			remoteInfo = OCMockTests;
+		};
+		BC105FC824C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 030EF0DC14632FF700B04273;
+			remoteInfo = OCMockLib;
+		};
+		BC105FCA24C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D31108AD1828DB8700737925;
+			remoteInfo = OCMockLibTests;
+		};
+		BC105FCC24C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F0B950F11B0080BE00942C38;
+			remoteInfo = "OCMock iOS";
+		};
+		BC105FCE24C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 817EB1621BD765130047E85A;
+			remoteInfo = "OCMock tvOS";
+		};
+		BC105FD024C5D0C900295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8DE97CA022B43EE60098C63F;
+			remoteInfo = "OCMock watchOS";
+		};
+		BC105FD224C5D0D600295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 030EF0A714632FD000B04273;
+			remoteInfo = OCMock;
+		};
+		BC105FD424C5D0E100295EF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F0B950F01B0080BE00942C38;
+			remoteInfo = "OCMock iOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -3482,8 +3543,7 @@
 		B141169D1E5BC24B00F70D7A /* PFFileUploadController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileUploadController.h; sourceTree = "<group>"; };
 		B14116FB1E5D078E00F70D7A /* PFFileUploadResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFFileUploadResult.m; sourceTree = "<group>"; };
 		B141170A1E5D081500F70D7A /* PFFileUploadResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileUploadResult.h; sourceTree = "<group>"; };
-		B9312D5623C4A6FC002D4A4C /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = ../Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
-		B9312D5C23C4A775002D4A4C /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = ../Carthage/Build/Mac/OCMock.framework; sourceTree = "<group>"; };
+		BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCMock.xcodeproj; path = ../Carthage/Checkouts/OCMock/Source/OCMock.xcodeproj; sourceTree = "<group>"; };
 		BCC5EAAC22D5F96600CF8900 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/iOS/Bolts.framework; sourceTree = "<group>"; };
 		BCC5EAB222D5F97D00CF8900 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/tvOS/Bolts.framework; sourceTree = "<group>"; };
 		BCC5EAB422D5F98F00CF8900 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/watchOS/Bolts.framework; sourceTree = "<group>"; };
@@ -3569,7 +3629,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B9312D5B23C4A6FC002D4A4C /* OCMock.framework in Frameworks */,
 				F5C42CC71B34C22100C720D8 /* AudioToolbox.framework in Frameworks */,
 				816F44761A8E8933009CDB32 /* StoreKit.framework in Frameworks */,
 				816F44771A8E8933009CDB32 /* libsqlite3.dylib in Frameworks */,
@@ -3585,7 +3644,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A13525620282B4D000F5FD5 /* Parse.framework in Frameworks */,
-				B9312D5D23C4A775002D4A4C /* OCMock.framework in Frameworks */,
 				F5B0B3171B44A2CA00F3EBC4 /* StoreKit.framework in Frameworks */,
 				F5B0B3161B44A22300F3EBC4 /* SystemConfiguration.framework in Frameworks */,
 			);
@@ -3855,8 +3913,7 @@
 		09D3364C139C54940098E916 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				B9312D5623C4A6FC002D4A4C /* OCMock.framework */,
-				B9312D5C23C4A775002D4A4C /* OCMock.framework */,
+				BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */,
 				BCC5EAAC22D5F96600CF8900 /* Bolts.framework */,
 				BCC5EAB222D5F97D00CF8900 /* Bolts.framework */,
 				BCC5EAB422D5F98F00CF8900 /* Bolts.framework */,
@@ -5097,6 +5154,20 @@
 				81EEE1AF1B446D600087AC4D /* PFCurrentUserController.m */,
 			);
 			path = CurrentUserController;
+			sourceTree = "<group>";
+		};
+		BC105FBB24C5D0C900295EF7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BC105FC524C5D0C900295EF7 /* OCMock.framework */,
+				BC105FC724C5D0C900295EF7 /* OCMockTests.xctest */,
+				BC105FC924C5D0C900295EF7 /* libOCMock.a */,
+				BC105FCB24C5D0C900295EF7 /* OCMockLibTests.xctest */,
+				BC105FCD24C5D0C900295EF7 /* OCMock.framework */,
+				BC105FCF24C5D0C900295EF7 /* OCMock.framework */,
+				BC105FD124C5D0C900295EF7 /* OCMock.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		F50C66301B33A6CE001941A6 /* Utilites */ = {
@@ -6806,6 +6877,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				BC105FD524C5D0E100295EF7 /* PBXTargetDependency */,
 				8111674C1B8402DF003CB026 /* PBXTargetDependency */,
 				4AE33A2D1F5451B20088DCA0 /* PBXTargetDependency */,
 			);
@@ -6826,6 +6898,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				BC105FD324C5D0D600295EF7 /* PBXTargetDependency */,
 				811167471B8402DA003CB026 /* PBXTargetDependency */,
 			);
 			name = "ParseUnitTests-macOS";
@@ -6979,6 +7052,10 @@
 					ProductGroup = 4A13517620281768000F5FD5 /* Products */;
 					ProjectRef = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
 				},
+				{
+					ProductGroup = BC105FBB24C5D0C900295EF7 /* Products */;
+					ProjectRef = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
+				},
 			);
 			projectRoot = "";
 			targets = (
@@ -7072,6 +7149,55 @@
 			fileType = wrapper.application;
 			path = BoltsTestUI.app;
 			remoteRef = 4A13519720281768000F5FD5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FC524C5D0C900295EF7 /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = BC105FC424C5D0C900295EF7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FC724C5D0C900295EF7 /* OCMockTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = OCMockTests.xctest;
+			remoteRef = BC105FC624C5D0C900295EF7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FC924C5D0C900295EF7 /* libOCMock.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libOCMock.a;
+			remoteRef = BC105FC824C5D0C900295EF7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FCB24C5D0C900295EF7 /* OCMockLibTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = OCMockLibTests.xctest;
+			remoteRef = BC105FCA24C5D0C900295EF7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FCD24C5D0C900295EF7 /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = BC105FCC24C5D0C900295EF7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FCF24C5D0C900295EF7 /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = BC105FCE24C5D0C900295EF7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC105FD124C5D0C900295EF7 /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = BC105FD024C5D0C900295EF7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -8656,6 +8782,16 @@
 			platformFilter = ios;
 			target = 81C3821B19CCA89E0066284A /* Parse-iOS */;
 			targetProxy = 8111674B1B8402DF003CB026 /* PBXContainerItemProxy */;
+		};
+		BC105FD324C5D0D600295EF7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OCMock;
+			targetProxy = BC105FD224C5D0D600295EF7 /* PBXContainerItemProxy */;
+		};
+		BC105FD524C5D0E100295EF7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "OCMock iOS";
+			targetProxy = BC105FD424C5D0E100295EF7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Parse/Parse/Internal/ParseModule.h
+++ b/Parse/Parse/Internal/ParseModule.h
@@ -8,12 +8,13 @@
  */
 
 #import <Foundation/Foundation.h>
+@import Bolts;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ParseModule <NSObject>
 
-- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(nullable NSString *)clientKey;
+- (BFTask *)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(nullable NSString *)clientKey;
 
 @end
 

--- a/Parse/Parse/Internal/ParseModule.m
+++ b/Parse/Parse/Internal/ParseModule.m
@@ -75,12 +75,19 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 #pragma mark - ParseModule
 ///--------------------------------------
 
-- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(nullable NSString *)clientKey {
+- (BFTask *)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(nullable NSString *)clientKey {
+    
+    BFTaskCompletionSource *completion = [BFTaskCompletionSource new];
+    
     dispatch_async(dispatch_get_main_queue(), ^{
         [self enumerateModulesWithBlock:^(id<ParseModule> module, BOOL *stop, BOOL *remove) {
             [module parseDidInitializeWithApplicationId:applicationId clientKey:clientKey];
         }];
+        [completion setResult:nil];
     });
+    
+    return completion.task;
+    
 }
 
 ///--------------------------------------

--- a/Parse/Parse/Parse.h
+++ b/Parse/Parse/Parse.h
@@ -243,4 +243,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+///--------------------------------------
+#pragma mark - Notifications
+///--------------------------------------
+
+/**
+ For testing purposes. Allows testers to know when init is complete.
+ */
+extern NSString *const _Nonnull PFParseInitializeDidCompleteNotification;
+
 NS_ASSUME_NONNULL_END

--- a/Parse/Parse/Parse.m
+++ b/Parse/Parse/Parse.m
@@ -89,7 +89,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
     [[[currentParseManager_ preloadDiskObjectsToMemoryAsync] continueWithBlock:^id _Nullable(BFTask * _Nonnull t) {
         return [[self parseModulesCollection] parseDidInitializeWithApplicationId:configuration.applicationId
                                                                         clientKey:configuration.clientKey];
-    }] continueWithBlock:^id _Nullable(BFTask * _Nonnull t) {
+    }] continueWithSuccessBlock:^id _Nullable(BFTask * _Nonnull t) {
         [[NSNotificationCenter defaultCenter] postNotificationName:PFParseInitializeDidCompleteNotification
                                                             object:nil];
         return nil;

--- a/Parse/Parse/Parse.m
+++ b/Parse/Parse/Parse.m
@@ -33,6 +33,8 @@
 
 #import "PFCategoryLoader.h"
 
+NSString *const PFParseInitializeDidCompleteNotification = @"PFParseInitializeDidCompleteNotification";
+
 @implementation Parse
 
 static ParseManager *currentParseManager_;
@@ -84,9 +86,15 @@ static ParseClientConfiguration *currentParseConfiguration_;
     [PFNetworkActivityIndicatorManager sharedManager].enabled = YES;
 #endif
 
-    [currentParseManager_ preloadDiskObjectsToMemoryAsync];
-
-    [[self parseModulesCollection] parseDidInitializeWithApplicationId:configuration.applicationId clientKey:configuration.clientKey];
+    [[[currentParseManager_ preloadDiskObjectsToMemoryAsync] continueWithBlock:^id _Nullable(BFTask * _Nonnull t) {
+        return [[self parseModulesCollection] parseDidInitializeWithApplicationId:configuration.applicationId
+                                                                        clientKey:configuration.clientKey];
+    }] continueWithBlock:^id _Nullable(BFTask * _Nonnull t) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:PFParseInitializeDidCompleteNotification
+                                                            object:nil];
+        return nil;
+    }];
+    
 }
 
 + (void)setServer:(nonnull NSString *)server {

--- a/Parse/Tests/Other/TestCases/TestCase/PFTestCase.m
+++ b/Parse/Tests/Other/TestCases/TestCase/PFTestCase.m
@@ -88,10 +88,7 @@
 }
 
 - (void)tearDown {
-    dispatch_sync(_mockQueue, ^{
-        [self->_mocks makeObjectsPerformSelector:@selector(stopMocking)];
-    });
-
+    [_mocks removeAllObjects];
     _mocks = nil;
     _mockQueue = nil;
 

--- a/Parse/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.m
+++ b/Parse/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.m
@@ -31,12 +31,13 @@
     self.applicationId = [[NSUUID UUID] UUIDString];
     self.clientKey = [[NSUUID UUID] UUIDString];
 
+    XCTestExpectation *expect = [self expectationForNotification:PFParseInitializeDidCompleteNotification object:nil handler:^BOOL(NSNotification * _Nonnull notification) {
+        return YES;
+    }];
+    
     [Parse setApplicationId:self.applicationId clientKey:self.clientKey];
-
-    // NOTE: (richardross) This may seem crazy, but this is to solve an issue with OCMock's mocking, which isn't thread
-    // Safe. +[Parse setApplicationId: clientKey:] launches a background task that uses several class methods that are
-    // mocked throughout our unit tests, and this ensures that that task has completed before we continue.
-    [[Parse _currentManager] clearEventuallyQueue];
+    
+    [self waitForExpectations:@[expect] timeout:2];
 }
 
 - (void)tearDown {

--- a/Parse/Tests/Unit/FileControllerTests.m
+++ b/Parse/Tests/Unit/FileControllerTests.m
@@ -72,9 +72,8 @@
 }
 
 - (void)tearDown {
-    [super tearDown];
-
     [[PFFileManager removeItemAtPathAsync:[self temporaryDirectory]] waitUntilFinished];
+    [super tearDown];
 }
 
 ///--------------------------------------

--- a/Parse/Tests/Unit/ParseModuleUnitTests.m
+++ b/Parse/Tests/Unit/ParseModuleUnitTests.m
@@ -18,8 +18,9 @@
 
 @implementation ParseTestModule
 
-- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
+- (BFTask *)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
     self.didInitializeCalled = YES;
+    return [BFTask taskWithResult:nil];
 }
 
 @end

--- a/Parse/Tests/Unit/PinningObjectStoreTests.m
+++ b/Parse/Tests/Unit/PinningObjectStoreTests.m
@@ -14,6 +14,7 @@
 #import "PFPin.h"
 #import "PFPinningObjectStore.h"
 #import "PFUnitTestCase.h"
+#import "Parse.h"
 
 @interface PinningObjectStoreTests : PFUnitTestCase
 
@@ -38,8 +39,8 @@
 
 - (void)setUp
 {
+    [Parse enableLocalDatastore];
     [super setUp];
-    [PFPin registerSubclass];
 }
 
 - (void)testConstructors {

--- a/ParseTwitterUtils/Tests/Unit/OAuth1FlowDialogTests.m
+++ b/ParseTwitterUtils/Tests/Unit/OAuth1FlowDialogTests.m
@@ -73,6 +73,35 @@
     [flowDialog dismissAnimated:NO];
 }
 
+/** This test is broken by iOS 13. The UIDevice -setOrientation:animated is no longer available and there doesn't seem to be a new equivalent. Leaving this here so we know it was once a thing.
+ 
+    If we find the need to test this again, a different approach such as a UI test should be used.*/
+- (void)skip_testRotation {
+    [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationPortrait];
+//    [[UIDevice currentDevice] setOrientation:UIDeviceOrientationPortrait animated:NO];
+
+    PFOAuth1FlowDialog *flowDialog = [[PFOAuth1FlowDialog alloc] initWithURL:nil queryParameters:nil];
+
+    [flowDialog showAnimated:NO];
+    CGRect oldBounds = flowDialog.bounds;
+
+    [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationLandscapeLeft];
+//    [[UIDevice currentDevice] setOrientation:UIDeviceOrientationLandscapeLeft animated:NO];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIDeviceOrientationDidChangeNotification object:nil];
+
+    CGRect newBounds = flowDialog.bounds;
+    XCTAssertFalse(CGRectEqualToRect(oldBounds, newBounds));
+
+    [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationPortrait];
+//    [[UIDevice currentDevice] setOrientation:UIDeviceOrientationPortrait animated:NO];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIDeviceOrientationDidChangeNotification object:nil];
+
+    newBounds = flowDialog.bounds;
+    XCTAssertTrue(CGRectEqualToRect(oldBounds, newBounds));
+
+    [flowDialog dismissAnimated:NO];
+}
+
 - (void)testWebViewDelegate {
     NSURL *sampleURL = [NSURL URLWithString:@"http://foo.bar"];
     NSURL *successURL = [NSURL URLWithString:@"foo://success"];

--- a/ParseTwitterUtils/Tests/Unit/OAuth1FlowDialogTests.m
+++ b/ParseTwitterUtils/Tests/Unit/OAuth1FlowDialogTests.m
@@ -19,12 +19,6 @@
 @interface OAuth1FlowDialogTests : PFTwitterTestCase
 @end
 
-@interface UIDevice (Yolo)
-
-- (void)setOrientation:(UIDeviceOrientation)orientation animated:(BOOL)animated;
-
-@end
-
 @implementation OAuth1FlowDialogTests
 
 ///--------------------------------------
@@ -75,32 +69,6 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:UIKeyboardWillHideNotification
                                                         object:nil
                                                       userInfo:notificationuserInfo];
-
-    [flowDialog dismissAnimated:NO];
-}
-
-- (void)testRotation {
-    [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationPortrait];
-    [[UIDevice currentDevice] setOrientation:UIDeviceOrientationPortrait animated:NO];
-
-    PFOAuth1FlowDialog *flowDialog = [[PFOAuth1FlowDialog alloc] initWithURL:nil queryParameters:nil];
-
-    [flowDialog showAnimated:NO];
-    CGRect oldBounds = flowDialog.bounds;
-
-    [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationLandscapeLeft];
-    [[UIDevice currentDevice] setOrientation:UIDeviceOrientationLandscapeLeft animated:NO];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIDeviceOrientationDidChangeNotification object:nil];
-
-    CGRect newBounds = flowDialog.bounds;
-    XCTAssertFalse(CGRectEqualToRect(oldBounds, newBounds));
-
-    [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationPortrait];
-    [[UIDevice currentDevice] setOrientation:UIDeviceOrientationPortrait animated:NO];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIDeviceOrientationDidChangeNotification object:nil];
-
-    newBounds = flowDialog.bounds;
-    XCTAssertTrue(CGRectEqualToRect(oldBounds, newBounds));
 
     [flowDialog dismissAnimated:NO];
 }


### PR DESCRIPTION
I decided to give those janky tests another shot rather than disable them today. I've made some progress.

These first changes should fix the testFetchPin test. There's some asynchronous action in the synchronous initializeWithConfiguration: method that wasn't handled properly. These changes wrap the asynchronous calls in the method and send a notification when all the work is actually done. This allows us to wait for the notification in our tests before proceeding, fixing the crash in the test.

I preferred this to changing the method signature of our init method to avoid breaking existing installs.