### PR TITLE
feat: Add `PFUser.unregisterAuthenticationDelegate` and allow to register delegate gracefully if another delegate is already registered

### DIFF
--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -55,8 +55,13 @@
                            forAuthType:(NSString *)authType {
     PFParameterAssert(delegate, @"Authentication delegate can't be `nil`.");
     PFParameterAssert(authType, @"`authType` can't be `nil`.");
-    PFParameterAssert(![self authenticationDelegateForAuthType:authType],
-                        @"Authentication delegate already registered for authType `%@`.", authType);
+    
+    // If auth delete is already registered then unregister it gracefully
+    if ([self authenticationDelegateForAuthType:authType]) {
+        NSLog(@"unregistering existing deletegate to gracefully register new delegate for authType `%@`.", authType);
+        [self unregisterAuthenticationDelegateForAuthType:authType];
+    }
+    
     dispatch_sync(_dataAccessQueue, ^{
         self->_authenticationDelegates[authType] = delegate;
     });

--- a/Parse/Parse/Source/PFUser.h
+++ b/Parse/Parse/Source/PFUser.h
@@ -302,7 +302,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *_Nullable error);
 
  @param authType The name of the type of third party authentication source.
  */
-+ (void)unregisterAuthType:(NSString *)authType;
++ (void)unregisterAuthenticationDelegateForAuthType:(NSString *)authType;
 
 /**
  Logs in a user with third party authentication credentials.

--- a/Parse/Parse/Source/PFUser.h
+++ b/Parse/Parse/Source/PFUser.h
@@ -283,7 +283,8 @@ typedef void(^PFUserLogoutResultBlock)(NSError *_Nullable error);
 ///--------------------------------------
 
 /**
- Registers a third party authentication delegate.
+ Registers a third party authentication delegate. If a delegate is already registered for the authType then
+ it is replaced by the new delegate.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
  @see PFUserAuthenticationDelegate
@@ -292,6 +293,16 @@ typedef void(^PFUserLogoutResultBlock)(NSError *_Nullable error);
  @param authType The name of the type of third party authentication source.
  */
 + (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate forAuthType:(NSString *)authType;
+
+/**
+ Unregisters a third party authentication delegate. If no delegate is registered, this fails gracefully.
+
+ @note This method shouldn't be invoked directly unless developing a third party authentication library.
+ @see PFUserAuthenticationDelegate
+
+ @param authType The name of the type of third party authentication source.
+ */
++ (void)unregisterAuthType:(NSString *)authType;
 
 /**
  Logs in a user with third party authentication credentials.

--- a/Parse/Parse/Source/PFUser.m
+++ b/Parse/Parse/Source/PFUser.m
@@ -848,6 +848,10 @@ static BOOL revocableSessionEnabled_;
     [[self authenticationController] registerAuthenticationDelegate:delegate forAuthType:authType];
 }
 
++ (void)unregisterAuthType:(NSString *)authType {
+    [[self authenticationController] unregisterAuthenticationDelegateForAuthType:authType];
+}
+
 #pragma mark Log In
 
 + (BFTask<__kindof PFUser *> *)logInWithAuthTypeInBackground:(NSString *)authType

--- a/Parse/Parse/Source/PFUser.m
+++ b/Parse/Parse/Source/PFUser.m
@@ -848,7 +848,7 @@ static BOOL revocableSessionEnabled_;
     [[self authenticationController] registerAuthenticationDelegate:delegate forAuthType:authType];
 }
 
-+ (void)unregisterAuthType:(NSString *)authType {
++ (void)unregisterAuthenticationDelegateForAuthType:(NSString *)authType {
     [[self authenticationController] unregisterAuthenticationDelegateForAuthType:authType];
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

SDK asserts that auth delegate can only be registered once.

Closes: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->


Gracefully deregister existing auth delegate and register new delegate instead of crashing.

### TODOs before merging
n/a