### PR TITLE
ci: Fix semantic release requires Node >=18

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
       - name: Setup Ruby
         uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
       - name: Cache Gems


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

Auto-release workflow fails because semantic-release requires Node >= 18

Closes: #n/a

### Approach

Upgrade to Node 18

### TODOs before merging
n/a