### PR TITLE
feat: Upgrade to Facebook SDK 13 via SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ npm-debug.log
 # Ruby
 .bundle
 Vendor/
+.build
+.swiftpm

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ npm-debug.log
 Vendor/
 .build
 .swiftpm
+Package.resolved

--- a/Parse.xcworkspace/contents.xcworkspacedata
+++ b/Parse.xcworkspace/contents.xcworkspacedata
@@ -16,9 +16,6 @@
    <Group
       location = "container:"
       name = "Vendor">
-      <FileRef
-         location = "group:Carthage/Checkouts/OCMock/Source/OCMock.xcodeproj">
-      </FileRef>
    </Group>
    <Group
       location = "container:"

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		403093761C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
 		403093771C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
 		403093781C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
-		4A13525620282B4D000F5FD5 /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97010FAC1630B18F00AB761E /* Parse.framework */; };
 		4AAEAA40200BE14B00AA7479 /* third_party_licenses.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8139B12C1A7BF559002BEF84 /* third_party_licenses.txt */; };
 		4ABF398C1F54592100BBA75A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4ABF398B1F54592100BBA75A /* Main.storyboard */; };
 		4AE33A0F1F5451AD0088DCA0 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AE33A0E1F5451AD0088DCA0 /* AppDelegate.m */; };
@@ -2641,11 +2640,12 @@
 		BC619D0527D2467D004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0427D2467D004FAFB5 /* Bolts */; };
 		BC619D0827D246F3004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0727D246F3004FAFB5 /* OCMock */; };
 		BC619D0A27D24765004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0927D24765004FAFB5 /* Bolts */; };
-		BC619D0C27D247FD004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0B27D247FD004FAFB5 /* OCMock */; };
+		BC619D0C27D247FD004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0B27D247FD004FAFB5 /* OCMock */; settings = {ATTRIBUTES = (Required, ); }; };
 		BC619D0E27D2483A004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0D27D2483A004FAFB5 /* Bolts */; };
 		BC619D1027D24B62004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0F27D24B62004FAFB5 /* Bolts */; };
 		BC619D1227D24B69004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D1127D24B69004FAFB5 /* Bolts */; };
 		BC619D1427D24B72004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D1327D24B72004FAFB5 /* Bolts */; };
+		BCB617B827D7AAB400526B01 /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97010FAC1630B18F00AB761E /* Parse.framework */; };
 		F50C66331B33A708001941A6 /* PFPushUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F50C66311B33A708001941A6 /* PFPushUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F50C66341B33A708001941A6 /* PFPushUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = F50C66321B33A708001941A6 /* PFPushUtilities.m */; };
 		F50C667C1B34B231001941A6 /* PFPushUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = F50C66321B33A708001941A6 /* PFPushUtilities.m */; };
@@ -3455,7 +3455,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A13525620282B4D000F5FD5 /* Parse.framework in Frameworks */,
+				BCB617B827D7AAB400526B01 /* Parse.framework in Frameworks */,
 				F5B0B3171B44A2CA00F3EBC4 /* StoreKit.framework in Frameworks */,
 				BC619D0C27D247FD004FAFB5 /* OCMock in Frameworks */,
 				F5B0B3161B44A22300F3EBC4 /* SystemConfiguration.framework in Frameworks */,

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -2637,8 +2637,15 @@
 		B141170F1E5D081500F70D7A /* PFFileUploadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B141170A1E5D081500F70D7A /* PFFileUploadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14117101E5D081500F70D7A /* PFFileUploadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B141170A1E5D081500F70D7A /* PFFileUploadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14117111E5D081500F70D7A /* PFFileUploadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B141170A1E5D081500F70D7A /* PFFileUploadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC150D7325A89F9C0092B00E /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A13518820281768000F5FD5 /* Bolts.framework */; };
-		BCAFF87325A88B7800B95DFC /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCAFF87225A88B7800B95DFC /* WebKit.framework */; platformFilter = ios; };
+		BC619D0327D244BB004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0227D244BB004FAFB5 /* Bolts */; };
+		BC619D0527D2467D004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0427D2467D004FAFB5 /* Bolts */; };
+		BC619D0827D246F3004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0727D246F3004FAFB5 /* OCMock */; };
+		BC619D0A27D24765004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0927D24765004FAFB5 /* Bolts */; };
+		BC619D0C27D247FD004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0B27D247FD004FAFB5 /* OCMock */; };
+		BC619D0E27D2483A004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0D27D2483A004FAFB5 /* Bolts */; };
+		BC619D1027D24B62004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D0F27D24B62004FAFB5 /* Bolts */; };
+		BC619D1227D24B69004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D1127D24B69004FAFB5 /* Bolts */; };
+		BC619D1427D24B72004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D1327D24B72004FAFB5 /* Bolts */; };
 		F50C66331B33A708001941A6 /* PFPushUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F50C66311B33A708001941A6 /* PFPushUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F50C66341B33A708001941A6 /* PFPushUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = F50C66321B33A708001941A6 /* PFPushUtilities.m */; };
 		F50C667C1B34B231001941A6 /* PFPushUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = F50C66321B33A708001941A6 /* PFPushUtilities.m */; };
@@ -2775,125 +2782,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4A13518320281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81ED94291BE147CF00795F05;
-			remoteInfo = "Bolts-iOS";
-		};
-		4A13518520281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 1D5D7DD31BE3CE8200FD67C7;
-			remoteInfo = "Bolts-iOS-Dynamic";
-		};
-		4A13518720281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81ED946E1BE14B5200795F05;
-			remoteInfo = "Bolts-macOS";
-		};
-		4A13518920281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F5AFCA021BA752750076E927;
-			remoteInfo = "Bolts-tvOS";
-		};
-		4A13518B20281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81E94D6A1C2B8BF200A6291E;
-			remoteInfo = "Bolts-tvOS-Dynamic";
-		};
-		4A13518D20281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8178F99C1BB0F87700AD289D;
-			remoteInfo = "Bolts-watchOS";
-		};
-		4A13518F20281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 819573F11C2B8ECB00BFCA39;
-			remoteInfo = "Bolts-watchOS-Dynamic";
-		};
-		4A13519120281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8E8C8EE917F23D1D00E3F1C7;
-			remoteInfo = "BoltsTests-iOS";
-		};
-		4A13519320281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8E8C8F1917F241DA00E3F1C7;
-			remoteInfo = "BoltsTests-macOS";
-		};
-		4A13519520281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F5AFCA131BA752770076E927;
-			remoteInfo = "BoltsTests-tvOS";
-		};
-		4A13519720281768000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 1EC3016018CDAA8400D06D07;
-			remoteInfo = BoltsTestUI;
-		};
-		4A1351F420281933000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 8178F9841BB0F87700AD289D;
-			remoteInfo = "Bolts-watchOS";
-		};
-		4A1351F62028193F000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = F5AFC9EA1BA752750076E927;
-			remoteInfo = "Bolts-tvOS";
-		};
-		4AA8ABFE20CEFC9A009306DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 819573D91C2B8ECB00BFCA39;
-			remoteInfo = "Bolts-watchOS-Dynamic";
-		};
-		4AA8AC0720CEFCA2009306DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 1D5D7DA61BE3CE8200FD67C7;
-			remoteInfo = "Bolts-iOS-Dynamic";
-		};
-		4AA8AC0920CEFCAD009306DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 81E94D521C2B8BF200A6291E;
-			remoteInfo = "Bolts-tvOS-Dynamic";
-		};
-		4ACBE7EA2151FCBF008DFAAF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 8EDDA62817E17DDC00655F8A;
-			remoteInfo = "Bolts-macOS";
-		};
 		4AE33A2C1F5451B20088DCA0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 09D33641139C54930098E916 /* Project object */;
@@ -2914,76 +2802,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 81C3821B19CCA89E0066284A;
 			remoteInfo = "Parse-iOS";
-		};
-		BC105FC424C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 030EF0A814632FD000B04273;
-			remoteInfo = OCMock;
-		};
-		BC105FC624C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 03565A3118F0566E003AE91E;
-			remoteInfo = OCMockTests;
-		};
-		BC105FC824C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 030EF0DC14632FF700B04273;
-			remoteInfo = OCMockLib;
-		};
-		BC105FCA24C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D31108AD1828DB8700737925;
-			remoteInfo = OCMockLibTests;
-		};
-		BC105FCC24C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F0B950F11B0080BE00942C38;
-			remoteInfo = "OCMock iOS";
-		};
-		BC105FCE24C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 817EB1621BD765130047E85A;
-			remoteInfo = "OCMock tvOS";
-		};
-		BC105FD024C5D0C900295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8DE97CA022B43EE60098C63F;
-			remoteInfo = "OCMock watchOS";
-		};
-		BC105FD224C5D0D600295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 030EF0A714632FD000B04273;
-			remoteInfo = OCMock;
-		};
-		BC105FD424C5D0E100295EF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = F0B950F01B0080BE00942C38;
-			remoteInfo = "OCMock iOS";
-		};
-		BCAFF88A25A88C4F00B95DFC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 81ED94111BE147CF00795F05;
-			remoteInfo = "Bolts-iOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -3046,7 +2864,6 @@
 		499E425615B6409000A2C28E /* PFProduct.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFProduct.m; sourceTree = "<group>"; };
 		49FDE2EC158C138F00126F64 /* PFPurchase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPurchase.h; sourceTree = "<group>"; };
 		49FDE2ED158C138F00126F64 /* PFPurchase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPurchase.m; sourceTree = "<group>"; };
-		4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Bolts.xcodeproj; path = "../Carthage/Checkouts/Bolts-ObjC/Bolts.xcodeproj"; sourceTree = "<group>"; };
 		4ABF398B1F54592100BBA75A /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		4AE33A0B1F5451AD0088DCA0 /* ParseUnitTests-iOS-host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ParseUnitTests-iOS-host.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AE33A0D1F5451AD0088DCA0 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -3540,12 +3357,6 @@
 		B141169D1E5BC24B00F70D7A /* PFFileUploadController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileUploadController.h; sourceTree = "<group>"; };
 		B14116FB1E5D078E00F70D7A /* PFFileUploadResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFFileUploadResult.m; sourceTree = "<group>"; };
 		B141170A1E5D081500F70D7A /* PFFileUploadResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileUploadResult.h; sourceTree = "<group>"; };
-		BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCMock.xcodeproj; path = ../Carthage/Checkouts/OCMock/Source/OCMock.xcodeproj; sourceTree = "<group>"; };
-		BCAFF7EE25A88A7E00B95DFC /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.3.sdk/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
-		BCAFF87225A88B7800B95DFC /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/iOSSupport/System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		BCC5EAAC22D5F96600CF8900 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/iOS/Bolts.framework; sourceTree = "<group>"; };
-		BCC5EAB222D5F97D00CF8900 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/tvOS/Bolts.framework; sourceTree = "<group>"; };
-		BCC5EAB422D5F98F00CF8900 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/watchOS/Bolts.framework; sourceTree = "<group>"; };
 		E9BBE98E16D18E5800CD7B52 /* PFObject+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "PFObject+Subclass.h"; path = "Parse/PFObject+Subclass.h"; sourceTree = SOURCE_ROOT; };
 		E9E81E8316EEF93E001D034F /* PFSubclassing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFSubclassing.h; sourceTree = "<group>"; };
 		F50C66311B33A708001941A6 /* PFPushUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPushUtilities.h; sourceTree = "<group>"; };
@@ -3614,6 +3425,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D1227D24B69004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3621,6 +3433,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D0E27D2483A004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3628,8 +3441,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCAFF87325A88B7800B95DFC /* WebKit.framework in Frameworks */,
 				F5C42CC71B34C22100C720D8 /* AudioToolbox.framework in Frameworks */,
