### PR TITLE
isDataAvailableForKey should be public to easier to check data available

### DIFF
--- a/Parse/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -16,7 +16,7 @@
 
 @interface PFCloudCodeController : NSObject
 
-@property (nonatomic, strong, readonly) id<PFCommandRunnerProvider> dataSource;
+@property (nonatomic, strong, readonly) id<PFCommandRunnerProvider, PFKeyValueCacheProvider> dataSource;
 
 ///--------------------------------------
 #pragma mark - Init
@@ -38,12 +38,26 @@
 
  @param functionName Function name to call.
  @param parameters   Parameters to pass. (can't be nil).
+ @param cachePolicy  Cache Policy
+ @param maxCacheAge  Max cache age
  @param sessionToken Session token to use.
 
  @return `BFTask` with a result set to a result of Cloud Function.
  */
 - (BFTask *)callCloudCodeFunctionAsync:(NSString *)functionName
                         withParameters:(NSDictionary *)parameters
+                           cachePolicy:(PFCachePolicy)cachePolicy
+                           maxCacheAge:(NSTimeInterval)maxCacheAge
                           sessionToken:(NSString *)sessionToken;
+
+///--------------------------------------
+#pragma mark - Caching
+///--------------------------------------
+
+- (nullable NSString *)cacheKeyForFunction:(nonnull NSString *)functionName parameters:(nullable NSDictionary *)parameters sessionToken:(nullable NSString *)sessionToken;
+- (BOOL)hasCachedResultForFunction:(nonnull NSString *)functionName parameters:(nullable NSDictionary *)parameters sessionToken:(nullable NSString *)sessionToken;
+
+- (void)clearCachedResultForFunction:(nonnull NSString *)functionName parameters:(nullable NSDictionary *)parameters sessionToken:(nullable NSString *)sessionToken;
+- (void)clearAllCachedResults;
 
 @end

--- a/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
+++ b/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
@@ -24,7 +24,7 @@
 #pragma mark - Init
 ///--------------------------------------s
 
-- (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
+- (instancetype)initWithDataSource:(id<PFCommandRunnerProvider, PFKeyValueCacheProvider>)dataSource {
     self = [super init];
     if (!self) return nil;
 
@@ -33,7 +33,7 @@
     return self;
 }
 
-+ (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
++ (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider, PFKeyValueCacheProvider>)dataSource {
     return [[self alloc] initWithDataSource:dataSource];
 }
 
@@ -43,7 +43,76 @@
 
 - (BFTask *)callCloudCodeFunctionAsync:(NSString *)functionName
                         withParameters:(NSDictionary *)parameters
-                          sessionToken:(NSString *)sessionToken {
+                           cachePolicy:(PFCachePolicty)cachePolicy
+                           maxCacheAge:(NSTimeInterval)maxCacheAge
+                          sessionToken:(NSString *)sessionToken{
+   
+    NSString *cacheKey = [self cacheKeyForFunction:functionName parameters:parameters sessionToken:sessionToken];
+    
+    switch (cachePolicy) {
+        case kPFCachePolicyIgnoreCache:
+        {
+            return [self callCloudCodeFunctionAsync:functionName withParameters:parameters sessionToken:sessionToken];
+        }
+            break;
+        case kPFCachePolicyNetworkOnly:
+        {
+            return [[self callCloudCodeFunctionAsync:functionName withParameters:parameters sessionToken:sessionToken] continueWithSuccessBlock:^id(BFTask *task) {
+                return [self _saveCommandResultAsync:task.result forCommandCacheKey:cacheKey];
+            }];
+        }
+            break;
+        case kPFCachePolicyCacheOnly: {
+            return [self taskWithCacheKey: cacheKey];
+        }
+            break;
+        case kPFCachePolicyNetworkElseCache: {
+            // Don't retry for network-else-cache, because it just slows things down.
+            BFTask *networkTask = [self callCloudCodeFunctionAsync:functionName withParameters:parameters sessionToken:sessionToken];
+            @weakify(self);
+            return [networkTask continueWithBlock:^id(BFTask *task) {
+                @strongify(self);
+                if (task.cancelled) {
+                    return task;
+                } else if (task.faulted) {
+                    return [self taskWithCacheKey: cacheKey];
+                }
+                return [self _saveCommandResultAsync:task.result forCommandCacheKey:cacheKey];
+            }];
+        }
+            break;
+        case kPFCachePolicyCacheElseNetwork:
+        {
+            BFTask *cacheTask = [self taskWithCacheKey: cacheKey];
+            @weakify(self);
+            return [cacheTask continueWithBlock:^id(BFTask *task) {
+                @strongify(self);
+                if (task.error) {
+                    return [self callCloudCodeFunctionAsync:functionName withParameters:parameters sessionToken:sessionToken];
+                }
+                return task;
+            }];
+        }
+            break;
+        case kPFCachePolicyCacheThenNetwork: {
+            NSError *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidQuery
+                                                     message:@"Cache then network is not supported directly in PFCloudCodeController."];
+            return [BFTask taskWithError:error];
+        }
+            break;
+        default: {
+            NSString *message = [NSString stringWithFormat:@"Unrecognized cache policy: %d", queryState.cachePolicy];
+            NSError *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidQuery message:message];
+            return [BFTask taskWithError:error];
+        }
+            break;
+    }
+    return nil;
+}
+
+- (BFTask *)callCloudCodeFunctionAsync:(NSString *)functionName
+                        withParameters:(NSDictionary *)parameters
+                        sessionToken:(NSString *)sessionToken{
     @weakify(self);
     return [[[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
         @strongify(self);
@@ -55,12 +124,85 @@
                                                                 sessionToken:sessionToken
                                                                        error:&error];
         PFPreconditionReturnFailedTask(command, error);
-        return [self.dataSource.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
+        
+        PFCommandRunningOptions options = 0;
+        if (cachePolicy != kPFCachePolicyNetworkElseCache) {
+            options = PFCommandRunningOptionRetryIfFailed;
+        }
+        return [self.dataSource.commandRunner runCommandAsync:command withOptions:options];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return ((PFCommandResult *)(task.result)).result[@"result"];
     }] continueWithSuccessBlock:^id(BFTask *task) {
+        if (cachePolicy == kPFCachePolicyNetworkOnly ||
+            cachePolicy == kPFCachePolicyNetworkElseCache ||
+            cachePolicy == kPFCachePolicyCacheElseNetwork) {
+            BFTask *newTask = [self _saveCommandResultAsync:task.result forCommandCacheKey:cacheKey];
+            return [[PFDecoder objectDecoder] decodeObject:newTask.result];
+        }
+        
         return [[PFDecoder objectDecoder] decodeObject:task.result];
     }];
+}
+
+///--------------------------------------
+#pragma mark - Caching
+///--------------------------------------
+
+- (nullable NSString *)cacheKeyForFunction:(nonnull NSString *)functionName parameters:(nullable NSDictionary *)parameters sessionToken:(nullable NSString *)sessionToken {
+    NSDictionary *encodedParameters = [[PFNoObjectEncoder objectEncoder] encodeObject:parameters error:nil];
+    return [PFRESTCloudCommand commandForFunction:functionName
+                                   withParameters:encodedParameters
+                                     sessionToken:sessionToken
+                                            error:nil].cacheKey;
+}
+
+- (BOOL)hasCachedResultForFunction:(nonnull NSString *)functionName parameters:(nullable NSDictionary *)parameters sessionToken:(nullable NSString *)sessionToken {
+    NSString *cacheKey = [self cacheKeyForFunction:functionName parameters:parameters sessionToken:sessionToken];
+    return ([self.dataSource.keyValueCache objectForKey:cacheKey maxAge:60] != nil);
+}
+
+- (void)clearCachedResultForFunction:(nonnull NSString *)functionName parameters:(nullable NSDictionary *)parameters sessionToken:(nullable NSString *)sessionToken {
+    NSString *cacheKey = [self cacheKeyForFunction:functionName parameters:parameters sessionToken:sessionToken];
+    [self.dataSource.keyValueCache removeObjectForKey:cacheKey];
+}
+
+- (void)clearAllCachedResults {
+    [self.dataSource.keyValueCache removeAllObjects];
+}
+
+- (BFTask *)taskWithCacheKey:(NSString*)cacheKey
+                 maxCacheAge:(NSTimeInterval)maxCacheAge {
+                               
+    NSString *jsonString = [self.dataSource.keyValueCache objectForKey:cacheKey maxAge:maxCacheAge];
+    if (!jsonString) {
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorCacheMiss
+                                                 message:@"Cache miss."
+                                               shouldLog:NO];
+        return [BFTask taskWithError:error];
+    }
+    
+    NSDictionary *object = [PFJSONSerialization JSONObjectFromString:jsonString];
+    if (!object) {
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorCacheMiss
+                                                 message:@"Cache contains corrupted JSON."];
+        return [BFTask taskWithError:error];
+    }
+    
+    NSDictionary *decodedObject = [[PFDecoder objectDecoder] decodeObject:object];
+    
+    PFCommandResult *result = [PFCommandResult commandResultWithResult:decodedObject
+                                                          resultString:jsonString
+                                                          httpResponse:nil];
+    return [BFTask taskWithResult:result];
+}
+
+- (BFTask *)_saveCommandResultAsync:(PFCommandResult *)result forCommandCacheKey:(NSString *)cacheKey {
+    NSString *resultString = result.resultString;
+    if (resultString) {
+        self.dataSource.keyValueCache[cacheKey] = resultString;
+    }
+    // Roll-forward the original result.
+    return [BFTask taskWithResult:result];
 }
 
 @end

