### PR TITLE
Fix "Incompatible block pointer types" error

### DIFF
--- a/Parse/Parse/ParseClientConfiguration.m
+++ b/Parse/Parse/ParseClientConfiguration.m
@@ -126,18 +126,19 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 ///--------------------------------------
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    return [ParseClientConfiguration configurationWithBlock:^(ParseClientConfiguration *configuration) {
-        // Use direct assignment to skip over all of the assertions that may fail if we're not fully initialized yet.
-        configuration->_applicationId = [self->_applicationId copy];
-        configuration->_clientKey = [self->_clientKey copy];
-        configuration->_server = [self.server copy];
-        configuration->_fileUploadController = self->_fileUploadController;
-        configuration->_localDatastoreEnabled = self->_localDatastoreEnabled;
-        configuration->_applicationGroupIdentifier = [self->_applicationGroupIdentifier copy];
-        configuration->_containingApplicationBundleIdentifier = [self->_containingApplicationBundleIdentifier copy];
-        configuration->_networkRetryAttempts = self->_networkRetryAttempts;
-        configuration->_URLSessionConfiguration = self->_URLSessionConfiguration;
-    }];
+    ParseClientConfiguration *const configuration = [[ParseClientConfiguration alloc] initEmpty];
+    if (!configuration) return nil;
+    // Use direct assignment to skip over all of the assertions that may fail if we're not fully initialized yet.
+    configuration->_applicationId = [self->_applicationId copy];
+    configuration->_clientKey = [self->_clientKey copy];
+    configuration->_server = [self.server copy];
+    configuration->_fileUploadController = self->_fileUploadController;
+    configuration->_localDatastoreEnabled = self->_localDatastoreEnabled;
+    configuration->_applicationGroupIdentifier = [self->_applicationGroupIdentifier copy];
+    configuration->_containingApplicationBundleIdentifier = [self->_containingApplicationBundleIdentifier copy];
+    configuration->_networkRetryAttempts = self->_networkRetryAttempts;
+    configuration->_URLSessionConfiguration = self->_URLSessionConfiguration;
+    return configuration;
 }
 
 @end


### PR DESCRIPTION
This fixes #1526 .

I checked that `ParseClientConfigurationTests` (Scheme "Parse-masOS") passes for Xcode 11.6 and Xcode 12 beta 4.