+				BC619D0827D246F3004FAFB5 /* OCMock in Frameworks */,
 				816F44761A8E8933009CDB32 /* StoreKit.framework in Frameworks */,
 				816F44771A8E8933009CDB32 /* libsqlite3.dylib in Frameworks */,
 				816F44781A8E8933009CDB32 /* Accounts.framework in Frameworks */,
@@ -3644,6 +3457,7 @@
 			files = (
 				4A13525620282B4D000F5FD5 /* Parse.framework in Frameworks */,
 				F5B0B3171B44A2CA00F3EBC4 /* StoreKit.framework in Frameworks */,
+				BC619D0C27D247FD004FAFB5 /* OCMock in Frameworks */,
 				F5B0B3161B44A22300F3EBC4 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3652,6 +3466,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D0327D244BB004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3659,6 +3474,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D0527D2467D004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3666,6 +3482,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D1027D24B62004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3673,6 +3490,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D1427D24B72004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3680,10 +3498,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC150D7325A89F9C0092B00E /* Bolts.framework in Frameworks */,
 				81B3F2021AC5DAA400A92677 /* Cocoa.framework in Frameworks */,
 				81B3F2011AC5DA7600A92677 /* libsqlite3.dylib in Frameworks */,
 				97DE045C163214C0007154E8 /* SystemConfiguration.framework in Frameworks */,
+				BC619D0A27D24765004FAFB5 /* Bolts in Frameworks */,
 				97DE045A16321492007154E8 /* Security.framework in Frameworks */,
 				97DE045116321428007154E8 /* CoreLocation.framework in Frameworks */,
 			);
@@ -3909,13 +3727,6 @@
 		09D3364C139C54940098E916 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				BCAFF7EE25A88A7E00B95DFC /* WebKit.framework */,
-				BCAFF87225A88B7800B95DFC /* WebKit.framework */,
-				BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */,
-				BCC5EAAC22D5F96600CF8900 /* Bolts.framework */,
-				BCC5EAB222D5F97D00CF8900 /* Bolts.framework */,
-				BCC5EAB422D5F98F00CF8900 /* Bolts.framework */,
-				4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */,
 				813E97A91A26A76A00373BA7 /* System Frameworks */,
 			);
 			name = Frameworks;
@@ -3928,24 +3739,6 @@
 				8101A14719ACDA97008BB503 /* PFAlertView.m */,
 			);
 			name = Views;
-			sourceTree = "<group>";
-		};
-		4A13517620281768000F5FD5 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4A13518420281768000F5FD5 /* Bolts.framework */,
-				4A13518620281768000F5FD5 /* Bolts.framework */,
-				4A13518820281768000F5FD5 /* Bolts.framework */,
-				4A13518A20281768000F5FD5 /* Bolts.framework */,
-				4A13518C20281768000F5FD5 /* Bolts.framework */,
-				4A13518E20281768000F5FD5 /* Bolts.framework */,
-				4A13519020281768000F5FD5 /* Bolts.framework */,
-				4A13519220281768000F5FD5 /* BoltsTests-iOS.xctest */,
-				4A13519420281768000F5FD5 /* BoltsTests-OSX.xctest */,
-				4A13519620281768000F5FD5 /* BoltsTests-tvOS.xctest */,
-				4A13519820281768000F5FD5 /* BoltsTestUI.app */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		4AAB99061EE6D7E50073D7A7 /* Recovered References */ = {
@@ -5152,20 +4945,6 @@
 				81EEE1AF1B446D600087AC4D /* PFCurrentUserController.m */,
 			);
 			path = CurrentUserController;
-			sourceTree = "<group>";
-		};
-		BC105FBB24C5D0C900295EF7 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				BC105FC524C5D0C900295EF7 /* OCMock.framework */,
-				BC105FC724C5D0C900295EF7 /* OCMockTests.xctest */,
-				BC105FC924C5D0C900295EF7 /* libOCMock.a */,
-				BC105FCB24C5D0C900295EF7 /* OCMockLibTests.xctest */,
-				BC105FCD24C5D0C900295EF7 /* OCMock.framework */,
-				BC105FCF24C5D0C900295EF7 /* OCMock.framework */,
-				BC105FD124C5D0C900295EF7 /* OCMock.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		F50C66301B33A6CE001941A6 /* Utilites */ = {
@@ -6836,9 +6615,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4A1351F520281933000F5FD5 /* PBXTargetDependency */,
 			);
 			name = "Parse-watchOS";
+			packageProductDependencies = (
+				BC619D1127D24B69004FAFB5 /* Bolts */,
+			);
 			productName = "Parse-iOS";
 			productReference = 810156691BB3832700D7C7BD /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6856,9 +6637,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4A1351F72028193F000F5FD5 /* PBXTargetDependency */,
 			);
 			name = "Parse-tvOS";
+			packageProductDependencies = (
+				BC619D0D27D2483A004FAFB5 /* Bolts */,
+			);
 			productName = "Parse-iOS";
 			productReference = 815F24151BD04D150054659F /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6875,11 +6658,13 @@
 			buildRules = (
 			);
 			dependencies = (
-				BC105FD524C5D0E100295EF7 /* PBXTargetDependency */,
 				8111674C1B8402DF003CB026 /* PBXTargetDependency */,
 				4AE33A2D1F5451B20088DCA0 /* PBXTargetDependency */,
 			);
 			name = "ParseUnitTests-iOS";
+			packageProductDependencies = (
+				BC619D0727D246F3004FAFB5 /* OCMock */,
+			);
 			productName = ParseTests;
 			productReference = 816F449B1A8E8933009CDB32 /* ParseUnitTests-iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -6896,10 +6681,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				BC105FD324C5D0D600295EF7 /* PBXTargetDependency */,
 				811167471B8402DA003CB026 /* PBXTargetDependency */,
 			);
 			name = "ParseUnitTests-macOS";
+			packageProductDependencies = (
+				BC619D0B27D247FD004FAFB5 /* OCMock */,
+			);
 			productName = ParseTests;
 			productReference = 81C09F861AF97A490043B49C /* ParseUnitTests-macOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -6917,9 +6704,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				BCAFF88B25A88C4F00B95DFC /* PBXTargetDependency */,
 			);
 			name = "Parse-iOS";
+			packageProductDependencies = (
+				BC619D0227D244BB004FAFB5 /* Bolts */,
+			);
 			productName = "Parse-iOS";
 			productReference = 81C3821C19CCA89E0066284A /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6937,9 +6726,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4AA8AC0820CEFCA2009306DD /* PBXTargetDependency */,
 			);
 			name = "Parse-iOS-Dynamic";
+			packageProductDependencies = (
+				BC619D0427D2467D004FAFB5 /* Bolts */,
+			);
 			productName = "Parse-iOS";
 			productReference = 81C5845D1C3B0A98000063C6 /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6957,9 +6748,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4AA8AC0A20CEFCAD009306DD /* PBXTargetDependency */,
 			);
 			name = "Parse-tvOS-Dynamic";
+			packageProductDependencies = (
+				BC619D0F27D24B62004FAFB5 /* Bolts */,
+			);
 			productName = "Parse-iOS";
 			productReference = 81C585BF1C3B0AA1000063C6 /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6977,9 +6770,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4AA8ABFF20CEFC9A009306DD /* PBXTargetDependency */,
 			);
 			name = "Parse-watchOS-Dynamic";
+			packageProductDependencies = (
+				BC619D1327D24B72004FAFB5 /* Bolts */,
+			);
 			productName = "Parse-iOS";
 			productReference = 81C5870F1C3B0AA9000063C6 /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6997,9 +6792,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4ACBE7EB2151FCBF008DFAAF /* PBXTargetDependency */,
 			);
 			name = "Parse-macOS";
+			packageProductDependencies = (
+				BC619D0927D24765004FAFB5 /* Bolts */,
+			);
 			productName = ParseMac;
 			productReference = 97010FAC1630B18F00AB761E /* Parse.framework */;
 			productType = "com.apple.product-type.framework";
@@ -7043,18 +6840,12 @@
 				Base,
 			);
 			mainGroup = 09D3363F139C54930098E916;
+			packageReferences = (
+				BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */,
+				BC619D0627D246F3004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */,
+			);
 			productRefGroup = 09D3364B139C54940098E916 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 4A13517620281768000F5FD5 /* Products */;
-					ProjectRef = 4A1351082027FCFB000F5FD5 /* Bolts.xcodeproj */;
-				},
-				{
-					ProductGroup = BC105FBB24C5D0C900295EF7 /* Products */;
-					ProjectRef = BC105FBA24C5D0C900295EF7 /* OCMock.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				81C3821B19CCA89E0066284A /* Parse-iOS */,
@@ -7070,135 +6861,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		4A13518420281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518320281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13518620281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518520281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13518820281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518720281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13518A20281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518920281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13518C20281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518B20281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13518E20281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518D20281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13519020281768000F5FD5 /* Bolts.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Bolts.framework;
-			remoteRef = 4A13518F20281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13519220281768000F5FD5 /* BoltsTests-iOS.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "BoltsTests-iOS.xctest";
-			remoteRef = 4A13519120281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13519420281768000F5FD5 /* BoltsTests-OSX.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "BoltsTests-OSX.xctest";
-			remoteRef = 4A13519320281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13519620281768000F5FD5 /* BoltsTests-tvOS.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "BoltsTests-tvOS.xctest";
-			remoteRef = 4A13519520281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A13519820281768000F5FD5 /* BoltsTestUI.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = BoltsTestUI.app;
-			remoteRef = 4A13519720281768000F5FD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FC524C5D0C900295EF7 /* OCMock.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = OCMock.framework;
-			remoteRef = BC105FC424C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FC724C5D0C900295EF7 /* OCMockTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = OCMockTests.xctest;
-			remoteRef = BC105FC624C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FC924C5D0C900295EF7 /* libOCMock.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libOCMock.a;
-			remoteRef = BC105FC824C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FCB24C5D0C900295EF7 /* OCMockLibTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = OCMockLibTests.xctest;
-			remoteRef = BC105FCA24C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FCD24C5D0C900295EF7 /* OCMock.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = OCMock.framework;
-			remoteRef = BC105FCC24C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FCF24C5D0C900295EF7 /* OCMock.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = OCMock.framework;
-			remoteRef = BC105FCE24C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC105FD124C5D0C900295EF7 /* OCMock.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = OCMock.framework;
-			remoteRef = BC105FD024C5D0C900295EF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4AE33A091F5451AD0088DCA0 /* Resources */ = {
@@ -8730,36 +8392,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		4A1351F520281933000F5FD5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-watchOS";
-			targetProxy = 4A1351F420281933000F5FD5 /* PBXContainerItemProxy */;
-		};
-		4A1351F72028193F000F5FD5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-tvOS";
-			targetProxy = 4A1351F62028193F000F5FD5 /* PBXContainerItemProxy */;
-		};
-		4AA8ABFF20CEFC9A009306DD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-watchOS-Dynamic";
-			targetProxy = 4AA8ABFE20CEFC9A009306DD /* PBXContainerItemProxy */;
-		};
-		4AA8AC0820CEFCA2009306DD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-iOS-Dynamic";
-			targetProxy = 4AA8AC0720CEFCA2009306DD /* PBXContainerItemProxy */;
-		};
-		4AA8AC0A20CEFCAD009306DD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-tvOS-Dynamic";
-			targetProxy = 4AA8AC0920CEFCAD009306DD /* PBXContainerItemProxy */;
-		};
-		4ACBE7EB2151FCBF008DFAAF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-macOS";
-			targetProxy = 4ACBE7EA2151FCBF008DFAAF /* PBXContainerItemProxy */;
-		};
 		4AE33A2D1F5451B20088DCA0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
@@ -8776,22 +8408,6 @@
 			platformFilter = ios;
 			target = 81C3821B19CCA89E0066284A /* Parse-iOS */;
 			targetProxy = 8111674B1B8402DF003CB026 /* PBXContainerItemProxy */;
