### PR TITLE
Xcode 12 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
     macos:
-      xcode: "11.6.0"
+      xcode: "12.0.1"
     shell: /bin/bash --login -eo pipefail
 aliases:
   - &cache-pull

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Vendor/xctoolchain"]
-	path = Vendor/xctoolchain
-	url = https://github.com/parse-community/xctoolchain.git
 [submodule "Carthage/Checkouts/Bolts-ObjC"]
 	path = Carthage/Checkouts/Bolts-ObjC
 	url = https://github.com/BoltsFramework/Bolts-ObjC.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "Vendor/xctoolchain"]
+	path = Vendor/xctoolchain
+	url = https://github.com/parse-community/xctoolchain.git
 [submodule "Carthage/Checkouts/Bolts-ObjC"]
 	path = Carthage/Checkouts/Bolts-ObjC
 	url = https://github.com/BoltsFramework/Bolts-ObjC.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 os: osx
-osx_image: xcode12.0.1
+osx_image: xcode12u
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 os: osx
-osx_image: xcode11.6
+osx_image: xcode12.0.1
 branches:
   only:
     - master

--- a/Rakefile
+++ b/Rakefile
@@ -79,137 +79,119 @@ module Constants
 end
 
 namespace :build do
-  desc 'Build iOS framework.'
+  desc 'Build iOS archive.'
   task :ios do
-    task = XCTask::BuildFrameworkTask.new do |t|
+    task = XCTask::CreateArchiveTask.new do |t|
       t.directory = script_folder
       t.build_directory = build_folder
       t.framework_type = XCTask::FrameworkType::IOS
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
       t.scheme = 'Parse-iOS'
-      t.configuration = 'Release'
+      t.destination = 'generic/platform=iOS'
     end
     result = task.execute
     unless result
-      puts 'Failed to build iOS Framework.'
+      puts 'Failed to build iOS archive.'
       exit(1)
     end
   end
 
-  desc 'Build watchOS framework.'
+  desc 'Build watchOS archive.'
   task :watchos do
-    task = XCTask::BuildFrameworkTask.new do |t|
+    task = XCTask::CreateArchiveTask.new do |t|
       t.directory = script_folder
       t.build_directory = build_folder
       t.framework_type = XCTask::FrameworkType::WATCHOS
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
       t.scheme = 'Parse-watchOS'
-      t.configuration = 'Release'
+      t.destination = 'generic/platform=watchOS'
     end
     result = task.execute
     unless result
-      puts 'Failed to build watchOS Framework.'
+      puts 'Failed to build watchOS archive.'
       exit(1)
     end
   end
 
-  desc 'Build macOS framework.'
+  desc 'Build macOS archive.'
   task :macos do
-    task = XCTask::BuildFrameworkTask.new do |t|
+    task = XCTask::CreateArchiveTask.new do |t|
       t.directory = script_folder
       t.build_directory = build_folder
       t.framework_type = XCTask::FrameworkType::OSX
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
       t.scheme = 'Parse-macOS'
-      t.configuration = 'Release'
+      t.destination = 'generic/platform=macOS'
     end
     result = task.execute
     unless result
-      puts 'Failed to build macOS Framework.'
+      puts 'Failed to build macOS archive.'
       exit(1)
     end
   end
 
-  desc 'Build tvOS framework.'
+  desc 'Build tvOS archive.'
   task :tvos do
-    task = XCTask::BuildFrameworkTask.new do |t|
+    task = XCTask::CreateArchiveTask.new do |t|
       t.directory = script_folder
       t.build_directory = build_folder
       t.framework_type = XCTask::FrameworkType::TVOS
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
       t.scheme = 'Parse-tvOS'
-      t.configuration = 'Release'
+      t.destination = 'generic/platform=tvOS'
     end
     result = task.execute
     unless result
-      puts 'Failed to build tvOS Framework.'
+      puts 'Failed to build tvOS archive.'
       exit(1)
     end
   end
 
   namespace :facebook_utils do
-    desc 'Build iOS FacebookUtils framework.'
+    desc 'Build iOS FacebookUtils archive.'
     task :ios do
-      task = XCTask::BuildFrameworkTask.new do |t|
+      task = XCTask::CreateArchiveTask.new do |t|
         t.directory = script_folder
         t.build_directory = File.join(build_folder, 'iOS')
         t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseFacebookUtilsV4.framework'