--- a/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
+++ b/Parse/Parse/Internal/CloudCode/PFCloudCodeController.m
@@ -43,7 +43,7 @@
 
 - (BFTask *)callCloudCodeFunctionAsync:(NSString *)functionName
                         withParameters:(NSDictionary *)parameters
-                           cachePolicy:(PFCachePolicty)cachePolicy
+                           cachePolicy:(PFCachePolicy)cachePolicy
                            maxCacheAge:(NSTimeInterval)maxCacheAge
                           sessionToken:(NSString *)sessionToken{
    

--- a/Parse/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Parse/Internal/Object/PFObjectPrivate.h
@@ -198,8 +198,6 @@
 - (void)setHasBeenFetched:(BOOL)fetched;
 - (void)_setDeleted:(BOOL)deleted;
 
-- (BOOL)isDataAvailableForKey:(NSString *)key;
-
 - (BOOL)_hasChanges;
 - (BOOL)_hasOutstandingOperations;
 - (PFOperationSet *)unsavedChanges;

--- a/Parse/Parse/PFCloud.h
+++ b/Parse/Parse/PFCloud.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Calls the given cloud function *asynchronously* with the parameters provided.
  
- @param functionName The function name to call.
+ @param function The function name to call.
  @param parameters The parameters to send to the function.
  @param cachePolicy Cache Policy
  @param maxCacheAge Max cache age
@@ -59,8 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)callFunctionInBackground:(NSString *)function
                   withParameters:(nullable NSDictionary *)parameters