-		};
-		BC105FD324C5D0D600295EF7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = OCMock;
-			targetProxy = BC105FD224C5D0D600295EF7 /* PBXContainerItemProxy */;
-		};
-		BC105FD524C5D0E100295EF7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "OCMock iOS";
-			platformFilter = ios;
-			targetProxy = BC105FD424C5D0E100295EF7 /* PBXContainerItemProxy */;
-		};
-		BCAFF88B25A88C4F00B95DFC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bolts-iOS";
-			targetProxy = BCAFF88A25A88C4F00B95DFC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -9248,6 +8864,73 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mman/Bolts-ObjC";
+			requirement = {
+				branch = spm;
+				kind = branch;
+			};
+		};
+		BC619D0627D246F3004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/erikdoe/ocmock";
+			requirement = {
+				kind = revision;
+				revision = afd2c6924e8a36cb872bc475248b978f743c6050;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BC619D0227D244BB004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D0427D2467D004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D0727D246F3004FAFB5 /* OCMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0627D246F3004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */;
+			productName = OCMock;
+		};
+		BC619D0927D24765004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D0B27D247FD004FAFB5 /* OCMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0627D246F3004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */;
+			productName = OCMock;
+		};
+		BC619D0D27D2483A004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D0F27D24B62004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D1127D24B69004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D1327D24B72004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D0127D244BB004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 09D33641139C54930098E916 /* Project object */;
 }

--- a/Parse/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.m
+++ b/Parse/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.m
@@ -9,7 +9,7 @@
 
 #import "PFDefaultACLController.h"
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "PFACLPrivate.h"
 #import "PFAsyncTaskQueue.h"

--- a/Parse/Parse/Internal/BFTask+Private.h
+++ b/Parse/Parse/Internal/BFTask+Private.h
@@ -9,8 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "PFInternalUtils.h"
 

--- a/Parse/Parse/Internal/BFTask+Private.m
+++ b/Parse/Parse/Internal/BFTask+Private.m
@@ -9,8 +9,7 @@
 
 #import "BFTask+Private.h"
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "PFLogging.h"
 

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -10,7 +10,7 @@
 #import "PFURLSessionCommandRunner.h"
 #import "PFURLSessionCommandRunner_Private.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.m
@@ -10,7 +10,7 @@
 #import "PFURLSession.h"
 #import "PFURLSession_Private.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFCommandResult.h"

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.m
@@ -10,8 +10,7 @@
 #import "PFURLSessionDataTaskDelegate.h"
 #import "PFURLSessionDataTaskDelegate_Private.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
-#import <Bolts/BFCancellationToken.h>
+@import Bolts;
 
 #import "PFAssert.h"
 #import "PFMacros.h"

--- a/Parse/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
+++ b/Parse/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
@@ -9,9 +9,7 @@
 
 #import "PFURLSessionJSONDataTaskDelegate.h"
 
-#import <Bolts/BFCancellationToken.h>
-#import <Bolts/BFTask.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFConstants.h"

--- a/Parse/Parse/Internal/File/Controller/PFFileController.m
+++ b/Parse/Parse/Internal/File/Controller/PFFileController.m
@@ -9,8 +9,7 @@
 
 #import "PFFileController.h"
 
-#import <Bolts/BFCancellationToken.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFFileDataStream.h"

--- a/Parse/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -9,8 +9,7 @@
 
 #import "PFOfflineQueryLogic.h"
 
-#import <Bolts/BFTask.h>
-#import <Bolts/BFExecutor.h>
+@import Bolts;
 
 #import "PFACL.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -9,7 +9,7 @@
 
 #import "PFOfflineStore.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.m
+++ b/Parse/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.m
@@ -12,8 +12,7 @@
 
 #import <sqlite3.h>
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFFileManager.h"

--- a/Parse/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.m
+++ b/Parse/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.m
@@ -9,8 +9,7 @@
 
 #import "PFSQLiteDatabaseController.h"
 
-#import <Bolts/BFTask.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "PFAssert.h"
 #import "PFAsyncTaskQueue.h"

--- a/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -9,7 +9,7 @@
 
 #import "PFObjectBatchController.h"
 
-#import <Bolts/Bolts.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Parse/Internal/Object/PFObjectPrivate.h
@@ -11,7 +11,7 @@
 
 #import <Parse/PFObject.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "PFDecoder.h"
 #import "PFEncoder.h"

--- a/Parse/Parse/Internal/PFAsyncTaskQueue.h
+++ b/Parse/Parse/Internal/PFAsyncTaskQueue.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Parse/Internal/PFAsyncTaskQueue.m
+++ b/Parse/Parse/Internal/PFAsyncTaskQueue.m
@@ -9,7 +9,7 @@
 
 #import "PFAsyncTaskQueue.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 

--- a/Parse/Parse/Internal/PFCommandCache.m
+++ b/Parse/Parse/Internal/PFCommandCache.m
@@ -12,8 +12,7 @@
 #include <mach/mach_time.h>
 #include <sys/xattr.h>
 
-#import <Bolts/BFTask.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/PFEventuallyPin.m
+++ b/Parse/Parse/Internal/PFEventuallyPin.m
@@ -9,7 +9,7 @@
 
 #import "PFEventuallyPin.h"
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "PFAssert.h"
 #import "PFHTTPRequest.h"

--- a/Parse/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Parse/Internal/PFEventuallyQueue.m
@@ -10,8 +10,7 @@
 #import "PFEventuallyQueue.h"
 #import "PFEventuallyQueue_Private.h"
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/PFFileManager.m
+++ b/Parse/Parse/Internal/PFFileManager.m
@@ -9,7 +9,7 @@
 
 #import "PFFileManager.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/PFMemoryEventuallyQueue.m
+++ b/Parse/Parse/Internal/PFMemoryEventuallyQueue.m
@@ -10,8 +10,7 @@
 #import "PFMemoryEventuallyQueue.h"
 #import "PFEventuallyQueue_Private.h"
 