-        t.workspace = 'Parse.xcworkspace'
         t.scheme = 'ParseFacebookUtilsV4-iOS'
-        t.configuration = 'Release'
+        t.destination = 'generic/platform=iOS'
       end
 
       result = task.execute
       unless result
-        puts 'Failed to build iOS FacebookUtils Framework.'
+        puts 'Failed to build iOS FacebookUtils archive.'
         exit(1)
       end
     end
 
-    desc 'Build tvOS FacebookUtils framework.'
+    desc 'Build tvOS FacebookUtils archive.'
     task :tvos do
-      task = XCTask::BuildFrameworkTask.new do |t|
+      task = XCTask::CreateArchiveTask.new do |t|
         t.directory = script_folder
         t.build_directory = File.join(build_folder, 'tvOS')
         t.framework_type = XCTask::FrameworkType::TVOS
-        t.framework_name = 'ParseFacebookUtilsV4.framework'
-        t.workspace = 'Parse.xcworkspace'
         t.scheme = 'ParseFacebookUtilsV4-tvOS'
-        t.configuration = 'Release'
+        t.destination = 'generic/platform=tvOS'
       end
       result = task.execute
       unless result
-        puts 'Failed to build tvOS FacebookUtils Framework.'
+        puts 'Failed to build tvOS FacebookUtils archive.'
         exit(1)
       end
     end
   end
 
   namespace :twitter_utils do
-    desc 'Build iOS TwitterUtils framework.'
+    desc 'Build iOS TwitterUtils archive.'
     task :ios do
-      task = XCTask::BuildFrameworkTask.new do |t|
+      task = XCTask::CreateArchiveTask.new do |t|
         t.directory = script_folder
         t.build_directory = File.join(build_folder, 'iOS')
         t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseTwitterUtils.framework'
-        t.workspace = 'Parse.xcworkspace'
         t.scheme = 'ParseTwitterUtils-iOS'
-        t.configuration = 'Release'
+        t.destination = 'generic/platform=iOS'
       end
 
       result = task.execute
       unless result
-        puts 'Failed to build iOS TwitterUtils Framework.'
+        puts 'Failed to build iOS TwitterUtils archive.'
         exit(1)
       end
     end
@@ -217,14 +199,12 @@ namespace :build do
 
   namespace :parseui do
     task :framework do
-      task = XCTask::BuildFrameworkTask.new do |t|
+      task = XCTask::CreateArchiveTask.new do |t|
         t.directory = script_folder
         t.build_directory = File.join(build_folder, 'iOS')
         t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseUI.framework'
-        t.workspace = 'Parse.xcworkspace'
         t.scheme = 'ParseUI'
-        t.configuration = 'Release'
+        t.destination = 'generic/platform=iOS'
       end
 
       result = task.execute
@@ -283,20 +263,20 @@ namespace :build do
 end
 
 namespace :package do
-  package_ios_name = 'Parse-iOS.zip'
-  package_macos_name = 'Parse-macOS.zip'
-  package_tvos_name = 'Parse-tvOS.zip'
-  package_watchos_name = 'Parse-watchOS.zip'
+  package_ios_name = 'Parse-iOS.xcarchive'
+  package_macos_name = 'Parse-macOS.xcarchive'
+  package_tvos_name = 'Parse-tvOS.xcarchive'
+  package_watchos_name = 'Parse-watchOS.xcarchive'
   package_starter_ios_name = 'ParseStarterProject-iOS.zip'
   package_starter_osx_name = 'ParseStarterProject-OSX.zip'
   package_starter_tvos_name = 'ParseStarterProject-tvOS.zip'
   package_starter_watchos_name = 'ParseStarterProject-watchOS.zip'
-  package_parseui_name = 'ParseUI.zip'
+  package_parseui_name = 'ParseUI.xcarchive'
 
   task :prepare do
-    `rm -rf #{build_folder} && mkdir -p #{build_folder}`
-    `rm -rf #{bolts_build_folder} && mkdir -p #{bolts_build_folder}`
-    `#{bolts_folder}/scripts/build_framework.sh -n -c Release --with-watchos --with-tvos`
+    # `rm -rf #{build_folder} && mkdir -p #{build_folder}`
+    # `rm -rf #{bolts_build_folder} && mkdir -p #{bolts_build_folder}`
+    # `#{bolts_folder}/scripts/build_framework.sh -n -c Release --with-watchos --with-tvos`
   end
 
   task :set_version, [:version] do |_, args|
