### PR TITLE
ci: Assets not building with auto-release workflow

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-11
     outputs:
       current_tag: ${{ steps.tag.outputs.current_tag }}
     steps:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

The release requires carthage to be installed.

Closes: #n/a

### Approach

Switching to macos-11 image which has carthage preinstalled.

### TODOs before merging
n/a