-#import <Bolts/BFTask.h>
-#import <Bolts/BFExecutor.h>
+@import Bolts;
 
 @interface PFMemoryEventuallyQueue () <PFEventuallyQueueSubclass> {
     dispatch_queue_t _dataAccessQueue;

--- a/Parse/Parse/Internal/PFPinningEventuallyQueue.m
+++ b/Parse/Parse/Internal/PFPinningEventuallyQueue.m
@@ -9,8 +9,7 @@
 
 #import "PFPinningEventuallyQueue.h"
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/PFTaskQueue.m
+++ b/Parse/Parse/Internal/PFTaskQueue.m
@@ -9,7 +9,7 @@
 
 #import "PFTaskQueue.h"
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 @interface PFTaskQueue ()
 

--- a/Parse/Parse/Internal/ParseManager.m
+++ b/Parse/Parse/Internal/ParseManager.m
@@ -9,7 +9,7 @@
 
 #import "ParseManager.h"
 
-#import <Bolts/BFExecutor.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAnalyticsController.h"

--- a/Parse/Parse/Internal/ParseModule.h
+++ b/Parse/Parse/Internal/ParseModule.h
@@ -8,7 +8,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Bolts/Bolts.h>
+@import Bolts;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Parse/Internal/Product/ProductsRequestHandler/PFProductsRequestHandler.m
+++ b/Parse/Parse/Internal/Product/ProductsRequestHandler/PFProductsRequestHandler.m
@@ -9,8 +9,7 @@
 
 #import "PFProductsRequestHandler.h"
 
-#import <Bolts/BFTask.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 @implementation PFProductsRequestResult
 

--- a/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
+++ b/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
@@ -11,7 +11,7 @@
 
 #import <StoreKit/StoreKit.h>
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/Query/Controller/PFCachedQueryController.m
+++ b/Parse/Parse/Internal/Query/Controller/PFCachedQueryController.m
@@ -9,7 +9,7 @@
 
 #import "PFCachedQueryController.h"
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "PFAssert.h"
 #import "PFCommandResult.h"

--- a/Parse/Parse/Internal/Query/Controller/PFQueryController.m
+++ b/Parse/Parse/Internal/Query/Controller/PFQueryController.m
@@ -9,7 +9,7 @@
 
 #import "PFQueryController.h"
 
-#import <Bolts/BFCancellationToken.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
@@ -9,7 +9,7 @@
 
 #import "PFAnonymousAuthenticationProvider.h"
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 NSString *const PFAnonymousUserAuthenticationType = @"anonymous";
 

--- a/Parse/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -9,7 +9,7 @@
 
 #import "PFCurrentUserController.h"
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAnonymousUtils_Private.h"

--- a/Parse/Parse/PFAnalytics.h
+++ b/Parse/Parse/PFAnalytics.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 

--- a/Parse/Parse/PFAnonymousUtils.h
+++ b/Parse/Parse/PFAnonymousUtils.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 #import <Parse/PFUser.h>

--- a/Parse/Parse/PFCloud.h
+++ b/Parse/Parse/PFCloud.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 

--- a/Parse/Parse/PFConfig.h
+++ b/Parse/Parse/PFConfig.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 

--- a/Parse/Parse/PFFileObject.h
+++ b/Parse/Parse/PFFileObject.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 

--- a/Parse/Parse/PFFileObject.m
+++ b/Parse/Parse/PFFileObject.m
@@ -10,7 +10,7 @@
 #import "PFFileObject.h"
 #import "PFFileObject_Private.h"
 
-#import <Bolts/BFCancellationTokenSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/PFFileUploadController.h
+++ b/Parse/Parse/PFFileUploadController.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 /**
  A policy interface for overriding the default upload behavior of uploading a PFFileObject

--- a/Parse/Parse/PFObject.h
+++ b/Parse/Parse/PFObject.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 

--- a/Parse/Parse/PFObject.m
+++ b/Parse/Parse/PFObject.m
@@ -17,7 +17,7 @@
 #import <objc/objc-sync.h>
 #import <objc/runtime.h>
 
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFACLPrivate.h"

--- a/Parse/Parse/PFPush.h
+++ b/Parse/Parse/PFPush.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 #import <Parse/PFInstallation.h>

--- a/Parse/Parse/PFQuery.h
+++ b/Parse/Parse/PFQuery.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 #import <Parse/PFGeoPoint.h>

--- a/Parse/Parse/PFQuery.m
+++ b/Parse/Parse/PFQuery.m
@@ -12,8 +12,7 @@
 #import "PFQuery+Synchronous.h"
 #import "PFQuery+Deprecated.h"
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFAssert.h"

--- a/Parse/Parse/PFRole.m
+++ b/Parse/Parse/PFRole.m
@@ -9,7 +9,7 @@
 
 #import "PFRole.h"
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import "PFAssert.h"
 #import "PFObject+Subclass.h"

--- a/Parse/Parse/PFSession.h
+++ b/Parse/Parse/PFSession.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFObject.h>
 #import <Parse/PFSubclassing.h>

--- a/Parse/Parse/PFUser.h
+++ b/Parse/Parse/PFUser.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts;
 
 #import <Parse/PFConstants.h>
 #import <Parse/PFObject.h>

--- a/Parse/Parse/PFUser.m
+++ b/Parse/Parse/PFUser.m
@@ -12,8 +12,7 @@
 #import "PFUser+Synchronous.h"
 #import "PFObject+Synchronous.h"
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFACLPrivate.h"

--- a/Parse/Tests/Other/OCMock/OCMock+Parse.m
+++ b/Parse/Tests/Other/OCMock/OCMock+Parse.m
@@ -9,7 +9,7 @@
 
 #import "OCMock+Parse.h"
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Parse/Tests/Other/TestCases/TestCase/PFTestCase.m
+++ b/Parse/Tests/Other/TestCases/TestCase/PFTestCase.m
@@ -9,7 +9,7 @@
 
 #import "PFTestCase.h"
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFTestSwizzlingUtilities.h"
 

--- a/Parse/Tests/Unit/AnalyticsUnitTests.m
+++ b/Parse/Tests/Unit/AnalyticsUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFAnalyticsController.h"
 #import "PFUnitTestCase.h"

--- a/Parse/Tests/Unit/AnonymousAuthenticationProviderTests.m
+++ b/Parse/Tests/Unit/AnonymousAuthenticationProviderTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFAnonymousAuthenticationProvider.h"
 #import "PFTestCase.h"

--- a/Parse/Tests/Unit/CloudCodeControllerTests.m
+++ b/Parse/Tests/Unit/CloudCodeControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "OCMock+Parse.h"
 #import "PFCloudCodeController.h"

--- a/Parse/Tests/Unit/ConfigControllerTests.m
+++ b/Parse/Tests/Unit/ConfigControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "OCMock+Parse.h"
 #import "PFCommandResult.h"

--- a/Parse/Tests/Unit/ConfigUnitTests.m
+++ b/Parse/Tests/Unit/ConfigUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFConfigController.h"
 #import "PFConfig_Private.h"

--- a/Parse/Tests/Unit/CurrentConfigControllerTests.m
+++ b/Parse/Tests/Unit/CurrentConfigControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFCommandResult.h"

--- a/Parse/Tests/Unit/DefaultACLControllerTests.m
+++ b/Parse/Tests/Unit/DefaultACLControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFACLPrivate.h"
 #import "PFCoreManager.h"

--- a/Parse/Tests/Unit/ExtensionDataSharingTests.m
+++ b/Parse/Tests/Unit/ExtensionDataSharingTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFExtensionDataSharingTestHelper.h"
 #import "PFFileManager.h"

--- a/Parse/Tests/Unit/FileControllerTests.m
+++ b/Parse/Tests/Unit/FileControllerTests.m
@@ -9,9 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
-@import Bolts.BFTask;
-@import Bolts.BFTaskCompletionSource;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Parse/Tests/Unit/FileUnitTests.m
+++ b/Parse/Tests/Unit/FileUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCoreManager.h"
 #import "PFFileController.h"

--- a/Parse/Tests/Unit/ObjectFilePersistenceControllerTests.m
+++ b/Parse/Tests/Unit/ObjectFilePersistenceControllerTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFObject.h"

--- a/Parse/Tests/Unit/ObjectOfflineTests.m
+++ b/Parse/Tests/Unit/ObjectOfflineTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFObject.h"
 #import "PFOfflineStore.h"

--- a/Parse/Tests/Unit/OfflineQueryControllerTests.m
+++ b/Parse/Tests/Unit/OfflineQueryControllerTests.m
@@ -9,8 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "OCMock+Parse.h"
 #import "PFCommandResult.h"

--- a/Parse/Tests/Unit/PurchaseControllerTests.m
+++ b/Parse/Tests/Unit/PurchaseControllerTests.m
@@ -11,8 +11,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFExecutor;
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Parse/Tests/Unit/PurchaseUnitTests.m
+++ b/Parse/Tests/Unit/PurchaseUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandRunning.h"
 #import "PFFileManager.h"

--- a/Parse/Tests/Unit/PushChannelsControllerTests.m
+++ b/Parse/Tests/Unit/PushChannelsControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCurrentInstallationController.h"
 #import "PFInstallation.h"

--- a/Parse/Tests/Unit/PushControllerTests.m
+++ b/Parse/Tests/Unit/PushControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Parse/Tests/Unit/PushUnitTests.m
+++ b/Parse/Tests/Unit/PushUnitTests.m
@@ -7,9 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <OCMock/OCMock.H>
+#import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCoreManager.h"
 #import "PFCurrentInstallationController.h"

--- a/Parse/Tests/Unit/QueryCachedControllerTests.m
+++ b/Parse/Tests/Unit/QueryCachedControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCachedQueryController.h"
 #import "PFCommandResult.h"

--- a/Parse/Tests/Unit/QueryControllerUnitTests.m
+++ b/Parse/Tests/Unit/QueryControllerUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFCommandResult.h"

--- a/Parse/Tests/Unit/QueryUnitTests.m
+++ b/Parse/Tests/Unit/QueryUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCoreManager.h"
 #import "PFMacros.h"

--- a/Parse/Tests/Unit/RoleUnitTests.m
+++ b/Parse/Tests/Unit/RoleUnitTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFMockURLProtocol.h"
 #import "PFRelation.h"

--- a/Parse/Tests/Unit/SQLiteDatabaseTest.m
+++ b/Parse/Tests/Unit/SQLiteDatabaseTest.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "BFTask+Private.h"
 #import "PFFileManager.h"

--- a/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Parse/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -9,8 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunningConstants.h"

--- a/Parse/Tests/Unit/URLSessionDataTaskDelegateTests.m
+++ b/Parse/Tests/Unit/URLSessionDataTaskDelegateTests.m
@@ -9,8 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFConstants.h"

--- a/Parse/Tests/Unit/URLSessionTests.m
+++ b/Parse/Tests/Unit/URLSessionTests.m
@@ -9,8 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFMacros.h"

--- a/Parse/Tests/Unit/URLSessionUploadTaskDelegateTests.m
+++ b/Parse/Tests/Unit/URLSessionUploadTaskDelegateTests.m
@@ -9,8 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-@import Bolts.BFCancellationTokenSource;
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFCommandResult.h"
 #import "PFTestCase.h"

--- a/Parse/Tests/Unit/UserControllerTests.m
+++ b/Parse/Tests/Unit/UserControllerTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "OCMock+Parse.h"
 #import "PFCommandResult.h"

--- a/ParseFacebookUtils/ParseFacebookUtils.xcodeproj/project.pbxproj
+++ b/ParseFacebookUtils/ParseFacebookUtils.xcodeproj/project.pbxproj
@@ -52,27 +52,35 @@
 		81FE7F7E1C17790400E6BD34 /* PFFacebookUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 813DFC851AB2510300F25A08 /* PFFacebookUtils.m */; };
 		81FE7F801C17790400E6BD34 /* PFFacebookPrivateUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 81E35FD31BAA6F8400348526 /* PFFacebookPrivateUtilities.m */; };
 		B9312D4123C4A290002D4A4C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EE9D23C497D2003E606E /* SystemConfiguration.framework */; platformFilter = ios; };
-		B9783177240D32260049C02B /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9783176240D32260049C02B /* OCMock.framework */; };
 		B9A7EEB823C49CB5003E606E /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EE9B23C497C3003E606E /* libsqlite3.tbd */; platformFilter = ios; };
 		B9A7EECC23C49DAE003E606E /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EECB23C49DAD003E606E /* CoreGraphics.framework */; platformFilter = ios; };
 		B9A7EED023C49F05003E606E /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EECF23C49F04003E606E /* Accelerate.framework */; platformFilter = ios; };
 		B9A7EED323C4A001003E606E /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EECD23C49DE3003E606E /* libc++.tbd */; platformFilter = ios; };
+		BC150F9427D1115200269B98 /* FacebookAEM in Frameworks */ = {isa = PBXBuildFile; productRef = BC150F9327D1115200269B98 /* FacebookAEM */; };
+		BC150F9627D1115200269B98 /* FacebookBasics in Frameworks */ = {isa = PBXBuildFile; productRef = BC150F9527D1115200269B98 /* FacebookBasics */; };
+		BC150F9827D1115200269B98 /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = BC150F9727D1115200269B98 /* FacebookCore */; };
+		BC150F9A27D1115200269B98 /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BC150F9927D1115200269B98 /* FacebookLogin */; };
+		BC150F9C27D1115200269B98 /* FacebookShare in Frameworks */ = {isa = PBXBuildFile; productRef = BC150F9B27D1115200269B98 /* FacebookShare */; };
 		BC4E4E212739860100B8C690 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EE9723C497AC003E606E /* AudioToolbox.framework */; };
 		BC4E4E222739860100B8C690 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A7EE9723C497AC003E606E /* AudioToolbox.framework */; platformFilter = maccatalyst; };
-		BCCC20F6271F36CB003C9D03 /* FBSDKLoginKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F3271F36CB003C9D03 /* FBSDKLoginKit.xcframework */; };
-		BCCC20F7271F36CB003C9D03 /* FBSDKLoginKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F3271F36CB003C9D03 /* FBSDKLoginKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BCCC20F8271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F4271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework */; };
-		BCCC20F9271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F4271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BCCC20FA271F36CC003C9D03 /* FBSDKCoreKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F5271F36CB003C9D03 /* FBSDKCoreKit.xcframework */; };
-		BCCC20FB271F36CC003C9D03 /* FBSDKCoreKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F5271F36CB003C9D03 /* FBSDKCoreKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BCCC20FC271F36D4003C9D03 /* FBSDKCoreKit_Basics.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F4271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework */; };
-		BCCC20FD271F36D4003C9D03 /* FBSDKCoreKit_Basics.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F4271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BCCC20FE271F36D4003C9D03 /* FBSDKCoreKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F5271F36CB003C9D03 /* FBSDKCoreKit.xcframework */; };
-		BCCC20FF271F36D4003C9D03 /* FBSDKCoreKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F5271F36CB003C9D03 /* FBSDKCoreKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BCCC2100271F36D4003C9D03 /* FBSDKLoginKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F3271F36CB003C9D03 /* FBSDKLoginKit.xcframework */; };
-		BCCC2101271F36D4003C9D03 /* FBSDKLoginKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC20F3271F36CB003C9D03 /* FBSDKLoginKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BCCC2103271F375D003C9D03 /* FBSDKTVOSKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC2102271F375D003C9D03 /* FBSDKTVOSKit.xcframework */; };
-		BCCC2104271F375D003C9D03 /* FBSDKTVOSKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCCC2102271F375D003C9D03 /* FBSDKTVOSKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BC619CE127D11A32004FAFB5 /* FacebookAEM in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CE027D11A32004FAFB5 /* FacebookAEM */; };
+		BC619CE327D11A32004FAFB5 /* FacebookBasics in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CE227D11A32004FAFB5 /* FacebookBasics */; };
+		BC619CE527D11A32004FAFB5 /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CE427D11A32004FAFB5 /* FacebookCore */; };
+		BC619CE727D11A32004FAFB5 /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CE627D11A32004FAFB5 /* FacebookLogin */; };
+		BC619CE927D11A32004FAFB5 /* FacebookShare in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CE827D11A32004FAFB5 /* FacebookShare */; };
+		BC619CEB27D11A32004FAFB5 /* FacebookTV in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CEA27D11A32004FAFB5 /* FacebookTV */; };
+		BC619CED27D11A4F004FAFB5 /* FacebookAEM in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CEC27D11A4F004FAFB5 /* FacebookAEM */; };
+		BC619CEF27D11A4F004FAFB5 /* FacebookBasics in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CEE27D11A4F004FAFB5 /* FacebookBasics */; };
+		BC619CF127D11A4F004FAFB5 /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CF027D11A4F004FAFB5 /* FacebookCore */; };
+		BC619CF327D11A4F004FAFB5 /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CF227D11A4F004FAFB5 /* FacebookLogin */; };
+		BC619CF527D11A4F004FAFB5 /* FacebookShare in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CF427D11A4F004FAFB5 /* FacebookShare */; };
+		BC619CF727D11A4F004FAFB5 /* FacebookTV in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CF627D11A4F004FAFB5 /* FacebookTV */; };
+		BC619CFA27D12BB9004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619CF927D12BB9004FAFB5 /* OCMock */; };
+		BCBD121127D108E000208265 /* FacebookAEM in Frameworks */ = {isa = PBXBuildFile; productRef = BCBD121027D108E000208265 /* FacebookAEM */; };
+		BCBD121327D108E000208265 /* FacebookBasics in Frameworks */ = {isa = PBXBuildFile; productRef = BCBD121227D108E000208265 /* FacebookBasics */; };
+		BCBD121527D108E000208265 /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = BCBD121427D108E000208265 /* FacebookCore */; };
+		BCBD121727D108E000208265 /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BCBD121627D108E000208265 /* FacebookLogin */; };
+		BCBD121927D108E000208265 /* FacebookShare in Frameworks */ = {isa = PBXBuildFile; productRef = BCBD121827D108E000208265 /* FacebookShare */; };
 		F5E3229B1B549C2C00E319F9 /* FacebookAuthenticationProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E3229A1B549C2C00E319F9 /* FacebookAuthenticationProviderTests.m */; platformFilter = ios; };
 		F5E3229D1B5583A800E319F9 /* FacebookUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E3229C1B5583A800E319F9 /* FacebookUtilsTests.m */; platformFilter = ios; };
 /* End PBXBuildFile section */