@@ -315,55 +295,17 @@ namespace :package do
     version = args[:version] || Constants.current_version
     Constants.update_version(version)
 
-    ## Build macOS Framework
+    ## Build XCFramework
     Rake::Task['build:macos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'osx', 'Bolts.framework')
-    osx_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [osx_framework_path, bolts_path],
-                 package_macos_name)
-
-    ## Build iOS Framework
     Rake::Task['build:ios'].invoke
-    bolts_path = File.join(bolts_build_folder, 'ios', 'Bolts.framework')
-    ios_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [ios_framework_path, bolts_path],
-                 package_ios_name)
-
-    ## Build tvOS Framework
     Rake::Task['build:tvos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'tvOS', 'Bolts.framework')
-    tvos_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                  [tvos_framework_path, bolts_path],
-                  package_tvos_name)
-
-    ## Build watchOS Framework
     Rake::Task['build:watchos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'watchOS', 'Bolts.framework')
-    watchos_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [watchos_framework_path, bolts_path],
-                 package_watchos_name)
-
     Rake::Task['build:facebook_utils:ios'].invoke
-    ios_fb_utils_framework_path = File.join(build_folder, 'iOS', 'ParseFacebookUtilsV4.framework')
-    make_package(release_folder, [ios_fb_utils_framework_path], 'ParseFacebookUtils-iOS.zip')
-
     Rake::Task['build:twitter_utils:ios'].invoke
-    ios_tw_utils_framework_path = File.join(build_folder, 'iOS', 'ParseTwitterUtils.framework')
-    make_package(release_folder, [ios_tw_utils_framework_path], 'ParseTwitterUtils-iOS.zip')
-
     Rake::Task['build:facebook_utils:tvos'].invoke
-    tvos_fb_utils_framework_path = File.join(build_folder, 'tvOS', 'ParseFacebookUtilsV4.framework')
-    make_package(release_folder, [tvos_fb_utils_framework_path], 'ParseFacebookUtils-tvOS.zip')
-
     Rake::Task['build:parseui:framework'].invoke
-    parseui_framework_path = File.join(build_folder, 'iOS', 'ParseUI.framework')
-    make_package(release_folder,
-                [parseui_framework_path],
-                package_parseui_name)
+    allArchives = Dir[build_folder + "**/*.xcarchive"]
+    puts(allArchives)
   end
 
   desc 'Build and package all starter projects for the release'
@@ -430,7 +372,7 @@ namespace :package do
   def make_starter_package(target_path, starter_projects, framework_archive, archive_name)
     starter_projects.each do |project_path|
       `git clean -xfd #{project_path}`
-      `cd #{project_path} && unzip -o #{framework_archive}`
+      `cd #{project_path} && cp . #{framework_archive}/Products/@rpath/Parse.framework`
 
       xcodeproj_path = Dir.glob(File.join(project_path, '*.xcodeproj'))[0]
       prepare_xcodeproj(xcodeproj_path)

--- a/Vendor/xctoolchain/.clang-format
+++ b/Vendor/xctoolchain/.clang-format
@@ -1,0 +1,71 @@
+# Copyright (c) 2015-present, Parse, LLC.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+---
+Language:        Cpp
+BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakTemplateDeclarations: false
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+BinPackArguments: true
+ColumnLimit:     0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+DerivePointerAlignment: true
+ExperimentalAutoDetectBinPacking: true
+IndentCaseLabels: true
+IndentWrappedFunctionNames: true
+IndentFunctionDeclarationAfterType: true
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: true
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 140
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 120
+PointerAlignment: Right
+SpacesBeforeTrailingComments: 1
+Cpp11BracedListStyle: true
+Standard:        Cpp11
+IndentWidth:     4
+TabWidth:        4
+UseTab:          Never
+BreakBeforeBraces: Attach
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpacesInContainerLiterals: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+CommentPragmas:  '^ IWYU pragma:'
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+SpaceBeforeParens: ControlStatements
+DisableFormat:   false
+...