-                     cachePolicy:(nonnull PFCachePolicy)cachePolicy
-                     maxCacheAge:(nonnull NSTimeInterval)maxCacheAge
+                     cachePolicy:(nullable PFCachePolicy)cachePolicy
+                     maxCacheAge:(nullable NSTimeInterval)maxCacheAge
                            block:(nullable PFIdResultBlock)block;
 
 @end

--- a/Parse/Parse/PFCloud.h
+++ b/Parse/Parse/PFCloud.h
@@ -32,16 +32,35 @@ NS_ASSUME_NONNULL_BEGIN
                           withParameters:(nullable NSDictionary *)parameters;
 
 /**
+ Calls the given cloud function *asynchronously* with the parameters provided.
+ 
+ @param function The function name to call.
+ @param parameters The parameters to send to the function.
+ @param cachePolicy Cache Policy
+ @param maxCacheAge Max cache age
+ 
+ @return The task, that encapsulates the work being done.
+ */
++ (BFTask *)callFunctionInBackground:(NSString *)functionName
+                      withParameters:(NSDictionary *)parameters
+                         cachePolicy:(PFCachePolicy)cachePolicy
+                         maxCacheAge:(NSTimeInterval)maxCacheAge;
+
+/**
  Calls the given cloud function *asynchronously* with the parameters provided
  and executes the given block when it is done.
 
  @param function The function name to call.
  @param parameters The parameters to send to the function.
+ @param cachePolicy Cache Policy
+ @param maxCacheAge Max cache age
  @param block The block to execute when the function call finished.
  It should have the following argument signature: `^(id result, NSError *error)`.
  */
 + (void)callFunctionInBackground:(NSString *)function
                   withParameters:(nullable NSDictionary *)parameters
