### PR TITLE
ci: Assets not building with auto-release workflow

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -34,7 +34,6 @@ jobs:
           sudo gem install bundler
           bundle config set path 'vendor/bundle'
           bundle install
-          carthage bootstrap --use-xcframeworks
       - run: npm ci
       - run: npx semantic-release
         env:
@@ -84,6 +83,7 @@ jobs:
           sudo gem install bundler
           bundle config set path 'vendor/bundle'
           bundle install
+          carthage bootstrap --use-xcframeworks
       - name: Build Release
         run: set -o pipefail && env NSUnbufferedIO=YES bundle exec rake package:release
         env:


### PR DESCRIPTION
Same as https://github.com/parse-community/Parse-SDK-iOS-OSX/pull/1692; added line to wrong workflow job