@@ -183,90 +191,6 @@
 			remoteGlobalIDString = D2AAC07D0554694100DB518D;
 			remoteInfo = "ParseFacebookUtilsV4-iOS";
 		};
-		BC666EEB26FE4ED30019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9D2697471A5DF40700143BFC;
-			remoteInfo = FBSDKCoreKit;
-		};
-		BC666EED26FE4ED30019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81B71DA31D19C87400933E93;
-			remoteInfo = "FBSDKCoreKit-Dynamic";
-		};
-		BC666EEF26FE4ED30019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9D2697521A5DF40700143BFC;
-			remoteInfo = FBSDKCoreKitTests;
-		};
-		BC666EF126FE4ED30019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9DB0FA731BC1CA71005EB8B1;
-			remoteInfo = FBSDKCoreKit_TV;
-		};
-		BC666EF326FE4ED30019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 814AC8571D1B528900D61E6C;
-			remoteInfo = "FBSDKCoreKit_TV-Dynamic";
-		};
-		BC666F1C26FE4EE90019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9D9DB8D91A114E500086167B;
-			remoteInfo = FBSDKLoginKit;
-		};
-		BC666F1E26FE4EE90019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 818EB4411D1A283100252851;
-			remoteInfo = "FBSDKLoginKit-Dynamic";
-		};
-		BC666F2026FE4EE90019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9D9DB8E41A114E500086167B;
-			remoteInfo = FBSDKLoginKitTests;
-		};
-		BC666F2226FE4EE90019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0B9DBF2C207C05CD00662776;
-			remoteInfo = FBSDKLoginKit_TV;
-		};
-		BC666F2426FE4EE90019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0B9DBF52207C07C600662776;
-			remoteInfo = "FBSDKLoginKit_TV-Dynamic";
-		};
-		BC666F2C26FE52280019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 9D9DB8D81A114E500086167B;
-			remoteInfo = FBSDKLoginKit;
-		};
-		BC666F2E26FE52280019EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 9D2697461A5DF40700143BFC;
-			remoteInfo = FBSDKCoreKit;
-		};
 		BCC0590D2430CE8C00981B02 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4A1350412027EA26000F5FD5 /* Parse.xcodeproj */;
@@ -283,9 +207,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BCCC20FF271F36D4003C9D03 /* FBSDKCoreKit.xcframework in Embed Frameworks */,
-				BCCC2101271F36D4003C9D03 /* FBSDKLoginKit.xcframework in Embed Frameworks */,
-				BCCC20FD271F36D4003C9D03 /* FBSDKCoreKit_Basics.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -296,10 +217,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BCCC20FB271F36CC003C9D03 /* FBSDKCoreKit.xcframework in Embed Frameworks */,
-				BCCC2104271F375D003C9D03 /* FBSDKTVOSKit.xcframework in Embed Frameworks */,
-				BCCC20F7271F36CB003C9D03 /* FBSDKLoginKit.xcframework in Embed Frameworks */,
-				BCCC20F9271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -347,7 +264,6 @@
 		81EDD4B41B58AC7D002F69C0 /* ParseFacebookUtilsV4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseFacebookUtilsV4.h; sourceTree = "<group>"; };
 		81FE7F721C1778FC00E6BD34 /* ParseFacebookUtilsV4-tvOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ParseFacebookUtilsV4-tvOS.xcconfig"; sourceTree = "<group>"; };
 		81FE7F8B1C17790400E6BD34 /* ParseFacebookUtilsV4.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseFacebookUtilsV4.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B9783176240D32260049C02B /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9A7EE9723C497AC003E606E /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		B9A7EE9923C497B2003E606E /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		B9A7EE9B23C497C3003E606E /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -359,12 +275,6 @@
 		B9A7EECD23C49DE3003E606E /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		B9A7EECF23C49F04003E606E /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		BC4E4E1C2739853300B8C690 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.0.sdk/System/Library/Frameworks/AudioToolbox.framework; sourceTree = DEVELOPER_DIR; };
-		BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FBSDKCoreKit.xcodeproj; path = "../Carthage/Checkouts/facebook-ios-sdk/FBSDKCoreKit/FBSDKCoreKit.xcodeproj"; sourceTree = "<group>"; };
-		BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FBSDKLoginKit.xcodeproj; path = "../Carthage/Checkouts/facebook-ios-sdk/FBSDKLoginKit/FBSDKLoginKit.xcodeproj"; sourceTree = "<group>"; };
-		BCCC20F3271F36CB003C9D03 /* FBSDKLoginKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FBSDKLoginKit.xcframework; path = ../Carthage/Build/FBSDKLoginKit.xcframework; sourceTree = "<group>"; };
-		BCCC20F4271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FBSDKCoreKit_Basics.xcframework; path = ../Carthage/Build/FBSDKCoreKit_Basics.xcframework; sourceTree = "<group>"; };
-		BCCC20F5271F36CB003C9D03 /* FBSDKCoreKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FBSDKCoreKit.xcframework; path = ../Carthage/Build/FBSDKCoreKit.xcframework; sourceTree = "<group>"; };
-		BCCC2102271F375D003C9D03 /* FBSDKTVOSKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FBSDKTVOSKit.xcframework; path = ../Carthage/Build/FBSDKTVOSKit.xcframework; sourceTree = "<group>"; };
 		D2AAC07E0554694100DB518D /* ParseFacebookUtilsV4.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseFacebookUtilsV4.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F52CD64A1B5838560051AB86 /* ParseFacebookUtilsV4-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ParseFacebookUtilsV4-iOS.xcconfig"; sourceTree = "<group>"; };
 		F52CD64B1B5838620051AB86 /* ParseFacebookUtilsV4-UnitTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ParseFacebookUtilsV4-UnitTests.xcconfig"; sourceTree = "<group>"; };
@@ -379,9 +289,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCCC20FE271F36D4003C9D03 /* FBSDKCoreKit.xcframework in Frameworks */,
-				BCCC2100271F36D4003C9D03 /* FBSDKLoginKit.xcframework in Frameworks */,
-				BCCC20FC271F36D4003C9D03 /* FBSDKCoreKit_Basics.xcframework in Frameworks */,
+				BC150F9A27D1115200269B98 /* FacebookLogin in Frameworks */,
+				BC150F9427D1115200269B98 /* FacebookAEM in Frameworks */,
+				BC150F9827D1115200269B98 /* FacebookCore in Frameworks */,
+				BC150F9C27D1115200269B98 /* FacebookShare in Frameworks */,
+				BC150F9627D1115200269B98 /* FacebookBasics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -389,10 +301,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCCC20FA271F36CC003C9D03 /* FBSDKCoreKit.xcframework in Frameworks */,
-				BCCC2103271F375D003C9D03 /* FBSDKTVOSKit.xcframework in Frameworks */,
-				BCCC20F6271F36CB003C9D03 /* FBSDKLoginKit.xcframework in Frameworks */,
-				BCCC20F8271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework in Frameworks */,
+				BC619CF327D11A4F004FAFB5 /* FacebookLogin in Frameworks */,
+				BC619CED27D11A4F004FAFB5 /* FacebookAEM in Frameworks */,
+				BC619CF727D11A4F004FAFB5 /* FacebookTV in Frameworks */,
+				BC619CF127D11A4F004FAFB5 /* FacebookCore in Frameworks */,
+				BC619CF527D11A4F004FAFB5 /* FacebookShare in Frameworks */,
+				BC619CEF27D11A4F004FAFB5 /* FacebookBasics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -400,8 +314,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B9783177240D32260049C02B /* OCMock.framework in Frameworks */,
 				B9312D4123C4A290002D4A4C /* SystemConfiguration.framework in Frameworks */,
+				BC619CFA27D12BB9004FAFB5 /* OCMock in Frameworks */,
 				B9A7EED323C4A001003E606E /* libc++.tbd in Frameworks */,
 				B9A7EED023C49F05003E606E /* Accelerate.framework in Frameworks */,
 				BC4E4E212739860100B8C690 /* AudioToolbox.framework in Frameworks */,
@@ -414,6 +328,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619CE727D11A32004FAFB5 /* FacebookLogin in Frameworks */,
+				BC619CE127D11A32004FAFB5 /* FacebookAEM in Frameworks */,
+				BC619CEB27D11A32004FAFB5 /* FacebookTV in Frameworks */,
+				BC619CE527D11A32004FAFB5 /* FacebookCore in Frameworks */,
+				BC619CE927D11A32004FAFB5 /* FacebookShare in Frameworks */,
+				BC619CE327D11A32004FAFB5 /* FacebookBasics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -421,6 +341,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCBD121727D108E000208265 /* FacebookLogin in Frameworks */,
+				BCBD121127D108E000208265 /* FacebookAEM in Frameworks */,
+				BCBD121527D108E000208265 /* FacebookCore in Frameworks */,
+				BCBD121927D108E000208265 /* FacebookShare in Frameworks */,
+				BCBD121327D108E000208265 /* FacebookBasics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -466,13 +391,6 @@
 			isa = PBXGroup;
 			children = (
 				BC4E4E1C2739853300B8C690 /* AudioToolbox.framework */,
-				BCCC2102271F375D003C9D03 /* FBSDKTVOSKit.xcframework */,
-				BCCC20F4271F36CB003C9D03 /* FBSDKCoreKit_Basics.xcframework */,
-				BCCC20F5271F36CB003C9D03 /* FBSDKCoreKit.xcframework */,
-				BCCC20F3271F36CB003C9D03 /* FBSDKLoginKit.xcframework */,
-				BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */,
-				BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */,
-				B9783176240D32260049C02B /* OCMock.framework */,
 				B9A7EECF23C49F04003E606E /* Accelerate.framework */,
 				B9A7EECD23C49DE3003E606E /* libc++.tbd */,
 				B9A7EECB23C49DAD003E606E /* CoreGraphics.framework */,
@@ -663,30 +581,6 @@
 			path = tvOS;
 			sourceTree = "<group>";
 		};
