### PR TITLE
ci: Fix manual documentation publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_11 }}
 
   docs:
-    needs: parseui
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.tag }}
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
       - name: Cache Gems
         id: cache-gems
         uses: actions/cache@v2

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -27,6 +27,8 @@ jobs:
             ${{ runner.os }}-gem-
       - name: Install Bundle
         run: |
+          git submodule update --init --recursive
+          sudo gem install bundler
           bundle config path vendor/bundle
           bundle install
       - name: Create Jazzy Docs


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Dependencies used to generate docs are missing.

<img width="597" alt="Screen Shot 2023-03-07 at 12 06 02 PM" src="https://user-images.githubusercontent.com/9830365/223523595-c84df9f0-194b-41c0-a4c1-5e064c063ef0.png">

Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1702

### Approach
<!-- Add a description of the approach in this PR. -->
* Install carthage submodules
* Remove the dependency on `parseui` test suite to generate docs.
