### PR TITLE
Add FBSDKCoreKit dependency to Parse/FacebookUtils

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -104,6 +104,7 @@ Pod::Spec.new do |s|
 
     s.dependency 'Parse/Core'
     s.dependency 'Bolts/Tasks', '~> 1.9.1'
+    s.dependency 'FBSDKCoreKit', '= 11.0.1'
     s.dependency 'FBSDKLoginKit', '= 11.0.1'
   end
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

Adding subspec `Parse/FacebookUtils` to a project will generate linking compilation issues, caused by the missing dependency `FBSDKCoreKit`.

Related issue: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1665

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)