--- a/Vendor/xctoolchain/Configurations/Common.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Common.xcconfig
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+#include "Warnings.xcconfig"
+
+// Disable legacy-compatible header searching
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Architectures to build
+ARCHS = $(ARCHS_STANDARD)
+
+// Whether to enable module imports
+CLANG_ENABLE_MODULES = YES
+CLANG_ENABLE_MODULE_DEBUGGING = NO
+
+// Build Options
+CLANG_ENABLE_OBJC_ARC = YES
+GCC_VERSION = com.apple.compilers.llvm.clang.1_0
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// The format of debugging symbols
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+
+// C Language
+GCC_C_LANGUAGE_STANDARD = gnu11
+
+// C++ Language
+CLANG_CXX_LANGUAGE_STANDARD = gnu++14
+CLANG_CXX_LIBRARY = libc++
+
+// Code Generation
+GCC_DYNAMIC_NO_PIC = NO
+GCC_INLINES_ARE_PRIVATE_EXTERN = YES
+GCC_NO_COMMON_BLOCKS = YES
+GCC_SYMBOLS_PRIVATE_EXTERN = NO
+
+// Static Analyzer - Analysis Policy
+RUN_CLANG_STATIC_ANALYZER = YES
+CLANG_STATIC_ANALYZER_MODE_ON_ANALYZE_ACTION = deep
+CLANG_STATIC_ANALYZER_MODE = shallow

--- a/Vendor/xctoolchain/Configurations/Platform/iOS.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Platform/iOS.xcconfig
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+SDKROOT = iphoneos
+IPHONEOS_DEPLOYMENT_TARGET = 8.0
+
+// Supported device families (1 is iPhone, 2 is iPad, 3 is Apple TV)
+TARGETED_DEVICE_FAMILY = 1,2
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks

--- a/Vendor/xctoolchain/Configurations/Platform/macOS.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Platform/macOS.xcconfig
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+SDKROOT = macosx
+MACOSX_DEPLOYMENT_TARGET = 10.9
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks

--- a/Vendor/xctoolchain/Configurations/Platform/tvOS.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Platform/tvOS.xcconfig
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+SDKROOT = appletvos
+TVOS_DEPLOYMENT_TARGET = 9.0
+
+// Supported device families (1 is iPhone, 2 is iPad, 3 is Apple TV)
+TARGETED_DEVICE_FAMILY = 3
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks

--- a/Vendor/xctoolchain/Configurations/Platform/watchOS.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Platform/watchOS.xcconfig
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+SDKROOT = watchos
+WATCHOS_DEPLOYMENT_TARGET = 2.0
+
+// Supported device families (1 is iPhone, 2 is iPad, 3 is Apple TV, 4 is watch)
+TARGETED_DEVICE_FAMILY = 4
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks

--- a/Vendor/xctoolchain/Configurations/Product/Application.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Product/Application.xcconfig
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
+ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage
+
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @executable_path/Frameworks

