### PR TITLE
fix: Compilation error on macOS `Undefined symbol: OBJC_CLASS$_PFProductsRequestHandler`

### DIFF
--- a/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
+++ b/Parse/Parse/Internal/Purchase/Controller/PFPurchaseController.m
@@ -9,6 +9,8 @@
 
 #import "PFPurchaseController.h"
 
+#if TARGET_OS_IOS || TARGET_OS_TV
+
 #import <StoreKit/StoreKit.h>
 
 #if __has_include(<Bolts/BFTaskCompletionSource.h>)
@@ -237,3 +239,5 @@
 }
 
 @end
+
+#endif


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
PFProduct and PFPurchase aren't supported on MacOS

Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1699

### Approach
<!-- Add a description of the approach in this PR. -->
* Remove PFPurchaseController from Mac build

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