-		BC666EDA26FE4ED30019EEF8 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				BC666EEC26FE4ED30019EEF8 /* FBSDKCoreKit.framework */,
-				BC666EEE26FE4ED30019EEF8 /* FBSDKCoreKit.framework */,
-				BC666EF026FE4ED30019EEF8 /* FBSDKCoreKitTests.xctest */,
-				BC666EF226FE4ED30019EEF8 /* FBSDKCoreKit.framework */,
-				BC666EF426FE4ED30019EEF8 /* FBSDKCoreKit.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		BC666F1326FE4EE90019EEF8 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				BC666F1D26FE4EE90019EEF8 /* FBSDKLoginKit.framework */,
-				BC666F1F26FE4EE90019EEF8 /* FBSDKLoginKit.framework */,
-				BC666F2126FE4EE90019EEF8 /* FBSDKLoginKitTests.xctest */,
-				BC666F2326FE4EE90019EEF8 /* FBSDKLoginKit.framework */,
-				BC666F2526FE4EE90019EEF8 /* FBSDKLoginKit.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		F52CD63A1B58383C0051AB86 /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
@@ -774,7 +668,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4AAEAA72200C020E00AA7479 /* Build configuration list for PBXNativeTarget "ParseFacebookUtilsV4-iOS-Dynamic" */;
 			buildPhases = (
-				4A13525320282699000F5FD5 /* Cleanup Vendored Static lib */,
 				4AAEAA5D200C020E00AA7479 /* Generate Localizable Strings */,
 				4AAEAA5E200C020E00AA7479 /* Headers */,
 				4AAEAA66200C020E00AA7479 /* Sources */,
@@ -785,10 +678,20 @@
 			buildRules = (
 			);
 			dependencies = (
+				BC619CCF27D1161E004FAFB5 /* PBXTargetDependency */,
+				BC619CD127D1161E004FAFB5 /* PBXTargetDependency */,
+				BC619CD327D1161E004FAFB5 /* PBXTargetDependency */,
+				BC619CD527D1161E004FAFB5 /* PBXTargetDependency */,
+				BC619CD727D1161E004FAFB5 /* PBXTargetDependency */,
 				BCC0590E2430CE8C00981B02 /* PBXTargetDependency */,
 			);
 			name = "ParseFacebookUtilsV4-iOS-Dynamic";
 			packageProductDependencies = (
+				BC150F9327D1115200269B98 /* FacebookAEM */,
+				BC150F9527D1115200269B98 /* FacebookBasics */,
+				BC150F9727D1115200269B98 /* FacebookCore */,
+				BC150F9927D1115200269B98 /* FacebookLogin */,
+				BC150F9B27D1115200269B98 /* FacebookShare */,
 			);
 			productName = Breakpad;
 			productReference = 4AAEAA75200C020E00AA7479 /* ParseFacebookUtilsV4.framework */;
@@ -798,7 +701,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4AAEAA8D200C022300AA7479 /* Build configuration list for PBXNativeTarget "ParseFacebookUtilsV4-tvOS-Dynamic" */;
 			buildPhases = (
-				4A135254202826D8000F5FD5 /* ShellScript */,
 				4AAEAA79200C022300AA7479 /* Generate Localizable Strings */,
 				4AAEAA7A200C022300AA7479 /* Headers */,
 				4AAEAA81200C022300AA7479 /* Sources */,
@@ -813,6 +715,12 @@
 			);
 			name = "ParseFacebookUtilsV4-tvOS-Dynamic";
 			packageProductDependencies = (
+				BC619CEC27D11A4F004FAFB5 /* FacebookAEM */,
+				BC619CEE27D11A4F004FAFB5 /* FacebookBasics */,
+				BC619CF027D11A4F004FAFB5 /* FacebookCore */,
+				BC619CF227D11A4F004FAFB5 /* FacebookLogin */,
+				BC619CF427D11A4F004FAFB5 /* FacebookShare */,
+				BC619CF627D11A4F004FAFB5 /* FacebookTV */,
 			);
 			productName = Breakpad;
 			productReference = 4AAEAA90200C022300AA7479 /* ParseFacebookUtilsV4.framework */;
@@ -833,6 +741,9 @@
 				B9A7EE7423C49272003E606E /* PBXTargetDependency */,
 			);
 			name = "ParseFacebookUtilsV4-UnitTests";
+			packageProductDependencies = (
+				BC619CF927D12BB9004FAFB5 /* OCMock */,
+			);
 			productName = "ParseFacebookUtilsV4-Tests";
 			productReference = 81CB98C61AB7905D00136FA5 /* ParseFacebookUtilsV4-UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -841,7 +752,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 81FE7F881C17790400E6BD34 /* Build configuration list for PBXNativeTarget "ParseFacebookUtilsV4-tvOS" */;
 			buildPhases = (
-				4A1351A5202817C7000F5FD5 /* Fetch Latest Dependencies */,
 				81FE7F751C17790400E6BD34 /* Generate Localizable Strings */,
 				81FE7F761C17790400E6BD34 /* Headers */,
 				81FE7F7D1C17790400E6BD34 /* Sources */,
@@ -854,6 +764,14 @@
 				4A1350A72027F4B2000F5FD5 /* PBXTargetDependency */,
 			);
 			name = "ParseFacebookUtilsV4-tvOS";
+			packageProductDependencies = (
+				BC619CE027D11A32004FAFB5 /* FacebookAEM */,
+				BC619CE227D11A32004FAFB5 /* FacebookBasics */,
+				BC619CE427D11A32004FAFB5 /* FacebookCore */,
+				BC619CE627D11A32004FAFB5 /* FacebookLogin */,
+				BC619CE827D11A32004FAFB5 /* FacebookShare */,
+				BC619CEA27D11A32004FAFB5 /* FacebookTV */,
+			);
 			productName = Breakpad;
 			productReference = 81FE7F8B1C17790400E6BD34 /* ParseFacebookUtilsV4.framework */;
 			productType = "com.apple.product-type.framework";
@@ -862,7 +780,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB921E08733DC00010E9CD /* Build configuration list for PBXNativeTarget "ParseFacebookUtilsV4-iOS" */;
 			buildPhases = (
-				4A1351B220281814000F5FD5 /* Fetch Latest Dependencies */,
 				81B3F2291AC9CA2600A92677 /* Generate Localizable Strings */,
 				D2AAC07A0554694100DB518D /* Headers */,
 				D2AAC07B0554694100DB518D /* Sources */,
@@ -873,11 +790,14 @@
 			);
 			dependencies = (
 				4A1350922027F4A9000F5FD5 /* PBXTargetDependency */,
-				BC666F2D26FE52280019EEF8 /* PBXTargetDependency */,
-				BC666F2F26FE52280019EEF8 /* PBXTargetDependency */,
 			);
 			name = "ParseFacebookUtilsV4-iOS";
 			packageProductDependencies = (
+				BCBD121027D108E000208265 /* FacebookAEM */,
+				BCBD121227D108E000208265 /* FacebookBasics */,
+				BCBD121427D108E000208265 /* FacebookCore */,
+				BCBD121627D108E000208265 /* FacebookLogin */,
+				BCBD121827D108E000208265 /* FacebookShare */,
 			);
 			productName = Breakpad;
 			productReference = D2AAC07E0554694100DB518D /* ParseFacebookUtilsV4.framework */;
@@ -940,18 +860,12 @@
 			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* Breakpad */;
 			packageReferences = (
+				BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */,
+				BC619CF827D12BB9004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */,
 			);
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
 			projectReferences = (
-				{
-					ProductGroup = BC666EDA26FE4ED30019EEF8 /* Products */;
-					ProjectRef = BC666ED926FE4ED30019EEF8 /* FBSDKCoreKit.xcodeproj */;
-				},
-				{
-					ProductGroup = BC666F1326FE4EE90019EEF8 /* Products */;
-					ProjectRef = BC666F1226FE4EE90019EEF8 /* FBSDKLoginKit.xcodeproj */;
-				},
 				{
 					ProductGroup = 4A1350422027EA26000F5FD5 /* Products */;
 					ProjectRef = 4A1350412027EA26000F5FD5 /* Parse.xcodeproj */;
@@ -1040,76 +954,6 @@
 			remoteRef = 4A1350602027EA26000F5FD5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		BC666EEC26FE4ED30019EEF8 /* FBSDKCoreKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKCoreKit.framework;
-			remoteRef = BC666EEB26FE4ED30019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666EEE26FE4ED30019EEF8 /* FBSDKCoreKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKCoreKit.framework;
-			remoteRef = BC666EED26FE4ED30019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666EF026FE4ED30019EEF8 /* FBSDKCoreKitTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = FBSDKCoreKitTests.xctest;
-			remoteRef = BC666EEF26FE4ED30019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666EF226FE4ED30019EEF8 /* FBSDKCoreKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKCoreKit.framework;
-			remoteRef = BC666EF126FE4ED30019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666EF426FE4ED30019EEF8 /* FBSDKCoreKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKCoreKit.framework;
-			remoteRef = BC666EF326FE4ED30019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666F1D26FE4EE90019EEF8 /* FBSDKLoginKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKLoginKit.framework;
-			remoteRef = BC666F1C26FE4EE90019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666F1F26FE4EE90019EEF8 /* FBSDKLoginKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKLoginKit.framework;
-			remoteRef = BC666F1E26FE4EE90019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666F2126FE4EE90019EEF8 /* FBSDKLoginKitTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = FBSDKLoginKitTests.xctest;
-			remoteRef = BC666F2026FE4EE90019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666F2326FE4EE90019EEF8 /* FBSDKLoginKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKLoginKit.framework;
-			remoteRef = BC666F2226FE4EE90019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		BC666F2526FE4EE90019EEF8 /* FBSDKLoginKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = FBSDKLoginKit.framework;
-			remoteRef = BC666F2426FE4EE90019EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -1158,61 +1002,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4A1351A5202817C7000F5FD5 /* Fetch Latest Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Fetch Latest Dependencies";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ ! -d $SRCROOT/Vendor/tvOS ]; then\nmkdir $SRCROOT/Vendor/tvOS\nfi\n\ncd $SRCROOT/Vendor/tvOS\n\nif [[ ! -d \"FBSDKCoreKit.framework\" || ! -d \"FBSDKTVOSKit.framework\" ]]; then\nARCHIVE_NAME=FBSDK.zip\n\nARCHIVE_URL=\"https://github.com/facebook/facebook-ios-sdk/releases/download/v11.0.1/FacebookSDK_Static.zip\"\ncurl -Lk $ARCHIVE_URL -o $ARCHIVE_NAME\n\nunzip $ARCHIVE_NAME -d fbsdk\nmv fbsdk/tv/FBSDKCoreKit.framework .\nmv fbsdk/tv/FBSDKTVOSKit.framework .\n\nrm $ARCHIVE_NAME\nrm -r fbsdk\nfi\n";
-		};
-		4A1351B220281814000F5FD5 /* Fetch Latest Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Fetch Latest Dependencies";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ ! -d $SRCROOT/Vendor ]; then\nmkdir $SRCROOT/Vendor\nfi\n\ncd $SRCROOT/Vendor\n\nif [[ ! -d \"FBSDKCoreKit.framework\" || ! -d \"FBSDKLoginKit.framework\" ]]; then\nARCHIVE_NAME=FBSDK.zip\n\nARCHIVE_URL=\"https://github.com/facebook/facebook-ios-sdk/releases/download/v11.0.1/FacebookSDK_Static.zip\"\ncurl -Lk $ARCHIVE_URL -o $ARCHIVE_NAME\n\nunzip $ARCHIVE_NAME -d fbsdk\nmv fbsdk/FBSDKCoreKit.framework .\nmv fbsdk/FBSDKLoginKit.framework .\n\nrm $ARCHIVE_NAME\nrm -r fbsdk\nfi\n";
-		};
-		4A13525320282699000F5FD5 /* Cleanup Vendored Static lib */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Cleanup Vendored Static lib";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rm -rf $SRCROOT/Vendor/*.framework\n";
-		};
-		4A135254202826D8000F5FD5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rm -rf $SRCROOT/Vendor/*.framework\n";
-		};
 		4AAEAA5D200C020E00AA7479 /* Generate Localizable Strings */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1362,15 +1151,25 @@
 			target = D2AAC07D0554694100DB518D /* ParseFacebookUtilsV4-iOS */;
 			targetProxy = B9A7EEB623C49C89003E606E /* PBXContainerItemProxy */;
 		};
-		BC666F2D26FE52280019EEF8 /* PBXTargetDependency */ = {
+		BC619CCF27D1161E004FAFB5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = FBSDKLoginKit;
-			targetProxy = BC666F2C26FE52280019EEF8 /* PBXContainerItemProxy */;
+			productRef = BC619CCE27D1161E004FAFB5 /* FacebookAEM */;
 		};
