### PR TITLE
feat: Add support to exclude `PFObject` fields in query results with `PFQuery.excludeKeys`

### DIFF
--- a/Parse/Parse/Internal/Commands/PFRESTQueryCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTQueryCommand.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
                                           conditions:(nullable NSDictionary *)conditions
                                         selectedKeys:(nullable NSSet *)selectedKeys
                                         includedKeys:(nullable NSSet *)includedKeys
+                                        excludedKeys:(nullable NSSet *)excludedKeys
                                                limit:(NSInteger)limit
                                                 skip:(NSInteger)skip
                                              explain:(BOOL)explain
@@ -54,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                conditions:(nullable NSDictionary *)conditions
                                              selectedKeys:(nullable NSSet *)selectedKeys
                                              includedKeys:(nullable NSSet *)includedKeys
+                                             excludedKeys:(nullable NSSet *)excludedKeys
                                                     limit:(NSInteger)limit
                                                      skip:(NSInteger)skip
                                                   explain:(BOOL)explain

--- a/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -36,6 +36,7 @@
                                          conditions:(NSDictionary *)conditions
                                        selectedKeys:(NSSet *)selectedKeys
                                        includedKeys:(NSSet *)includedKeys
+                                       excludedKeys:(NSSet *)excludedKeys
                                               limit:(NSInteger)limit
                                                skip:(NSInteger)skip
                                              explain:(BOOL)explain
@@ -48,6 +49,7 @@
                                                          conditions:conditions
                                                        selectedKeys:selectedKeys
                                                        includedKeys:includedKeys
+                                                       excludedKeys:excludedKeys
                                                               limit:limit
                                                                skip:skip
                                                             explain:explain
@@ -102,6 +104,7 @@
                                      conditions:queryState.conditions
                                    selectedKeys:queryState.selectedKeys
                                    includedKeys:queryState.includedKeys
+                                   excludedKeys:queryState.excludedKeys
                                           limit:queryState.limit
                                            skip:queryState.skip
                                         explain:queryState.explain
@@ -115,6 +118,7 @@
                                       conditions:(NSDictionary *)conditions
                                     selectedKeys:(NSSet *)selectedKeys
                                     includedKeys:(NSSet *)includedKeys
+                                    excludedKeys:(NSSet *)excludedKeys
                                            limit:(NSInteger)limit
                                             skip:(NSInteger)skip
                                          explain:(BOOL)explain
@@ -136,6 +140,11 @@
         NSArray *sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"self" ascending:YES selector:@selector(compare:)] ];
         NSArray *keysArray = [includedKeys sortedArrayUsingDescriptors:sortDescriptors];
         parameters[@"include"] = [keysArray componentsJoinedByString:@","];
