### PR TITLE
Updated FBSDK to 9.0

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "BoltsFramework/Bolts-ObjC" "1.9.1"
-github "facebook/facebook-ios-sdk" "v8.2.0"
+github "facebook/facebook-ios-sdk" "v9.0.0"

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -104,7 +104,7 @@ Pod::Spec.new do |s|
 
     s.dependency 'Parse/Core'
     s.dependency 'Bolts/Tasks', '~> 1.9.1'
-    s.dependency 'FBSDKLoginKit', '~> 8.x'
+    s.dependency 'FBSDKLoginKit', '~> 9.x'
   end
 
   s.subspec 'FacebookUtils-tvOS' do |s|
@@ -126,8 +126,8 @@ Pod::Spec.new do |s|
 
     s.dependency 'Parse/Core'
     s.dependency 'Bolts/Tasks', '~> 1.9.1'
-    s.dependency 'FBSDKTVOSKit', '~> 8.x'
-    s.dependency 'FBSDKShareKit', '~> 8.x'
+    s.dependency 'FBSDKTVOSKit', '~> 9.x'
+    s.dependency 'FBSDKShareKit', '~> 9.x'
   end
 
   s.subspec 'TwitterUtils' do |s|

--- a/ParseFacebookUtils/Tests/Unit/FacebookAuthenticationProviderTests.m
+++ b/ParseFacebookUtils/Tests/Unit/FacebookAuthenticationProviderTests.m
@@ -49,6 +49,7 @@
                                                        dataAccessExpirationDate:nil];
         
         FBSDKLoginManagerLoginResult *result = [[FBSDKLoginManagerLoginResult alloc] initWithToken:token
+																			   authenticationToken:nil
                                                                                        isCancelled:NO
                                                                                 grantedPermissions:[NSSet setWithObject:@"read"]
                                                                                declinedPermissions:[NSSet setWithArray:@[]]];
@@ -93,6 +94,7 @@
                                                        dataAccessExpirationDate:nil];
         
         FBSDKLoginManagerLoginResult *result = [[FBSDKLoginManagerLoginResult alloc] initWithToken:token
+																			   authenticationToken:nil
                                                                                        isCancelled:NO
                                                                                 grantedPermissions:[NSSet setWithObject:@"publish"]
                                                                                declinedPermissions:[NSSet setWithArray:@[]]];
@@ -136,6 +138,7 @@
                                                        dataAccessExpirationDate:nil];
         
         FBSDKLoginManagerLoginResult *result = [[FBSDKLoginManagerLoginResult alloc] initWithToken:token
+																			   authenticationToken:nil
                                                                                        isCancelled:NO
                                                                                 grantedPermissions:[NSSet setWithArray:@[ @"read", @"publish" ]]
                                                                                declinedPermissions:[NSSet setWithArray:@[]]];
@@ -162,7 +165,8 @@
         [invocation getArgument:&handler atIndex:4];
 
         FBSDKLoginManagerLoginResult *result = [[FBSDKLoginManagerLoginResult alloc] initWithToken:nil
-                                                                                       isCancelled:YES
+																			   authenticationToken:nil
+																					   isCancelled:YES
                                                                                 grantedPermissions:[NSSet setWithArray:@[]]
                                                                                declinedPermissions:[NSSet setWithObject:@"publish"]];
 
@@ -231,6 +235,7 @@
                                                        dataAccessExpirationDate:nil];
         
         FBSDKLoginManagerLoginResult *result = [[FBSDKLoginManagerLoginResult alloc] initWithToken:token
+																			   authenticationToken:nil
                                                                                        isCancelled:NO
                                                                                 grantedPermissions:[NSSet setWithObject:@"publish"]
                                                                                declinedPermissions:[NSSet setWithArray:@[]]];


### PR DESCRIPTION
Updated FBSDK to v9.0
According to the docs, Facebook introduced a new login method with v9.0 with "limited data mode", which is not covered by this PR. The old login method is still present on v9.0 and working just fine with Parse.
Given that [Facebook is deprecating all previous SDKs](https://developers.facebook.com/blog/post/2021/01/19/introducing-facebook-platform-sdk-version-9/), I think it would be a good idea to integrate v9.0 now, and leave the new login mode for later (though I haven't check what/if changes are needed).