--- a/Vendor/xctoolchain/Configurations/Product/DynamicFramework.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Product/DynamicFramework.xcconfig
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+// Dynamic frameworks are backed by dynamic library.
+MACH_O_TYPE = mh_dylib
+
+// Whether this framework should define an LLVM module
+DEFINES_MODULE = YES
+
+// Disable clang modules autolink
+CLANG_MODULES_AUTOLINK = NO
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether function calls should be position-dependent (should always be disabled for shared code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Don't include in an xcarchive
+SKIP_INSTALL = YES
+
+// Don't install in any specific location
+INSTALL_PATH =
+
+// Do not require code signing
+CODE_SIGNING_REQUIRED = NO
+
+// Disable code signing
+CODE_SIGN_IDENTITY =
+
+// Enables the framework to be included from any location as long as the loader’s runpath search paths includes it.
+// For example from an application bundle (inside the "Frameworks" folder) or shared folder.
+LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
+DYLIB_INSTALL_NAME_BASE = @rpath

--- a/Vendor/xctoolchain/Configurations/Product/LogicTests.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Product/LogicTests.xcconfig
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+BUNDLE_LOADER = $(TEST_HOST)
+
+OTHER_LDFLAGS = $(inherited) -ObjC -framework XCTest

--- a/Vendor/xctoolchain/Configurations/Product/StaticFramework.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Product/StaticFramework.xcconfig
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+// Static frameworks are backed by static libraries
+MACH_O_TYPE = staticlib
+
+// Whether this framework should define an LLVM module
+DEFINES_MODULE = YES
+
+// Disable clang modules autolink
+CLANG_MODULES_AUTOLINK = NO
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether function calls should be position-dependent (should always be disabled for shared code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Enables the framework to be included from any location as long as the loader’s runpath search paths includes it.
+// For example from an application bundle (inside the "Frameworks" folder) or shared folder
+INSTALL_PATH = @rpath
+
+// Don't include in an xcarchive
+SKIP_INSTALL = YES
+
+// Do not require code signing
+CODE_SIGNING_REQUIRED = NO
+
+// Disable code signing
+CODE_SIGN_IDENTITY = 

--- a/Vendor/xctoolchain/Configurations/Project/Debug.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Project/Debug.xcconfig
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+#include "../Common.xcconfig"
+
+// Architectures
+ONLY_ACTIVE_ARCH = YES
+
+// Optimization
+GCC_OPTIMIZATION_LEVEL = 0
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+
+// Preprocessor
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
+ENABLE_NS_ASSERTIONS = YES
+
+// Testability
+ENABLE_TESTABILITY = YES
+
+// Deployment 
+COPY_PHASE_STRIP = NO
+
+SANITIZE_FLAGS = -fsanitize-undefined-trap-on-error -fsanitize=undefined-trap
+OTHER_CFLAGS = $(value) $(SANITIZE_FLAGS)
+OTHER_LDFLAGS = $(value) $(SANITIZE_FLAGS)

--- a/Vendor/xctoolchain/Configurations/Project/Release.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Project/Release.xcconfig
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+#include "../Common.xcconfig"
+
+// Architectures
+ONLY_ACTIVE_ARCH = NO
+
+// Build
+VALIDATE_PRODUCT = YES
+
+// Optimization
+GCC_OPTIMIZATION_LEVEL = s
+SWIFT_OPTIMIZATION_LEVEL = -Owholemodule
+
+// Preprocessor
+ENABLE_NS_ASSERTIONS = NO
+
+// Deployment
+DEPLOYMENT_POSTPROCESSING = YES
+COPY_PHASE_STRIP = YES
+STRIP_STYLE = debugging
+STRIP_INSTALLED_PRODUCT = YES
+CLANG_ENABLE_CODE_COVERAGE = YES
+

--- a/Vendor/xctoolchain/Configurations/Warnings.xcconfig
+++ b/Vendor/xctoolchain/Configurations/Warnings.xcconfig
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// Portions Copyright (c) 2017-present, Nikita Lutsenko
+//
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found
+// in the LICENSE file in the root directory of this source tree.
+//
+
+ENABLE_STRICT_OBJC_MSGSEND = YES
+
+GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = YES
+GCC_WARN_ABOUT_MISSING_NEWLINE = YES
+GCC_WARN_ABOUT_POINTER_SIGNEDNESS = YES
+GCC_WARN_CHECK_SWITCH_STATEMENTS = YES
+GCC_WARN_MISSING_PARENTHESES = YES
+GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES
+GCC_WARN_UNKNOWN_PRAGMAS = YES
+GCC_WARN_UNUSED_FUNCTION = YES
+GCC_WARN_UNUSED_LABEL = YES
+GCC_WARN_UNUSED_VALUE = YES
+GCC_WARN_UNUSED_VARIABLE = YES
+GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
+GCC_WARN_UNDECLARED_SELECTOR = YES
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES
+GCC_WARN_UNINITIALIZED_AUTOS = YES
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+GCC_WARN_SHADOW = YES
+
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES
+CLANG_WARN__ARC_BRIDGE_CAST_NONARC = YES
+CLANG_WARN_BOOL_CONVERSION = YES
+CLANG_WARN_CONSTANT_CONVERSION = YES
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES
+CLANG_WARN_EMPTY_BODY = YES
+CLANG_WARN_ENUM_CONVERSION = YES
+CLANG_WARN_UNREACHABLE_CODE = YES
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES
+CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
+CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES
+CLANG_WARN_BOOL_CONVERSION = YES
+CLANG_WARN_INFINITE_RECURSION = YES
+CLANG_WARN_SUSPICIOUS_MOVE = YES
+CLANG_WARN_STRICT_PROTOTYPES = YES
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES
+CLANG_WARN_COMMA = YES
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES
+
+// Errors
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+// Static Analyzer Warnings
+CLANG_ANALYZER_NONNULL = YES
+CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
+
+//
+// Extra warnings, not available directly in build settings.
+// 'auto-import' - warns when an old-style hashed import could be replaced with modular import aka @import.
+// 'switch-enum' - enforces explicit handling of cases in switch statements.
+// 'method-signatures' - enforces method signatures to always match.
+// 'idiomatic-parentheses' - do not allow usage of an assignment as a condition without extra paranthesis.
+// 'covered-switch-default' - warns when implementing 'default' case in switch statement that covers all options.
+// 'custom-atomic-properties' - safeguards atomic properties with custom implementations.
+// 'cstring-format-directive' - do not allow NSString * to be used as c-string formatting argument aka '%s'.
+// 'conditional-uninitialized' - warn about potential use of of uninitialized variables.
+// 'unused-exception-parameter' - @try @catch without usage of exception parameter.
+// 'missing-variable-declarations' - will mark all variables that are missing declarations, including non-static extern constants.
+//
+WARNING_CFLAGS = $(inherited) -Wswitch-enum -Wmethod-signatures -Widiomatic-parentheses -Wcustom-atomic-properties -Wconditional-uninitialized -Wunused-exception-parameter -Wmissing-variable-declarations

--- a/Vendor/xctoolchain/README.md
+++ b/Vendor/xctoolchain/README.md
@@ -1,0 +1,2 @@
+# xctoolchain
+Common configuration files and scripts that are used to build our SDKs with Xcode.

--- a/Vendor/xctoolchain/Scripts/xctask/build_framework_task.rb
+++ b/Vendor/xctoolchain/Scripts/xctask/build_framework_task.rb
@@ -1,0 +1,198 @@
+#!/usr/bin/env ruby
+#
+# Copyright (c) 2015-present, Parse, LLC.
+# Portions Copyright (c) 2017-present, Nikita Lutsenko
+#
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found
+# in the LICENSE file in the root directory of this source tree.
+#
+
+require 'naturally'
+require_relative 'build_task'
+
+module XCTask
+  # This class defines all possible framework types for BuildFrameworkTask.
+  class FrameworkType
+    IOS = 'ios'
+    OSX = 'osx'
+    WATCHOS = 'watchos'
+    TVOS = 'tvos'
+
+    def self.verify(type)
+      if type.nil? || (type != IOS && type != OSX && type != WATCHOS && type != TVOS)
+        fail "Unknown framework type. Available types: 'ios', 'osx', 'watchos', 'tvos'."
+      end
+    end
+  end
+
+  # This class adds ability to easily configure a building of iOS/OSX framework and execute the build process.
+  class BuildFrameworkTask
+    attr_accessor :directory
+    attr_accessor :build_directory
+    attr_accessor :framework_type
+    attr_accessor :framework_name
+
+    attr_accessor :workspace
+    attr_accessor :project
+    attr_accessor :scheme
+    attr_accessor :configuration
+
+    def initialize
+      @directory = '.'
+      @build_directory = './build'
+      yield self if block_given?
+    end
+
+    def execute
+      verify
+      prepare_build
+      build
+    end
+
+    private
+
+    def verify
+      FrameworkType.verify(@framework_type)
+    end
+
+    def prepare_build
+      Dir.chdir(@directory) unless @directory.nil?
+    end
+
+    def build
+      case @framework_type
+      when FrameworkType::IOS
+        build_ios_framework
+      when FrameworkType::OSX
+        build_osx_framework
+      when FrameworkType::WATCHOS
+        build_watchos_framework
+      when FrameworkType::TVOS
+        build_tvos_framework
+      end
+    end
+
+    def build_ios_framework
+      framework_paths = []
+      framework_paths << build_framework('iphoneos')
+      framework_paths << build_framework('iphonesimulator', 'platform="iOS Simulator",name="iPhone 11"')
+      final_path = final_framework_path
+
+      system("rm -rf #{final_path} && cp -R #{framework_paths[0]} #{final_path}")
+
+      binary_name = File.basename(@framework_name, '.framework')
+      system("rm -rf #{final_path}/#{binary_name}")
+
+      lipo_command = 'lipo -create'
+      framework_paths.each do |path|
+        lipo_command += " #{path}/#{binary_name}"
+      end
+      lipo_command += " -o #{final_path}/#{binary_name}"
+
+      result = system(lipo_command)
+      unless result
+        puts 'Failed to lipo iOS framework.'
+        exit(1)
+      end
+      result
+    end
+
+    def build_watchos_framework
+      framework_paths = []
+      framework_paths << build_framework('watchos')
+      framework_paths << build_framework('watchsimulator', 'platform="watchOS Simulator",name="Apple Watch Series 5 - 44mm"')
+      final_path = final_framework_path
+
+      system("rm -rf #{final_path} && cp -R #{framework_paths[0]} #{final_path}")
+
+      binary_name = File.basename(@framework_name, '.framework')
+      system("rm -rf #{final_path}/#{binary_name}")
+
+      lipo_command = 'lipo -create'
+      framework_paths.each do |path|
+        lipo_command += " #{path}/#{binary_name}"
+      end
+      lipo_command += " -o #{final_path}/#{binary_name}"
+
+      result = system(lipo_command)
+      unless result
+        puts 'Failed to lipo watchOS framework.'
+        exit(1)
+      end
+      result
+    end
+
+    def build_tvos_framework
+      framework_paths = []
+      framework_paths << build_framework('appletvos')
+      framework_paths << build_framework('appletvsimulator', 'platform="tvOS Simulator",name="Apple TV 4K"')
+      final_path = final_framework_path
+
+      system("rm -rf #{final_path} && cp -R #{framework_paths[0]} #{final_path}")
+
+      binary_name = File.basename(@framework_name, '.framework')
+      system("rm -rf #{final_path}/#{binary_name}")
+
+      lipo_command = 'lipo -create'
+      framework_paths.each do |path|
+        lipo_command += " #{path}/#{binary_name}"
+      end
+      lipo_command += " -o #{final_path}/#{binary_name}"
+
+      result = system(lipo_command)
+      unless result
+        puts 'Failed to lipo tvOS framework.'
+        exit(1)
+      end
+      result
+    end
+
+    def build_osx_framework
+      build_path = build_framework('macosx')
+      final_path = final_framework_path
+      system("rm -rf #{final_path} && cp -R #{build_path} #{final_path}")
+    end
+
+    def build_framework(sdk, destination = nil)
+      configuration_directory = configuration_build_directory(sdk)
+      build_task = BuildTask.new do |t|
+        t.directory = @directory
+        t.project = @project
+        t.workspace = @workspace
+
+        t.scheme = @scheme
+        t.sdk = latest_sdk(sdk)
+        t.configuration = @configuration
+        t.destinations = [destination] unless destination.nil?
+
+        t.actions = [BuildAction::CLEAN, BuildAction::BUILD]
+        t.formatter = BuildFormatter::XCPRETTY
+
+        t.additional_options = { 'CONFIGURATION_BUILD_DIR' => "'#{configuration_directory}'" }
+      end
+
+      result = build_task.execute
+      unless result
+        puts "Failed to build framework for #{sdk}."
+        exit(1)
+      end
+
+      "#{configuration_directory}/#{@framework_name}"
+    end
+
+    def latest_sdk(platform)
+      sdks = Naturally.sort(`xcodebuild -showsdks`.scan(/-sdk (.*)$/)).reverse.flatten
+      sdks.select { |s| s =~ /#{platform}/ }[0]
+    end
+
+    def configuration_build_directory(sdk)
+      "#{@build_directory}/#{@configuration}-#{@framework_type}-#{sdk}"
+    end
+
+    def final_framework_path
+      "#{@build_directory}/#{@framework_name}"
+    end
+  end
+end

--- a/Vendor/xctoolchain/Scripts/xctask/build_framework_task.rb
+++ b/Vendor/xctoolchain/Scripts/xctask/build_framework_task.rb
@@ -27,6 +27,39 @@ module XCTask
     end
   end
 
+  class CreateArchiveTask
+    attr_accessor :directory
+    attr_accessor :build_directory
+    attr_accessor :scheme
+    attr_accessor :destination
+    
+    attr_accessor :framework_type
+
+
+
+    def initialize
+      @directory = '.'
+      @build_directory = './build'
+      yield self if block_given?
+    end
+
+    def execute
+      Dir.chdir(@directory) unless @directory.nil?
+      system("xcodebuild archive -scheme #{@scheme} -destination #{@destination} -archivePath #{final_archive_path} SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES")
+    end
+
+    private
+
+    def verify
+      FrameworkType.verify(@framework_type)
+    end
+
+    def final_archive_path
+      "#{@build_directory}/#{@scheme}"
+    end
+
+  end
+
   # This class adds ability to easily configure a building of iOS/OSX framework and execute the build process.
   class BuildFrameworkTask
     attr_accessor :directory

--- a/Vendor/xctoolchain/Scripts/xctask/build_task.rb
+++ b/Vendor/xctoolchain/Scripts/xctask/build_task.rb
@@ -1,0 +1,135 @@
+#!/usr/bin/env ruby
+#
+# Copyright (c) 2015-present, Parse, LLC.
+# Portions Copyright (c) 2017-present, Nikita Lutsenko
+#
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found
+# in the LICENSE file in the root directory of this source tree.
+#
+
+module XCTask
+  # This class defines all possible build formatters for BuildTask.
+  class BuildFormatter
+    XCODEBUILD = 'xcodebuild'
+    XCPRETTY = 'xcpretty'
+    XCTOOL = 'xctool'
+
+    def self.verify(formatter)
+      if formatter &&
+         formatter != XCPRETTY &&
+         formatter != XCODEBUILD &&
+         formatter != XCTOOL
+        fail "Unknown formatter used. Available formatters: 'xcodebuild', 'xcpretty', 'xctool'."
+      end
+    end
+  end
+
+  # This class defines all possible build actions for BuildTask.
+  class BuildAction
+    BUILD = 'build'
+    CLEAN = 'clean'
+    TEST = 'test'
+    ANALYZE = 'analyze'
+
+    def self.verify(action)
+      if action.nil? ||
+         (action != BUILD &&
+         action != CLEAN &&
+         action != TEST &&
+         action != ANALYZE)
+        fail "Unknown build action used. Available actions: 'build', 'clean', 'test', 'analyze'."
+      end
+    end
+  end
+
+  # This class adds ability to easily configure a xcodebuild task and execute it.
+  class BuildTask
+    attr_accessor :directory
+    attr_accessor :workspace
+    attr_accessor :project
+
+    attr_accessor :scheme
+    attr_accessor :sdk
+    attr_accessor :configuration
+    attr_accessor :destinations
+
+    attr_accessor :additional_options
+    attr_accessor :actions
+    attr_accessor :formatter
+
+    attr_accessor :reports_enabled
+
+    def initialize
+      @directory = '.'
+      @destinations = []
+      @additional_options = {}
+
+      yield self if block_given?
+    end
+
+    def execute
+      verify
+      prepare_build
+      build
+    end
+
+    private
+
+    def verify
+      BuildFormatter.verify(@formatter)
+      @actions.each do |action|
+        BuildAction.verify(action)
+      end
+    end
+
+    def prepare_build
+      Dir.chdir(@directory) unless @directory.nil?
+    end
+
+    def build
+      system(build_command_string(@formatter))
+    end
+
+    def build_command_string(formatter)
+      command_string = nil
+
+      case formatter
+      when BuildFormatter::XCODEBUILD
+        command_string = 'xcodebuild ' + build_options_string
+      when BuildFormatter::XCPRETTY
+        command_string = build_command_string('xcodebuild') + ' | xcpretty -c'
+        if @actions.include? BuildAction::TEST
+          command_string += " --report junit --output build/reports/#{@sdk}.xml"
+        end
+        command_string += ' ; exit ${PIPESTATUS[0]}'
+      when BuildFormatter::XCTOOL
+        command_string = 'xctool ' + build_options_string
+      else
+        command_string = build_command_string(BuildFormatter::XCODEBUILD)
+      end
+
+      command_string
+    end
+
+    def build_options_string
+      opts = []
+      opts << "-workspace #{@workspace}" if @workspace
+      opts << "-project #{@project}" if @project
+      opts << "-scheme #{@scheme}" if @scheme
+      opts << "-sdk #{@sdk}" if @sdk
+      opts << "-configuration #{@configuration}" if @configuration
+      @destinations.each do |d|
+        opts << "-destination #{d}"
+      end
+      opts << @actions.compact.join(' ') if @actions
+
+      @additional_options.each do |key, value|
+        opts << "#{key}=#{value}"
+      end
+
+      opts.compact.join(' ')
+    end
+  end
+end


### PR DESCRIPTION
We need to get the build process running with Xcode 12.

There are issues with the lipo command in the build process; we include arm64 arch in both our simulator and our release builds, and then include them in the output. This is a new issue in Xcode 12, since the simulator used to only build for x86 (Apple Silicon cometh). Some approaches to working around this are outlined [here](https://stackoverflow.com/questions/64022291/ios-14-lipo-error-while-creating-library-for-both-device-and-simulator).

It also looks like some tests are broken.

Whatever else needs fixing to migrate to Xcode 12, we can put here.

Close #1591 