+                     cachePolicy:(PFCachePolicy)cachePolicy
+                     maxCacheAge:(NSTimeInterval)maxCacheAge
                            block:(nullable PFIdResultBlock)block;
 
 @end

--- a/Parse/Parse/PFCloud.h
+++ b/Parse/Parse/PFCloud.h
@@ -34,14 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Calls the given cloud function *asynchronously* with the parameters provided.
  
- @param function The function name to call.
+ @param functionName The function name to call.
  @param parameters The parameters to send to the function.
  @param cachePolicy Cache Policy
  @param maxCacheAge Max cache age
  
  @return The task, that encapsulates the work being done.
  */
-+ (BFTask *)callFunctionInBackground:(NSString *)functionName
++ (BFTask *)callFunctionInBackground:(NSString *)function
                       withParameters:(NSDictionary *)parameters
                          cachePolicy:(PFCachePolicy)cachePolicy
                          maxCacheAge:(NSTimeInterval)maxCacheAge;
@@ -59,8 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)callFunctionInBackground:(NSString *)function
                   withParameters:(nullable NSDictionary *)parameters
-                     cachePolicy:(PFCachePolicy)cachePolicy
-                     maxCacheAge:(NSTimeInterval)maxCacheAge
+                     cachePolicy:(nonnull PFCachePolicy)cachePolicy
+                     maxCacheAge:(nonnull NSTimeInterval)maxCacheAge
                            block:(nullable PFIdResultBlock)block;
 
 @end

--- a/Parse/Parse/PFCloud.m
+++ b/Parse/Parse/PFCloud.m
@@ -23,19 +23,30 @@
 ///--------------------------------------
 
 + (BFTask *)callFunctionInBackground:(NSString *)functionName withParameters:(NSDictionary *)parameters {
+    return [callFunctionInBackground:functionName withParameters:parameters cachePolicy:kPFCachePolicyNetworkOnly maxCacheAge:60]
+}
+
++ (BFTask *)callFunctionInBackground:(NSString *)functionName
+                      withParameters:(NSDictionary *)parameters
+                         cachePolicy:(PFCachePolicy)cachePolicy
+                         maxCacheAge:(NSTimeInterval)maxCacheAge {
     return [[PFUser _getCurrentUserSessionTokenAsync] continueWithBlock:^id(BFTask *task) {
         NSString *sessionToken = task.result;
         PFCloudCodeController *controller = [Parse _currentManager].coreManager.cloudCodeController;
         return [controller callCloudCodeFunctionAsync:functionName
                                        withParameters:parameters
+                                          cachePolicy:cachePolicy,
+                                          maxCacheAge:maxCacheAge,
                                          sessionToken:sessionToken];
     }];
 }
 
 + (void)callFunctionInBackground:(NSString *)function
                   withParameters:(NSDictionary *)parameters
