### PR TITLE
feat: Upgrade to Facebook SDK 15

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "BoltsFramework/Bolts-ObjC" ~> 1.9.1
-github "facebook/facebook-ios-sdk" == 11.0.1
+github "facebook/facebook-ios-sdk" == 15.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "BoltsFramework/Bolts-ObjC" "1.9.1"
-github "facebook/facebook-ios-sdk" "v11.0.1"
+github "facebook/facebook-ios-sdk" "v15.1.0"

--- a/Parse.podspec
+++ b/Parse.podspec
@@ -104,8 +104,8 @@ Pod::Spec.new do |s|
 
     s.dependency 'Parse/Core'
     s.dependency 'Bolts/Tasks', '~> 1.9.1'
-    s.dependency 'FBSDKCoreKit', '= 11.0.1'
-    s.dependency 'FBSDKLoginKit', '= 11.0.1'
+    s.dependency 'FBSDKCoreKit', '= 15.1.0'
+    s.dependency 'FBSDKLoginKit', '= 15.1.0'
   end
 
   s.subspec 'FacebookUtils-tvOS' do |s|
@@ -127,8 +127,8 @@ Pod::Spec.new do |s|
 
     s.dependency 'Parse/Core'
     s.dependency 'Bolts/Tasks', '~> 1.9.1'
-    s.dependency 'FBSDKTVOSKit', '= 11.0'
-    s.dependency 'FBSDKShareKit', '= 11.0.1'
+    s.dependency 'FBSDKTVOSKit', '= 15.1.0'
+    s.dependency 'FBSDKShareKit', '= 15.1.0'
   end
 
   s.subspec 'TwitterUtils' do |s|


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

- Update the FacebookSDK version from 11.0.1 to 15.1.0
- Update Carthage dependencies

Closes: #1635

### Approach
<!-- Add a description of the approach in this PR. -->
1. Update FacebookSDK to the latest version
2. Update dependencies (Carthage)
3. Test how it works 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
n/a