+    }
+    if (excludedKeys.count > 0) {
+        NSArray *sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"self" ascending:YES selector:@selector(compare:)] ];
+        NSArray *keysArray = [excludedKeys sortedArrayUsingDescriptors:sortDescriptors];
+        parameters[@"excludedKeys"] = [keysArray componentsJoinedByString:@","];
     }
     if (limit >= 0) {
         parameters[@"limit"] = [NSString stringWithFormat:@"%d", (int)limit];
@@ -171,12 +180,14 @@
                     PFParameterAssert(subquery.state.skip == 0, @"OR queries do not support sub queries with skip");
                     PFParameterAssert(subquery.state.sortKeys.count == 0, @"OR queries do not support sub queries with order");
                     PFParameterAssert(subquery.state.includedKeys.count == 0, @"OR queries do not support sub-queries with includes");
+                    PFParameterAssert(subquery.state.excludedKeys.count == 0, @"OR queries do not support sub-queries with excludeKeys");
                     PFParameterAssert(subquery.state.selectedKeys == nil, @"OR queries do not support sub-queries with selectKeys");
 
                     NSDictionary *queryDict = [self findCommandParametersWithOrder:subquery.state.sortOrderString
                                                                         conditions:subquery.state.conditions
                                                                       selectedKeys:subquery.state.selectedKeys
                                                                       includedKeys:subquery.state.includedKeys
+                                                                      excludedKeys:subquery.state.excludedKeys
                                                                              limit:subquery.state.limit
                                                                               skip:subquery.state.skip
                                                                            explain:subquery.state.explain
@@ -240,6 +251,7 @@
                                                               conditions:subquery.state.conditions
                                                             selectedKeys:subquery.state.selectedKeys
                                                             includedKeys:subquery.state.includedKeys
+                                                            excludedKeys:subquery.state.excludedKeys
                                                                    limit:subquery.state.limit
                                                                     skip:subquery.state.skip
                                                                  explain:subquery.state.explain

--- a/Parse/Parse/Internal/Query/State/PFMutableQueryState.h
+++ b/Parse/Parse/Internal/Query/State/PFMutableQueryState.h
@@ -71,6 +71,13 @@
 - (void)includeKeys:(NSArray<NSString *> *)keys;
 
 ///--------------------------------------
+#pragma mark - Excludes
+///--------------------------------------
+
+- (void)excludeKey:(NSString *)key;
+- (void)excludeKeys:(NSArray<NSString *> *)keys;
+
+///--------------------------------------
 #pragma mark - Selected Keys
 ///--------------------------------------
 

--- a/Parse/Parse/Internal/Query/State/PFMutableQueryState.m
+++ b/Parse/Parse/Internal/Query/State/PFMutableQueryState.m
@@ -17,7 +17,7 @@
     NSMutableDictionary<NSString *, id> *_conditions;
     NSMutableArray<NSString *> *_sortKeys;
     NSMutableSet<NSString *> *_includedKeys;
-    NSMutableSet<NSString *> *_excludeKeys;
+    NSMutableSet<NSString *> *_excludedKeys;
     NSMutableDictionary<NSString *, NSString *> *_extraOptions;
 }
 
@@ -171,18 +171,18 @@
 ///--------------------------------------
 
 - (void)excludeKey:(NSString *)key {
-    if (!_excludeKeys) {
-        _excludeKeys = [NSMutableSet setWithObject:key];
+    if (!_excludedKeys) {
+        _excludedKeys = [NSMutableSet setWithObject:key];
     } else {
-        [_excludeKeys addObject:key];
+        [_excludedKeys addObject:key];
     }
 }
 
 - (void)excludeKeys:(NSArray<NSString *> *)keys {
-    if (!_excludeKeys) {
-        _excludeKeys = [NSMutableSet setWithArray:keys];
+    if (!_excludedKeys) {
+        _excludedKeys = [NSMutableSet setWithArray:keys];
     } else {
-        [_excludeKeys addObjectsFromArray:keys];
+        [_excludedKeys addObjectsFromArray:keys];
     }
 }
 

--- a/Parse/Parse/Internal/Query/State/PFMutableQueryState.m
+++ b/Parse/Parse/Internal/Query/State/PFMutableQueryState.m
@@ -17,6 +17,7 @@
     NSMutableDictionary<NSString *, id> *_conditions;
     NSMutableArray<NSString *> *_sortKeys;
     NSMutableSet<NSString *> *_includedKeys;
+    NSMutableSet<NSString *> *_excludeKeys;
     NSMutableDictionary<NSString *, NSString *> *_extraOptions;
 }
 
@@ -27,6 +28,7 @@
 @synthesize conditions = _conditions;
 @synthesize sortKeys = _sortKeys;
 @synthesize includedKeys = _includedKeys;
+@synthesize excludedKeys = _excludedKeys;
 @synthesize extraOptions = _extraOptions;
 
 @dynamic parseClassName;
@@ -53,6 +55,7 @@
     attributes[PFQueryStatePropertyName(conditions)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
     attributes[PFQueryStatePropertyName(sortKeys)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
     attributes[PFQueryStatePropertyName(includedKeys)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
+     attributes[PFQueryStatePropertyName(excludedKeys)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
     attributes[PFQueryStatePropertyName(extraOptions)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
 
     return attributes;
@@ -160,6 +163,26 @@
         _includedKeys = [NSMutableSet setWithArray:keys];
     } else {
         [_includedKeys addObjectsFromArray:keys];
+    }
+}
+
+///--------------------------------------
+#pragma mark - Excludes
+///--------------------------------------
+
+- (void)excludeKey:(NSString *)key {
+    if (!_excludeKeys) {
+        _excludeKeys = [NSMutableSet setWithObject:key];
+    } else {
+        [_excludeKeys addObject:key];
+    }
+}
+
+- (void)excludeKeys:(NSArray<NSString *> *)keys {
+    if (!_excludeKeys) {
+        _excludeKeys = [NSMutableSet setWithArray:keys];
+    } else {
+        [_excludeKeys addObjectsFromArray:keys];
     }
 }
 

--- a/Parse/Parse/Internal/Query/State/PFQueryState.h
+++ b/Parse/Parse/Internal/Query/State/PFQueryState.h
@@ -23,6 +23,7 @@
 @property (nonatomic, copy, readonly) NSString *sortOrderString;
 
 @property (nonatomic, copy, readonly) NSSet<NSString *> *includedKeys;
+@property (nonatomic, copy, readonly) NSSet<NSString *> *excludedKeys;
 @property (nonatomic, copy, readonly) NSSet<NSString *> *selectedKeys;
 @property (nonatomic, copy, readonly) NSDictionary<NSString *, NSString *> *extraOptions;
 

--- a/Parse/Parse/Internal/Query/State/PFQueryState.m
+++ b/Parse/Parse/Internal/Query/State/PFQueryState.m
@@ -26,6 +26,7 @@
         PFQueryStatePropertyName(conditions): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
         PFQueryStatePropertyName(sortKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
         PFQueryStatePropertyName(includedKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(excludedKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
         PFQueryStatePropertyName(selectedKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
         PFQueryStatePropertyName(extraOptions): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
 

--- a/Parse/Parse/Internal/Query/State/PFQueryState_Private.h
+++ b/Parse/Parse/Internal/Query/State/PFQueryState_Private.h
@@ -29,6 +29,7 @@
     NSArray<NSString *> *_sortKeys;
 
     NSSet<NSString *> *_includedKeys;
+    NSSet<NSString *> *_excludedKeys;
     NSSet<NSString *> *_selectedKeys;
     NSDictionary<NSString *, NSString *> *_extraOptions;
 

--- a/Parse/Parse/Source/PFQuery.h
+++ b/Parse/Parse/Source/PFQuery.h
@@ -108,6 +108,28 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *_Nullable obje
 - (instancetype)includeKeys:(NSArray<NSString *> *)keys;
 
 /**
+ Make the query restrict the fields of the returned `PFObject`s to exclude the provided key.
+
+ If this is called multiple times, then all of the keys specified in each of the calls will be excluded.
+
+ @param key The key to exclude in the result.
+
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
+ */
+- (instancetype)excludeKey:(NSString *)key;
+
+/**
+ Make the query restrict the fields of the returned `PFObject`s to exclude the provided keys.
+
+ If this is called multiple times, then all of the keys specified in each of the calls will be excluded.
+
+ @param keys The keys to exclude in the result.
+
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
+ */
+- (instancetype)excludeKeys:(NSArray<NSString *> *)keys;
+
+/**
  Make the query restrict the fields of the returned `PFObject`s to include only the provided keys.
 
  If this is called multiple times, then all of the keys specified in each of the calls will be included.

--- a/Parse/Parse/Source/PFQuery.m
+++ b/Parse/Parse/Source/PFQuery.m
@@ -432,7 +432,7 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
 
 - (instancetype)excludeKey:(NSString *)key {
     [self checkIfCommandIsRunning];
-    [self.state excludeKey:keys];
+    [self.state excludeKey:key];
     return self;
 }
 

--- a/Parse/Parse/Source/PFQuery.m
+++ b/Parse/Parse/Source/PFQuery.m
@@ -427,6 +427,22 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
 }
 
 ///--------------------------------------
+#pragma mark - Exclude
+///--------------------------------------
+
+- (instancetype)excludeKey:(NSString *)key {
+    [self checkIfCommandIsRunning];
+    [self.state excludeKey:keys];
+    return self;
+}
+
+- (instancetype)excludeKeys:(NSArray<NSString *> *)keys {
+    [self checkIfCommandIsRunning];
+    [self.state excludeKeys:keys];
+    return self;
+}
+
+///--------------------------------------
 #pragma mark - Select
 ///--------------------------------------
 

--- a/Parse/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.m
+++ b/Parse/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.m
@@ -37,7 +37,7 @@
     
     [Parse setApplicationId:self.applicationId clientKey:self.clientKey];
     
-    [self waitForExpectations:@[expect] timeout:10];
+    [self waitForExpectations:@[expect] timeout:30];
 }
 
 - (void)tearDown {

--- a/Parse/Tests/Unit/QueryStateUnitTests.m
+++ b/Parse/Tests/Unit/QueryStateUnitTests.m
@@ -41,6 +41,7 @@
     [state sortByKey:@"a" ascending:NO];
 
     [state includeKey:@"yolo"];
+    [state excludeKey:@"yolo"];
     [state selectKeys:@[ @"yolo" ]];
     [state redirectClassNameForKey:@"ABC"];
     return state;
@@ -62,6 +63,7 @@
     XCTAssertEqualObjects(state.sortKeys, differentState.sortKeys);
     XCTAssertEqualObjects(state.sortOrderString, differentState.sortOrderString);
     XCTAssertEqualObjects(state.includedKeys, differentState.includedKeys);
+    XCTAssertEqualObjects(state.excludedKeys, differentState.excludedKeys);
     XCTAssertEqualObjects(state.selectedKeys, differentState.selectedKeys);
     XCTAssertEqualObjects(state.extraOptions, differentState.extraOptions);
 
@@ -211,6 +213,23 @@
 
     NSSet *includedKeys = PF_SET(@"a", @"b", @"c");
     XCTAssertEqualObjects(state.includedKeys, includedKeys);
+}
+
+- (void)testExcludeKeys {
+    PFMutableQueryState *state = [[PFMutableQueryState alloc] initWithParseClassName:@"Yarr"];
+    [state excludeKey:@"a"];
+    [state excludeKey:@"b"];
+
+    NSSet *excludedKeys = PF_SET(@"a", @"b");
+    XCTAssertEqualObjects(state.excludedKeys, excludedKeys);
+}
+
+- (void)testExcludeMultipleKeys {
+    PFMutableQueryState *state = [[PFMutableQueryState alloc] initWithParseClassName:@"Yarr"];
+    [state excludeKeys:@[ @"a", @"b", @"c" ]];
+
+    NSSet *excludedKeys = PF_SET(@"a", @"b", @"c");
+    XCTAssertEqualObjects(state.excludedKeys, excludedKeys);
 }
 
 - (void)testSelectKeys {

--- a/Parse/Tests/Unit/QueryUnitTests.m
+++ b/Parse/Tests/Unit/QueryUnitTests.m
@@ -261,6 +261,17 @@
     XCTAssertTrue([query.state.includedKeys containsObject:@"yolo1"]);
 }
 
+- (void)testExcludeKey {
+    PFQuery *query = [PFQuery queryWithClassName:@"a"];
+    [query excludeKey:@"yolo"];
+    XCTAssertEqualObjects(query.state.excludedKeys, (PF_SET(@"yolo")));
+
+    [query excludeKey:@"yolo1"];
+    XCTAssertEqualObjects(query.state.excludedKeys, (PF_SET(@"yolo", @"yolo1")));
+    XCTAssertTrue([query.state.excludedKeys containsObject:@"yolo"]);
+    XCTAssertTrue([query.state.excludedKeys containsObject:@"yolo1"]);
+}
+
 - (void)testSelectKeys {
     PFQuery *query = [PFQuery queryWithClassName:@"a"];
     [query selectKeys:@[ @"a", @"a" ]];
@@ -1320,6 +1331,7 @@
     [query orderByAscending:@"b"];
     [query includeKey:@"c"];
     [query selectKeys:@[ @"d" ]];
+    [query excludeKeys:@[ @"f" ]];
     [query redirectClassNameForKey:@"e"];
 
     query.limit = 10;
@@ -1338,6 +1350,7 @@
     XCTAssertEqualObjects(queryCopy.state.conditions[@"a"], query.state.conditions[@"a"]);
     XCTAssertEqualObjects(queryCopy.state.sortOrderString, query.state.sortOrderString);
     XCTAssertEqualObjects([queryCopy.state.includedKeys anyObject], [query.state.includedKeys anyObject]);
+    XCTAssertEqualObjects([queryCopy.state.excludedKeys anyObject], [query.state.excludedKeys anyObject]);
     XCTAssertEqualObjects([queryCopy.state.selectedKeys anyObject], [query.state.selectedKeys anyObject]);
     XCTAssertEqualObjects([[queryCopy.state.extraOptions allValues] lastObject],
                           [[query.state.extraOptions allValues] lastObject]);


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Added support for parameter excludeKeys in queries (similar to select keys) in order to exclude the desired fields from retrieved objects.

Added in Parse-Server 3.6.0 https://github.com/parse-community/parse-server/pull/5737

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
