### PR TITLE
ci: add manual cocoapods release workflow

### DIFF
--- a/.github/workflows/release-manual-cocoapods.yml
+++ b/.github/workflows/release-manual-cocoapods.yml
@@ -1,0 +1,28 @@
+# Trigger this workflow only to manually publish a Cocoapods release; this should only be used
+# in extraordinary circumstances, as releases are normally published automatically as part of
+# the automated release workflow.
+
+name: release-manual-cocoapods
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        default: ''
+        description: 'Reference (tag / SHA):'  
+env:
+  CI_XCODE_13: '/Applications/Xcode_13.0.app/Contents/Developer'
+jobs:
+  cocoapods:
+    runs-on: macos-11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: CocoaPods
+        run: set -o pipefail && env NSUnbufferedIO=YES pod lib lint --allow-warnings --verbose
+      - name: Deploy CocoaPods
+        run: set -o pipefail && env NSUnbufferedIO=YES pod trunk push Parse.podspec --allow-warnings --verbose
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          DEVELOPER_DIR: ${{ env.CI_XCODE_13 }}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

Adds a manual cocoapods release workflow.

Related issue: #n/a

### Approach

Adds manual cocoapods release workflow.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
n/a