-		BC666F2F26FE52280019EEF8 /* PBXTargetDependency */ = {
+		BC619CD127D1161E004FAFB5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = FBSDKCoreKit;
-			targetProxy = BC666F2E26FE52280019EEF8 /* PBXContainerItemProxy */;
+			productRef = BC619CD027D1161E004FAFB5 /* FacebookBasics */;
+		};
+		BC619CD327D1161E004FAFB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = BC619CD227D1161E004FAFB5 /* FacebookCore */;
+		};
+		BC619CD527D1161E004FAFB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = BC619CD427D1161E004FAFB5 /* FacebookLogin */;
+		};
+		BC619CD727D1161E004FAFB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = BC619CD627D1161E004FAFB5 /* FacebookShare */;
 		};
 		BCC0590E2430CE8C00981B02 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1627,6 +1426,168 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BC619CF827D12BB9004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/erikdoe/ocmock";
+			requirement = {
+				kind = revision;
+				revision = afd2c6924e8a36cb872bc475248b978f743c6050;
+			};
+		};
+		BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 13.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BC150F9327D1115200269B98 /* FacebookAEM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookAEM;
+		};
+		BC150F9527D1115200269B98 /* FacebookBasics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookBasics;
+		};
+		BC150F9727D1115200269B98 /* FacebookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookCore;
+		};
+		BC150F9927D1115200269B98 /* FacebookLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookLogin;
+		};
+		BC150F9B27D1115200269B98 /* FacebookShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookShare;
+		};
+		BC619CCE27D1161E004FAFB5 /* FacebookAEM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookAEM;
+		};
+		BC619CD027D1161E004FAFB5 /* FacebookBasics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookBasics;
+		};
+		BC619CD227D1161E004FAFB5 /* FacebookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookCore;
+		};
+		BC619CD427D1161E004FAFB5 /* FacebookLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookLogin;
+		};
+		BC619CD627D1161E004FAFB5 /* FacebookShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookShare;
+		};
+		BC619CE027D11A32004FAFB5 /* FacebookAEM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookAEM;
+		};
+		BC619CE227D11A32004FAFB5 /* FacebookBasics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookBasics;
+		};
+		BC619CE427D11A32004FAFB5 /* FacebookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookCore;
+		};
+		BC619CE627D11A32004FAFB5 /* FacebookLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookLogin;
+		};
+		BC619CE827D11A32004FAFB5 /* FacebookShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookShare;
+		};
+		BC619CEA27D11A32004FAFB5 /* FacebookTV */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookTV;
+		};
+		BC619CEC27D11A4F004FAFB5 /* FacebookAEM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookAEM;
+		};
+		BC619CEE27D11A4F004FAFB5 /* FacebookBasics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookBasics;
+		};
+		BC619CF027D11A4F004FAFB5 /* FacebookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookCore;
+		};
+		BC619CF227D11A4F004FAFB5 /* FacebookLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookLogin;
+		};
+		BC619CF427D11A4F004FAFB5 /* FacebookShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookShare;
+		};
+		BC619CF627D11A4F004FAFB5 /* FacebookTV */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookTV;
+		};
+		BC619CF927D12BB9004FAFB5 /* OCMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619CF827D12BB9004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */;
+			productName = OCMock;
+		};
+		BCBD121027D108E000208265 /* FacebookAEM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookAEM;
+		};
+		BCBD121227D108E000208265 /* FacebookBasics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookBasics;
+		};
+		BCBD121427D108E000208265 /* FacebookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookCore;
+		};
+		BCBD121627D108E000208265 /* FacebookLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookLogin;
+		};
+		BCBD121827D108E000208265 /* FacebookShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCBD120F27D108E000208265 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookShare;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 0867D690FE84028FC02AAC07 /* Project object */;
 }

--- a/ParseFacebookUtils/ParseFacebookUtils.xcodeproj/project.pbxproj
+++ b/ParseFacebookUtils/ParseFacebookUtils.xcodeproj/project.pbxproj
@@ -414,8 +414,8 @@
 				4A1350532027EA26000F5FD5 /* ParseUnitTests-iOS.xctest */,
 				4A1350552027EA26000F5FD5 /* Parse.framework */,
 				4A1350572027EA26000F5FD5 /* ParseUnitTests-macOS.xctest */,
-				4A1350592027EA26000F5FD5 /* Parse.framework */,
-				4A13505B2027EA26000F5FD5 /* Parse.framework */,
+				4A1350592027EA26000F5FD5 /* .framework */,
+				4A13505B2027EA26000F5FD5 /* .framework */,
 				4A13505D2027EA26000F5FD5 /* Parse.framework */,
 				4A13505F2027EA26000F5FD5 /* Parse.framework */,
 				4A1350612027EA26000F5FD5 /* ParseUnitTests-iOS-host.app */,
@@ -919,17 +919,17 @@
 			remoteRef = 4A1350562027EA26000F5FD5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4A1350592027EA26000F5FD5 /* Parse.framework */ = {
+		4A1350592027EA26000F5FD5 /* .framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			path = Parse.framework;
+			path = .framework;
 			remoteRef = 4A1350582027EA26000F5FD5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4A13505B2027EA26000F5FD5 /* Parse.framework */ = {
+		4A13505B2027EA26000F5FD5 /* .framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			path = Parse.framework;
+			path = .framework;
 			remoteRef = 4A13505A2027EA26000F5FD5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};

--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/AuthenticationProvider/iOS/PFFacebookMobileAuthenticationProvider.h
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/AuthenticationProvider/iOS/PFFacebookMobileAuthenticationProvider.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <FBSDKLoginKit/FBSDKLoginManager.h>
+@import FBSDKLoginKit;
 
 #import <Parse/PFConstants.h>
 #import <Parse/PFUser.h>

--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.h
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.h
@@ -12,7 +12,7 @@
 
 #import <Bolts/BFExecutor.h>
 #import <Bolts/BFTask.h>
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
+@import FBSDKCoreKit;
 
 #import <Parse/PFConstants.h>
 

--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.m
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.m
@@ -51,7 +51,7 @@
     }
 
 NSDate *expirationDate = [[NSDateFormatter pffb_preciseDateFormatter] dateFromString:expirationDateString];
-    FBSDKAccessToken *token = [[FBSDKAccessToken alloc] initWithTokenString: accessToken permissions:@[] declinedPermissions:@[] expiredPermissions:@[] appID: [FBSDKSettings appID] userID: authData[@"id"] expirationDate: expirationDate refreshDate: nil dataAccessExpirationDate: nil];
+    FBSDKAccessToken *token = [[FBSDKAccessToken alloc] initWithTokenString: accessToken permissions:@[] declinedPermissions:@[] expiredPermissions:@[] appID: [[FBSDKSettings sharedSettings] appID] userID: authData[@"id"] expirationDate: expirationDate refreshDate: nil dataAccessExpirationDate: nil];
     return token;
 }
 

--- a/ParseTwitterUtils/ParseTwitterUtils.xcodeproj/project.pbxproj
+++ b/ParseTwitterUtils/ParseTwitterUtils.xcodeproj/project.pbxproj
@@ -58,94 +58,13 @@
 		81ECACCD1D1E14E000FA7673 /* PFTwitterAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 819DAAD51BB5EC79002BDE2B /* PFTwitterAlertView.m */; };
 		81ECACD21D1E14E000FA7673 /* third_party_licenses.txt in Resources */ = {isa = PBXBuildFile; fileRef = 813DFC971AB2526000F25A08 /* third_party_licenses.txt */; };
 		81ECACD31D1E14E000FA7673 /* ParseTwitterUtils.strings in Resources */ = {isa = PBXBuildFile; fileRef = 06D00BAD1BC78F23005BAA6F /* ParseTwitterUtils.strings */; };
-		B9783173240D14A50049C02B /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9783172240D14A50049C02B /* OCMock.framework */; };
+		BC619D1727D24CBA004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D1627D24CBA004FAFB5 /* Bolts */; };
+		BC619D2127D24D4E004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2027D24D4E004FAFB5 /* Bolts */; };
+		BC619D2427D24ECC004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2327D24ECC004FAFB5 /* OCMock */; };
+		BC619D2627D24EFE004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2527D24EFE004FAFB5 /* Bolts */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4A1350A82027F4B8000F5FD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 81C3821B19CCA89E0066284A;
-			remoteInfo = "Parse-iOS";
-		};
-		4A51E4072027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81C3821C19CCA89E0066284A;
-			remoteInfo = "Parse-iOS";
-		};
-		4A51E4092027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81C5845D1C3B0A98000063C6;
-			remoteInfo = "Parse-iOS-Dynamic";
-		};
-		4A51E40B2027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 816F449B1A8E8933009CDB32;
-			remoteInfo = "ParseUnitTests-iOS";
-		};
-		4A51E40D2027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 97010FAC1630B18F00AB761E;
-			remoteInfo = "Parse-macOS";
-		};
-		4A51E40F2027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81C09F861AF97A490043B49C;
-			remoteInfo = "ParseUnitTests-macOS";
-		};
-		4A51E4112027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 815F24151BD04D150054659F;
-			remoteInfo = "Parse-tvOS";
-		};
-		4A51E4132027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81C585BF1C3B0AA1000063C6;
-			remoteInfo = "Parse-tvOS-Dynamic";
-		};
-		4A51E4152027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 810156691BB3832700D7C7BD;
-			remoteInfo = "Parse-watchOS";
-		};
-		4A51E4172027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 81C5870F1C3B0AA9000063C6;
-			remoteInfo = "Parse-watchOS-Dynamic";
-		};
-		4A51E4192027CC0F0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4AE33A0B1F5451AD0088DCA0;
-			remoteInfo = "ParseUnitTests-iOS-host";
-		};
-		4A51E41B2027CC1C0066DE1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 81C582E11C3B0A98000063C6;
-			remoteInfo = "Parse-iOS-Dynamic";
-		};
 		8166FB941B4F1E9A003841A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -165,9 +84,6 @@
 /* Begin PBXFileReference section */
 		06D00BAE1BC78F29005BAA6F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ParseTwitterUtils.strings; sourceTree = "<group>"; };
 		06D00BB41BC790F3005BAA6F /* PFTwitterLocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFTwitterLocalization.h; sourceTree = "<group>"; };
-		4A0ECBDD200D41B600BA84A3 /* Parse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Parse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A13522820282037000F5FD5 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = ../Carthage/Build/iOS/Bolts.framework; sourceTree = "<group>"; };
-		4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Parse.xcodeproj; path = ../Parse/Parse.xcodeproj; sourceTree = "<group>"; };
 		8135E48E1B4B6A0E0092F452 /* PF_Twitter_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PF_Twitter_Private.h; sourceTree = "<group>"; };
 		8135E48F1B4B6A0E0092F452 /* PFTwitterAuthenticationProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFTwitterAuthenticationProvider.h; sourceTree = "<group>"; };
 		8135E4901B4B6A0E0092F452 /* PFTwitterAuthenticationProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFTwitterAuthenticationProvider.m; sourceTree = "<group>"; };
@@ -223,7 +139,6 @@
 		81D342A01B4C7DA500B6C124 /* ParseTwitterUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseTwitterUtils.h; sourceTree = "<group>"; };
 		81ECACD71D1E14E000FA7673 /* ParseTwitterUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseTwitterUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81ECACD91D1E14F300FA7673 /* ParseTwitterUtils-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ParseTwitterUtils-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
-		B9783172240D14A50049C02B /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B99F4FFE2444B5B00061A6F5 /* ParseTwitterTestApplication.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ParseTwitterTestApplication.entitlements; sourceTree = "<group>"; };
 		B9A7EEC123C49D94003E606E /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		D2AAC07E0554694100DB518D /* ParseTwitterUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseTwitterUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -244,9 +159,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B9783173240D14A50049C02B /* OCMock.framework in Frameworks */,
