### PR TITLE
ci: API reference documentation not generated

### DIFF
--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -2,7 +2,7 @@ mkdir -p ./Parse/Bolts # Create a temporary bolts folder
 cp -R Carthage/Checkouts/Bolts-ObjC/Bolts/**/*.h ./Parse/Bolts # Copy bolts
 
 ver=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" Parse/Parse/Resources/Parse-iOS.Info.plist`
-bundle exec jazzy \
+set -eo pipefail && bundle exec jazzy \
   --objc \
   --clean \
   --author "Parse Community" \

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -14,7 +14,7 @@ bundle exec jazzy \
   --skip-undocumented \
   --exclude=./Bolts/* \
   --module Parse \
-  --umbrella-header Parse/Parse/Parse.h \
+  --umbrella-header Parse/Parse/Source/Parse.h \
   --framework-root Parse \
   --output docs/api
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Parse.h header file was moved in https://github.com/parse-community/Parse-SDK-iOS-OSX/pull/1683 preventing the api documentation from generating. 

```
error: error reading '/Users/runner/work/Parse-SDK-iOS-OSX/Parse-SDK-iOS-OSX/Parse/Parse/Parse.h'
```

Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1702

### Approach
* Allow jazzy script to fail with non-zero exit code
* Correct the proper header path