### PR TITLE
perf: Skip registering auth delegate if it's already registered

### DIFF
--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -56,12 +56,19 @@
     PFParameterAssert(delegate, @"Authentication delegate can't be `nil`.");
     PFParameterAssert(authType, @"`authType` can't be `nil`.");
     
-    // If same auth delete is already registered then don't register it again
-    if ([self authenticationDelegateForAuthType:authType] == delegate) {
-        NSLog(@"delegate already registered for authType `%@`.", authType);
-        return;
+    // If auth delete is already registered for provider
+    if ([self authenticationDelegateForAuthType:authType]) {
+        
+        // If same auth delete is already registered then don't register it again
+        if ([self authenticationDelegateForAuthType:authType] == delegate) {
+            NSLog(@"delegate already registered for authType `%@`.", authType);
+            return;
+        }
+        
+        NSLog(@"unregistering existing deletegate to gracefully register new delegate for authType `%@`.", authType);
+        [self unregisterAuthenticationDelegateForAuthType:authType];
     }
-    
+             
     dispatch_sync(_dataAccessQueue, ^{
         self->_authenticationDelegates[authType] = delegate;
     });

--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -61,7 +61,7 @@
         
         // If same auth delete is already registered then don't register it again
         if ([self authenticationDelegateForAuthType:authType] == delegate) {
-            NSLog(@"same delegate already registered for authType `%@`.", authType);
+            NSLog(@"skipping registering as same delegate already registered for authType `%@`.", authType);
             return;
         }
         

--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -61,7 +61,7 @@
         
         // If same auth delete is already registered then don't register it again
         if ([self authenticationDelegateForAuthType:authType] == delegate) {
-            NSLog(@"delegate already registered for authType `%@`.", authType);
+            NSLog(@"same delegate already registered for authType `%@`.", authType);
             return;
         }
         

--- a/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -56,10 +56,10 @@
     PFParameterAssert(delegate, @"Authentication delegate can't be `nil`.");
     PFParameterAssert(authType, @"`authType` can't be `nil`.");
     
-    // If auth delete is already registered then unregister it gracefully
-    if ([self authenticationDelegateForAuthType:authType]) {
-        NSLog(@"unregistering existing deletegate to gracefully register new delegate for authType `%@`.", authType);
-        [self unregisterAuthenticationDelegateForAuthType:authType];
+    // If same auth delete is already registered then don't register it again
+    if ([self authenticationDelegateForAuthType:authType] == delegate) {
+        NSLog(@"delegate already registered for authType `%@`.", authType);
+        return;
     }
     
     dispatch_sync(_dataAccessQueue, ^{


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

When registering the same auth delegate again, it is actually fully re-registered in the SDK.

Closes: #n/a

### Approach

Don't register same auth delegate again if its already registered. Instead just do nothing.

