### PR TITLE
isDataAvailableForKey should be public to easier to check data available

### DIFF
--- a/Parse/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Parse/Internal/Object/PFObjectPrivate.h
@@ -198,8 +198,6 @@
 - (void)setHasBeenFetched:(BOOL)fetched;
 - (void)_setDeleted:(BOOL)deleted;
 
-- (BOOL)isDataAvailableForKey:(NSString *)key;
-
 - (BOOL)_hasChanges;
 - (BOOL)_hasOutstandingOperations;
 - (PFOperationSet *)unsavedChanges;

--- a/Parse/Parse/PFObject.h
+++ b/Parse/Parse/PFObject.h
@@ -395,6 +395,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 @property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
+/**
+ Gets whether the `PFObject` has data for given key
+ 
+ @return `YES` if data is available for given key
+ */
+- (BOOL)isDataAvailableForKey:(NSString *)key;
+
 #if TARGET_OS_IOS
 
 /**

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -2142,7 +2142,9 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (id)objectForKey:(NSString *)key {
     @synchronized (lock) {
-        if (![self isDataAvailableForKey:key]) { return nil }
+        if (![self isDataAvailableForKey:key]) {
+            return nil;
+        }
         
         id result = _estimatedData[key];
         if ([key isEqualToString:PFObjectACLRESTKey] && [result isKindOfClass:[PFACL class]]) {

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -743,19 +743,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 }
 
-- (BOOL)isDataAvailableForKey:(NSString *)key {
-    if (!key) {
-        return NO;
-    }
-
-    @synchronized (lock) {
-        if (self.dataAvailable) {
-            return YES;
-        }
-        return [_availableKeys containsObject:key];
-    }
-}
-
 ///--------------------------------------
 #pragma mark - Validations
 ///--------------------------------------
@@ -2028,6 +2015,19 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (BOOL)isDataAvailable {
     return self._state.complete;
+}
+
+- (BOOL)isDataAvailableForKey:(NSString *)key {
+    if (!key) {
+        return NO;
+    }
+    
+    @synchronized (lock) {
+        if (self.dataAvailable) {
+            return YES;
+        }
+        return [_availableKeys containsObject:key];
+    }
 }
 
 - (instancetype)refresh {

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -2142,9 +2142,8 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (id)objectForKey:(NSString *)key {
     @synchronized (lock) {
-        PFConsistencyAssert([self isDataAvailableForKey:key],
-                            @"Key \"%@\" has no data.  Call fetchIfNeeded before getting its value.", key);
-
+        if (![self isDataAvailableForKey:key]) { return nil }
+        
         id result = _estimatedData[key];
         if ([key isEqualToString:PFObjectACLRESTKey] && [result isKindOfClass:[PFACL class]]) {
             PFACL *acl = result;

--- a/Parse/Tests/Unit/ObjectUnitTests.m
+++ b/Parse/Tests/Unit/ObjectUnitTests.m
@@ -106,7 +106,7 @@
 
 - (void)testObjectForUnavailableKey {
     PFObject *object = [PFObject objectWithoutDataWithClassName:@"Yarr" objectId:nil];
-    PFAssertThrowsInconsistencyException(object[@"yarr"]);
+    XCTAssertNil(object[@"yarr"]);
 }
 
 - (void)testSettersWithNilArguments {

--- a/ParseUI/Classes/SignUpViewController/PFSignUpView.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpView.m
@@ -213,7 +213,7 @@ NSString *const PFSignUpViewDismissButtonAccessibilityIdentifier = @"PFSignUpVie
         frame.origin.y = currentY + loginButtonTopInset;
         _signUpButton.frame = frame;
 
-        currentY = CGRectGetMaxY(frame);
+//        currentY = CGRectGetMaxY(frame);
     }
 }
 


### PR DESCRIPTION
… so you don't need to fetch all data to get a certain data.
Sometimes the data of a user is very long but we just need to get the "username" which is already fetched.
This PR also avoid crashing when we try to get data from key which is not fetched. It should returns nil.

So we could check or get data by either ways:
```
if user.isDataAvailable(forKey: "username") {
 // ok
}
```
or
```
if let username = user["username"] {
// username is available
}
else {
// username is unavailable, please fetch it
}
```