### PR TITLE
fix: `Parse.setServer` does not set new server URL

### DIFF
--- a/Parse/Parse/Internal/PFInternalUtils.h
+++ b/Parse/Parse/Internal/PFInternalUtils.h
@@ -19,9 +19,6 @@
 
 @interface PFInternalUtils : NSObject
 
-+ (NSString *)parseServerURLString;
-+ (void)setParseServer:(NSString *)server;
-
 /**
  Clears system time zone cache, gets the name of the time zone
  and caches it. This method is completely thread-safe.

--- a/Parse/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Parse/Internal/PFInternalUtils.m
@@ -40,26 +40,7 @@
 #import "PFProduct.h"
 #endif
 
-static NSString *parseServer_;
-
 @implementation PFInternalUtils
-
-+ (void)initialize {
-    if (self == [PFInternalUtils class]) {
-        [self setParseServer:_ParseDefaultServerURLString];
-    }
-}
-
-+ (NSString *)parseServerURLString {
-    return parseServer_;
-}
-
-// Useful for testing.
-// Beware of race conditions if you call setParseServer while something else may be using
-// httpClient.
-+ (void)setParseServer:(NSString *)server {
-    parseServer_ = [server copy];
-}
 
 + (NSString *)currentSystemTimeZoneName {
     static NSLock *methodLock;

--- a/Parse/Parse/Source/Parse.h
+++ b/Parse/Parse/Source/Parse.h
@@ -107,11 +107,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly, class) ParseClientConfiguration *currentConfiguration;
 
 /**
- Sets the server URL to connect to Parse Server. The local client cache is not cleared.
- @discussion This can be used to update the server URL after this client has been initialized, without having to destroy this client. An example use case is
- server connection failover, where the clients connects to another URL if the server becomes unreachable at the current URL.
- @warning The new server URL must point to a Parse Server that connects to the same database. Otherwise, issues may arise
- related to locally cached data or delayed methods such as saveEventually.
+ Sets the server URL to connect to Parse Server.
+ @discussion This can be used to update the server URL after the client was initialized. An example use case is server
+ connection failover, where the client connects to another URL if the server becomes unreachable at the current URL. The
+ client will be re-initialized maintaining the same configuration. Any pending requests will still be made against the previous
+ server URL that was set at the time the request was queued.
+ @warning The new server URL must point to a Parse Server that connects to the same database. Otherwise, issues may
+ arise related to locally cached data or delayed methods such as saveEventually.
  @param server  The server URL to set.
  */
 + (void)setServer:(nonnull NSString *)server;

--- a/Parse/Parse/Source/Parse.m
+++ b/Parse/Parse/Source/Parse.m
@@ -100,11 +100,12 @@ static ParseClientConfiguration *currentParseConfiguration_;
 }
 
 + (void)setServer:(nonnull NSString *)server {
+    // Use current config with new server
+    ParseClientConfiguration *config = currentParseManager_ ? currentParseManager_.configuration : currentParseConfiguration_;
+    config.server = server;
+    
     // Re-initialize SDK
-    currentParseConfiguration_.applicationId = currentParseManager_.configuration.applicationId;
-    currentParseConfiguration_.clientKey = currentParseManager_.configuration.clientKey;
-    currentParseConfiguration_.server = server;
-    [self initializeWithConfigurationAllowingReinitialize:currentParseConfiguration_];
+    [self initializeWithConfigurationAllowingReinitialize:config];
 }
 
 + (nullable ParseClientConfiguration *)currentConfiguration {

--- a/Parse/Parse/Source/Parse.m
+++ b/Parse/Parse/Source/Parse.m
@@ -59,7 +59,6 @@ static ParseClientConfiguration *currentParseConfiguration_;
     PFParameterAssert(clientKey.length, @"`clientKey` should not be nil.");
     currentParseConfiguration_.applicationId = applicationId;
     currentParseConfiguration_.clientKey = clientKey;
-    currentParseConfiguration_.server = [PFInternalUtils parseServerURLString]; // TODO: (nlutsenko) Clean this up after tests are updated.
 
     [self initializeWithConfiguration:currentParseConfiguration_];
 
@@ -69,13 +68,17 @@ static ParseClientConfiguration *currentParseConfiguration_;
 }
 
 + (void)initializeWithConfiguration:(ParseClientConfiguration *)configuration {
+    PFConsistencyAssert(![self currentConfiguration], @"Parse is already initialized.");
+    [self initializeWithConfigurationAllowingReinitialize:configuration];
+}
+
++ (void)initializeWithConfigurationAllowingReinitialize:(ParseClientConfiguration *)configuration {
     PFConsistencyAssert(configuration.applicationId.length != 0,
                         @"You must set your configuration's `applicationId` before calling %s!", __PRETTY_FUNCTION__);
     PFConsistencyAssert(![PFApplication currentApplication].extensionEnvironment ||
                         configuration.applicationGroupIdentifier == nil ||
                         configuration.containingApplicationBundleIdentifier != nil,
                         @"'containingApplicationBundleIdentifier' must be non-nil in extension environment");
-    PFConsistencyAssert(![self currentConfiguration], @"Parse is already initialized.");
 
     ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration];
     [manager startManaging];
@@ -94,11 +97,14 @@ static ParseClientConfiguration *currentParseConfiguration_;
                                                             object:nil];
         return nil;
     }];
-    
 }
 
 + (void)setServer:(nonnull NSString *)server {
-    [PFInternalUtils setParseServer:server];
+    // Re-initialize SDK
+    currentParseConfiguration_.applicationId = currentParseManager_.configuration.applicationId;
+    currentParseConfiguration_.clientKey = currentParseManager_.configuration.clientKey;
+    currentParseConfiguration_.server = server;
+    [self initializeWithConfigurationAllowingReinitialize:currentParseConfiguration_];
 }
 
 + (nullable ParseClientConfiguration *)currentConfiguration {
@@ -126,7 +132,9 @@ static ParseClientConfiguration *currentParseConfiguration_;
 }
 
 + (nullable NSString *)server {
-    return [[PFInternalUtils parseServerURLString] copy];
+    ParseClientConfiguration *config = currentParseManager_ ? currentParseManager_.configuration
+                                                            : currentParseConfiguration_;
+    return currentParseManager_.configuration.server;
 }
 
 ///--------------------------------------


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1528

### Approach

- Remove unused `PFInternalUtils.setParseServer`
- Completely re-init SDK when setting new server URL