+				BC619D2427D24ECC004FAFB5 /* OCMock in Frameworks */,
 				8168326A1D1E1A8B00315E21 /* AudioToolbox.framework in Frameworks */,
 				8168325E1D1E1A8600315E21 /* libsqlite3.tbd in Frameworks */,
+				BC619D2627D24EFE004FAFB5 /* Bolts in Frameworks */,
 				816832591D1E1A7E00315E21 /* SystemConfiguration.framework in Frameworks */,
 				816832521D1E1A7900315E21 /* Security.framework in Frameworks */,
 			);
@@ -256,6 +172,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D2127D24D4E004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,6 +180,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC619D1727D24CBA004FAFB5 /* Bolts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,31 +217,10 @@
 		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				B9783172240D14A50049C02B /* OCMock.framework */,
 				B9A7EEC123C49D94003E606E /* CoreGraphics.framework */,
-				4A13522820282037000F5FD5 /* Bolts.framework */,
-				4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */,
-				4A0ECBDD200D41B600BA84A3 /* Parse.framework */,
 				813DFC8E1AB2513300F25A08 /* System Frameworks */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		4A51E3FB2027CC0F0066DE1A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4A51E4082027CC0F0066DE1A /* Parse.framework */,
-				4A51E40A2027CC0F0066DE1A /* Parse.framework */,
-				4A51E40C2027CC0F0066DE1A /* ParseUnitTests-iOS.xctest */,
-				4A51E40E2027CC0F0066DE1A /* Parse.framework */,
-				4A51E4102027CC0F0066DE1A /* ParseUnitTests-macOS.xctest */,
-				4A51E4122027CC0F0066DE1A /* Parse.framework */,
-				4A51E4142027CC0F0066DE1A /* Parse.framework */,
-				4A51E4162027CC0F0066DE1A /* Parse.framework */,
-				4A51E4182027CC0F0066DE1A /* Parse.framework */,
-				4A51E41A2027CC0F0066DE1A /* ParseUnitTests-iOS-host.app */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		8135E48C1B4B6A0E0092F452 /* ParseTwitterUtils */ = {
@@ -611,6 +508,10 @@
 				8166FB951B4F1E9A003841A2 /* PBXTargetDependency */,
 			);
 			name = "ParseTwitterUtils-Tests";
+			packageProductDependencies = (
+				BC619D2327D24ECC004FAFB5 /* OCMock */,
+				BC619D2527D24EFE004FAFB5 /* Bolts */,
+			);
 			productName = "ParseFacebookUtilsV4-Tests";
 			productReference = 81CB98C61AB7905D00136FA5 /* ParseTwitterUtils-Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -628,9 +529,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4A51E41C2027CC1C0066DE1A /* PBXTargetDependency */,
 			);
 			name = "ParseTwitterUtils-iOS-Dynamic";
+			packageProductDependencies = (
+				BC619D2027D24D4E004FAFB5 /* Bolts */,
+			);
 			productName = Breakpad;
 			productReference = 81ECACD71D1E14E000FA7673 /* ParseTwitterUtils.framework */;
 			productType = "com.apple.product-type.framework";
@@ -648,9 +551,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				4A1350A92027F4B8000F5FD5 /* PBXTargetDependency */,
 			);
 			name = "ParseTwitterUtils-iOS";
+			packageProductDependencies = (
+				BC619D1627D24CBA004FAFB5 /* Bolts */,
+			);
 			productName = Breakpad;
 			productReference = D2AAC07E0554694100DB518D /* ParseTwitterUtils.framework */;
 			productType = "com.apple.product-type.framework";
@@ -683,14 +588,12 @@
 				Base,
 			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* Breakpad */;
+			packageReferences = (
+				BC619D1527D24CBA004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */,
+				BC619D2227D24ECC004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */,
+			);
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 4A51E3FB2027CC0F0066DE1A /* Products */;
-					ProjectRef = 4A51E3FA2027CC0F0066DE1A /* Parse.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				D2AAC07D0554694100DB518D /* ParseTwitterUtils-iOS */,
@@ -700,79 +603,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		4A51E4082027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E4072027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E40A2027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E4092027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E40C2027CC0F0066DE1A /* ParseUnitTests-iOS.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "ParseUnitTests-iOS.xctest";
-			remoteRef = 4A51E40B2027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E40E2027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E40D2027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E4102027CC0F0066DE1A /* ParseUnitTests-macOS.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "ParseUnitTests-macOS.xctest";
-			remoteRef = 4A51E40F2027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E4122027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E4112027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E4142027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E4132027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E4162027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E4152027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E4182027CC0F0066DE1A /* Parse.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Parse.framework;
-			remoteRef = 4A51E4172027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A51E41A2027CC0F0066DE1A /* ParseUnitTests-iOS-host.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = "ParseUnitTests-iOS-host.app";
-			remoteRef = 4A51E4192027CC0F0066DE1A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		8139B1341A7BF6B5002BEF84 /* Resources */ = {
@@ -895,16 +725,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		4A1350A92027F4B8000F5FD5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Parse-iOS";
-			targetProxy = 4A1350A82027F4B8000F5FD5 /* PBXContainerItemProxy */;
-		};
-		4A51E41C2027CC1C0066DE1A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Parse-iOS-Dynamic";
-			targetProxy = 4A51E41B2027CC1C0066DE1A /* PBXContainerItemProxy */;
-		};
 		8166FB951B4F1E9A003841A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
@@ -1095,6 +915,48 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BC619D1527D24CBA004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mman/Bolts-ObjC";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+		BC619D2227D24ECC004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/erikdoe/ocmock";
+			requirement = {
+				kind = revision;
+				revision = afd2c6924e8a36cb872bc475248b978f743c6050;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BC619D1627D24CBA004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D1527D24CBA004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D2027D24D4E004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D1527D24CBA004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+		BC619D2327D24ECC004FAFB5 /* OCMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D2227D24ECC004FAFB5 /* XCRemoteSwiftPackageReference "ocmock" */;
+			productName = OCMock;
+		};
+		BC619D2527D24EFE004FAFB5 /* Bolts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC619D1527D24CBA004FAFB5 /* XCRemoteSwiftPackageReference "Bolts-ObjC" */;
+			productName = Bolts;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 0867D690FE84028FC02AAC07 /* Project object */;
 }

--- a/ParseTwitterUtils/ParseTwitterUtils.xcodeproj/project.pbxproj
+++ b/ParseTwitterUtils/ParseTwitterUtils.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		BC619D1727D24CBA004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D1627D24CBA004FAFB5 /* Bolts */; };
 		BC619D2127D24D4E004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2027D24D4E004FAFB5 /* Bolts */; };
 		BC619D2427D24ECC004FAFB5 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2327D24ECC004FAFB5 /* OCMock */; };
-		BC619D2627D24EFE004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2527D24EFE004FAFB5 /* Bolts */; };
+		BC619D2627D24EFE004FAFB5 /* Bolts in Frameworks */ = {isa = PBXBuildFile; productRef = BC619D2527D24EFE004FAFB5 /* Bolts */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/ParseTwitterUtils/Tests/Unit/TwitterAuthenticationProviderTests.m
+++ b/ParseTwitterUtils/Tests/Unit/TwitterAuthenticationProviderTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Bolts.BFTask;
+@import Bolts;
 
 #import "PFTwitterAuthenticationProvider.h"
 #import "PFTwitterTestCase.h"

--- a/ParseTwitterUtils/Tests/Unit/TwitterTests.m
+++ b/ParseTwitterUtils/Tests/Unit/TwitterTests.m
@@ -8,7 +8,7 @@
  */
 
 @import Accounts;
-@import Bolts.BFTask;
+@import Bolts;
 @import Parse.PFConstants;
 @import Social;
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,6 @@ require_relative 'Vendor/xctoolchain/Scripts/xctask/build_framework_task'
 script_folder = File.expand_path(File.dirname(__FILE__))
 build_folder = File.join(script_folder, 'build')
 release_folder = File.join(build_folder, 'release')
-bolts_build_folder = File.join(script_folder, 'Carthage', 'Build')
-bolts_folder = File.join(script_folder, 'Carthage', 'Checkouts', 'Bolts-ObjC')
 ios_simulator = 'platform="iOS Simulator",name="iPhone 11"'
 tvos_simulator = 'platform="tvOS Simulator",name="Apple TV 4K"'
 
@@ -295,8 +293,6 @@ namespace :package do
 
   task :prepare do
     `rm -rf #{build_folder} && mkdir -p #{build_folder}`
-    `rm -rf #{bolts_build_folder} && mkdir -p #{bolts_build_folder}`
-    `#{bolts_folder}/scripts/build_framework.sh -n -c Release --with-watchos --with-tvos`
   end
 
   task :set_version, [:version] do |_, args|
@@ -317,34 +313,30 @@ namespace :package do
 
     ## Build macOS Framework
     Rake::Task['build:macos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'osx', 'Bolts.framework')
     osx_framework_path = File.join(build_folder, 'Parse.framework')
     make_package(release_folder,
-                 [osx_framework_path, bolts_path],
+                 [osx_framework_path],
                  package_macos_name)
 
     ## Build iOS Framework
     Rake::Task['build:ios'].invoke
-    bolts_path = File.join(bolts_build_folder, 'ios', 'Bolts.framework')
     ios_framework_path = File.join(build_folder, 'Parse.framework')
     make_package(release_folder,
-                 [ios_framework_path, bolts_path],
+                 [ios_framework_path],
                  package_ios_name)
 
     ## Build tvOS Framework
     Rake::Task['build:tvos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'tvOS', 'Bolts.framework')
     tvos_framework_path = File.join(build_folder, 'Parse.framework')
     make_package(release_folder,
-                  [tvos_framework_path, bolts_path],
+                  [tvos_framework_path],
                   package_tvos_name)
 
     ## Build watchOS Framework
     Rake::Task['build:watchos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'watchOS', 'Bolts.framework')
     watchos_framework_path = File.join(build_folder, 'Parse.framework')
     make_package(release_folder,
-                 [watchos_framework_path, bolts_path],
+                 [watchos_framework_path],
                  package_watchos_name)
 
     Rake::Task['build:facebook_utils:ios'].invoke
@@ -471,7 +463,7 @@ namespace :test do
       t.sdk = 'iphonesimulator'
       t.destinations = [ios_simulator]
       t.configuration = 'Debug'
-      t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
+      t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "NO",
                                "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
 
       t.actions = [XCTask::BuildAction::TEST]
@@ -492,7 +484,7 @@ namespace :test do
       t.scheme = 'Parse-macOS'
       t.sdk = 'macosx'
       t.configuration = 'Debug'
-      t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
+      t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "NO",
                                "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
 
       t.actions = [XCTask::BuildAction::TEST]
@@ -515,7 +507,7 @@ namespace :test do
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
+        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "NO",
                                  "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
 
         t.actions = [XCTask::BuildAction::TEST]
@@ -541,7 +533,7 @@ namespace :test do
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
+        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "NO",
                                  "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
 
         t.actions = [XCTask::BuildAction::TEST]
@@ -592,7 +584,7 @@ namespace :test do
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
+        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "NO",
                                  "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
 
         t.actions = [XCTask::BuildAction::CLEAN, XCTask::BuildAction::BUILD]
@@ -615,7 +607,7 @@ namespace :test do
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
+        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "NO",
                                  "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
 
         t.actions = [XCTask::BuildAction::CLEAN, XCTask::BuildAction::BUILD]


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1635).

### Issue Description
Facebook SDK compatibility. Moves to SPM for internal dependency management.

Closes https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1635

### Approach
Removed most of the mishmash of other approaches to internal dependency management, and replaced it with SPM.
Updated FB lib version to 13.

### TODOs before merging
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)