+                     cachePolicy:(PFCachePolicy)cachePolicy
+                     maxCacheAge:(NSTimeInterval)maxCacheAge
                            block:(PFIdResultBlock)block {
-    [[self callFunctionInBackground:function withParameters:parameters] thenCallBackOnMainThreadAsync:block];
+    [[self callFunctionInBackground:function withParameters:parameters cachePolicy:cachePolicy maxCacheAge:maxCacheAge] thenCallBackOnMainThreadAsync:block];
 }
 
 @end

--- a/Parse/Parse/PFObject.h
+++ b/Parse/Parse/PFObject.h
@@ -395,6 +395,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 @property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
+/**
+ Gets whether the `PFObject` has data for given key
+ 
+ @return `YES` if data is available for given key
+ */
+- (BOOL)isDataAvailableForKey:(NSString *)key;
+
 #if TARGET_OS_IOS
 
 /**

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -2142,7 +2142,9 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (id)objectForKey:(NSString *)key {
     @synchronized (lock) {
-        if (![self isDataAvailableForKey:key]) { return nil }
+        if (![self isDataAvailableForKey:key]) {
+            return nil;
+        }
         
         id result = _estimatedData[key];
         if ([key isEqualToString:PFObjectACLRESTKey] && [result isKindOfClass:[PFACL class]]) {

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -743,19 +743,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 }
 
-- (BOOL)isDataAvailableForKey:(NSString *)key {
-    if (!key) {
-        return NO;
-    }
-
-    @synchronized (lock) {
-        if (self.dataAvailable) {
-            return YES;
-        }
-        return [_availableKeys containsObject:key];
-    }
-}
-
 ///--------------------------------------
 #pragma mark - Validations
 ///--------------------------------------
@@ -2028,6 +2015,19 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (BOOL)isDataAvailable {
     return self._state.complete;
+}
+
+- (BOOL)isDataAvailableForKey:(NSString *)key {
+    if (!key) {
+        return NO;
+    }
+    
+    @synchronized (lock) {
+        if (self.dataAvailable) {
+            return YES;
+        }
+        return [_availableKeys containsObject:key];
+    }
 }
 
 - (instancetype)refresh {

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -2142,9 +2142,8 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (id)objectForKey:(NSString *)key {
     @synchronized (lock) {
-        PFConsistencyAssert([self isDataAvailableForKey:key],
-                            @"Key \"%@\" has no data.  Call fetchIfNeeded before getting its value.", key);
-
+        if (![self isDataAvailableForKey:key]) { return nil }
+        
         id result = _estimatedData[key];
         if ([key isEqualToString:PFObjectACLRESTKey] && [result isKindOfClass:[PFACL class]]) {
             PFACL *acl = result;

--- a/Parse/Tests/Unit/ObjectUnitTests.m
+++ b/Parse/Tests/Unit/ObjectUnitTests.m
@@ -106,7 +106,7 @@
 
 - (void)testObjectForUnavailableKey {
     PFObject *object = [PFObject objectWithoutDataWithClassName:@"Yarr" objectId:nil];
-    PFAssertThrowsInconsistencyException(object[@"yarr"]);
+    XCTAssertNil(object[@"yarr"]);
 }
 
 - (void)testSettersWithNilArguments {


### PR DESCRIPTION
… so you don't need to fetch all data to get a certain data.
Sometimes the data of a user is very long but we just need to get the "username" which is already fetched.
This PR also avoid crashing when we try to get data from key which is not fetched. It should returns nil.

So we could check or get data by either ways:
```
if user.isDataAvailable(forKey: "username") {
 // ok
}
```
or
```
if let username = user["username"] {
// username is available
}
else {
// username is unavailable, please fetch it
}
```