### PR TITLE
Allow Parse SDK to be built for maccatalyst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,4 +85,3 @@ jobs:
           on:
             all_branches: true
             tags: true
-

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -9046,7 +9046,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -9065,7 +9065,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
This makes it possible to build Parse SDK for maccatalyst by "checking the box".