### PR TITLE
refactor: Remove framework builder for assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ A library that gives you access to the powerful Parse Server backend from your i
 ---
 
 - [Getting Started](#getting-started)
-  - [Alternative Installation Options](#alternative-installation-options)
-    - [Compile Source](#compile-source)
-    - [Add Sub-Project](#add-sub-project)
 - [How Do I Contribute?](#how-do-i-contribute)
 - [Dependencies](#dependencies)
 
@@ -41,35 +38,9 @@ The easiest way to install the SDK is via Swift Package Manager.
   https://github.com/parse-community/Parse-SDK-iOS-OSX
   ```
 3. Add package
-3. Choose the submodules you want to install
+4. Choose the submodules you want to install
 
 Take a look at the public [documentation][docs] & [API][api] and start building.
-
-### Alternative Installation Options
-
-#### Compile Source
-
-If you want to manually compile the SDK, clone it locally, and run the following commands in the root directory of the repository:
-
-```
-# To pull in extra dependencies (Bolts and OCMock)
-git submodule update --init --recursive
-
-# To install bundler
-gem install bundler
-
-# To install all the gems via bundler
-bundle install
-
-# Build & Package the Frameworks
-bundle exec rake package:frameworks
-```
-
-Compiled frameworks will be inside the `build/release` folder.
-
-#### Add Sub-Project
-
-You can also include parse as a subproject inside of your application if you'd prefer, although we do not recommend this, as it will increase your indexing time significantly. To do so, just drag and drop the Parse.xcodeproj file into your workspace. Note that unit tests will be unavailable if you use Parse like this, as OCMock will be unable to be found.
 
 ## How Do I Contribute?
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,353 +8,18 @@
 #
 
 require_relative 'Vendor/xctoolchain/Scripts/xctask/build_task'
-require_relative 'Vendor/xctoolchain/Scripts/xctask/build_framework_task'
 
 script_folder = File.expand_path(File.dirname(__FILE__))
 build_folder = File.join(script_folder, 'build')
 starters_folder = File.join(script_folder, 'ParseStarterProject')
-release_folder = File.join(build_folder, 'release')
-bolts_build_folder = File.join(script_folder, 'Carthage', 'Build')
-bolts_folder = File.join(script_folder, 'Carthage', 'Checkouts', 'Bolts-ObjC')
+
 ios_simulator = 'platform="iOS Simulator",name="iPhone 14"'
 tvos_simulator = 'platform="tvOS Simulator",name="Apple TV"'
 watchos_simulator = 'platform="watchOS Simulator",name="Apple Watch Series 8 (45mm)"'
 
 build_action = [XCTask::BuildAction::CLEAN, XCTask::BuildAction::BUILD];
 
-module Constants
-  require 'plist'
-
-  script_folder = File.expand_path(File.dirname(__FILE__))
-
-  PARSE_CONSTANTS_HEADER = File.join(script_folder, 'Parse', 'Parse', 'Source/PFConstants.h')
-
-  PLISTS = [
-    File.join(script_folder, 'Parse', 'Parse', 'Resources', 'Parse-iOS.Info.plist'),
-    File.join(script_folder, 'Parse', 'Parse', 'Resources', 'Parse-OSX.Info.plist'),
-    File.join(script_folder, 'Parse', 'Parse', 'Resources', 'Parse-watchOS.Info.plist'),
-    File.join(script_folder, 'Parse', 'Parse', 'Resources', 'Parse-tvOS.Info.plist'),
-    File.join(script_folder, 'ParseFacebookUtils', 'ParseFacebookUtils', 'Resources', 'Info-iOS.plist'),
-    File.join(script_folder, 'ParseFacebookUtils', 'ParseFacebookUtils', 'Resources', 'Info-tvOS.plist'),
-    File.join(script_folder, 'ParseTwitterUtils', 'ParseTwitterUtils', 'Resources', 'Info-iOS.plist'),
-    File.join(script_folder, 'ParseUI', 'ParseUI', 'Resources', 'Info-iOS.plist'),
-    File.join(script_folder, 'ParseLiveQuery', 'ParseLiveQuery', 'Resources', 'Info.plist'),
-    File.join(script_folder, 'ParseLiveQuery', 'ParseLiveQuery-tvOS', 'Info.plist'),
-    File.join(script_folder, 'ParseLiveQuery', 'ParseLiveQuery-watchOS', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'iOS', 'ParseStarterProject', 'Resources', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'iOS', 'ParseStarterProject-Swift', 'Resources', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'OSX', 'ParseOSXStarterProject', 'Resources', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'OSX', 'ParseOSXStarterProject-Swift', 'Resources', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'tvOS', 'ParseStarterProject-Swift', 'ParseStarter', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'watchOS', 'ParseStarterProject-Swift', 'ParseStarter', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'watchOS', 'ParseStarterProject-Swift', 'ParseStarter Extension', 'Info.plist'),
-    File.join(script_folder, 'ParseStarterProject', 'watchOS', 'ParseStarterProject-Swift', 'Resources', 'Info.plist'),
-  ]
-
-  def self.current_version
-    constants_file = File.open(PARSE_CONSTANTS_HEADER, 'r').read
-    matches = constants_file.match(/(.*PARSE_VERSION\s*@")(.*)(")/)
-    matches[2] # Return the second match, which is the version itself
-  end
-
-  def self.update_version(version)
-    constants_file = File.open(PARSE_CONSTANTS_HEADER, 'r+')
-    constants = constants_file.read
-    constants.gsub!(/(.*PARSE_VERSION\s*@")(.*)(")/, "\\1#{version}\\3")
-
-    constants_file.seek(0)
-    constants_file.write(constants)
-
-    PLISTS.each do |plist|
-      update_info_plist_version(plist, version)
-    end
-  end
-
-  def self.update_info_plist_version(plist_path, version)
-    info_plist = Plist.parse_xml(plist_path)
-    info_plist['CFBundleShortVersionString'] = version
-    info_plist['CFBundleVersion'] = version
-    File.open(plist_path, 'w') { |f| f.write(info_plist.to_plist) }
-  end
-end
-
 namespace :build do
-  desc 'Build iOS framework.'
-  task :ios do
-    task = XCTask::BuildFrameworkTask.new do |t|
-      t.directory = script_folder
-      t.build_directory = build_folder
-      t.framework_type = XCTask::FrameworkType::IOS
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
-      t.scheme = 'Parse-iOS'
-      t.configuration = 'Release'
-    end
-    result = task.execute
-    unless result
-      puts 'Failed to build iOS Framework.'
-      exit(1)
-    end
-  end
-
-  desc 'Build watchOS framework.'
-  task :watchos do
-    task = XCTask::BuildFrameworkTask.new do |t|
-      t.directory = script_folder
-      t.build_directory = build_folder
-      t.framework_type = XCTask::FrameworkType::WATCHOS
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
-      t.scheme = 'Parse-watchOS'
-      t.configuration = 'Release'
-    end
-    result = task.execute
-    unless result
-      puts 'Failed to build watchOS Framework.'
-      exit(1)
-    end
-  end
-
-  desc 'Build macOS framework.'
-  task :macos do
-    task = XCTask::BuildFrameworkTask.new do |t|
-      t.directory = script_folder
-      t.build_directory = build_folder
-      t.framework_type = XCTask::FrameworkType::OSX
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
-      t.scheme = 'Parse-macOS'
-      t.configuration = 'Release'
-    end
-    result = task.execute
-    unless result
-      puts 'Failed to build macOS Framework.'
-      exit(1)
-    end
-  end
-
-  desc 'Build tvOS framework.'
-  task :tvos do
-    task = XCTask::BuildFrameworkTask.new do |t|
-      t.directory = script_folder
-      t.build_directory = build_folder
-      t.framework_type = XCTask::FrameworkType::TVOS
-      t.framework_name = 'Parse.framework'
-
-      t.workspace = 'Parse.xcworkspace'
-      t.scheme = 'Parse-tvOS'
-      t.configuration = 'Release'
-    end
-    result = task.execute
-    unless result
-      puts 'Failed to build tvOS Framework.'
-      exit(1)
-    end
-  end
-
-  namespace :parse_live_query do
-    desc 'Build iOS LiveQuery framework.'
-    task :ios do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'iOS')
-        t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseLiveQuery.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseLiveQuery-iOS'
-        t.configuration = 'Release'
-      end
-      result = task.execute
-      unless result
-        puts 'Failed to build iOS LiveQuery Framework.'
-        exit(1)
-      end
-    end
-
-    desc 'Build macOS LiveQuery framework.'
-    task :macos do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'macOS')
-        t.framework_type = XCTask::FrameworkType::OSX
-        t.framework_name = 'ParseLiveQuery.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseLiveQuery-OSX'
-        t.configuration = 'Release'
-      end
-      result = task.execute
-      unless result
-        puts 'Failed to build macOS LiveQuery Framework.'
-        exit(1)
-      end
-    end
-
-    desc 'Build watchOS LiveQuery framework.'
-    task :watchos do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'watchOS')
-        t.framework_type = XCTask::FrameworkType::WATCHOS
-        t.framework_name = 'ParseLiveQuery_watchOS.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseLiveQuery-watchOS'
-        t.configuration = 'Release'
-      end
-      result = task.execute
-      unless result
-        puts 'Failed to build watchOS LiveQuery Framework.'
-        exit(1)
-      end
-    end
-
-    desc 'Build tvOS LiveQuery framework.'
-    task :tvos do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'tvOS')
-        t.framework_type = XCTask::FrameworkType::TVOS
-        t.framework_name = 'ParseLiveQuery_tvOS.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseLiveQuery-tvOS'
-        t.configuration = 'Release'
-      end
-      result = task.execute
-      unless result
-        puts 'Failed to build tvOS LiveQuery Framework.'
-        exit(1)
-      end
-    end
-  end
-
-  namespace :facebook_utils do
-    desc 'Build iOS FacebookUtils framework.'
-    task :ios do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'iOS')
-        t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseFacebookUtilsV4.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseFacebookUtilsV4-iOS'
-        t.configuration = 'Release'
-      end
-
-      result = task.execute
-      unless result
-        puts 'Failed to build iOS FacebookUtils Framework.'
-        exit(1)
-      end
-    end
-
-    desc 'Build tvOS FacebookUtils framework.'
-    task :tvos do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'tvOS')
-        t.framework_type = XCTask::FrameworkType::TVOS
-        t.framework_name = 'ParseFacebookUtilsV4.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseFacebookUtilsV4-tvOS'
-        t.configuration = 'Release'
-      end
-      result = task.execute
-      unless result
-        puts 'Failed to build tvOS FacebookUtils Framework.'
-        exit(1)
-      end
-    end
-  end
-
-  namespace :twitter_utils do
-    desc 'Build iOS TwitterUtils framework.'
-    task :ios do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'iOS')
-        t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseTwitterUtils.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseTwitterUtils-iOS'
-        t.configuration = 'Release'
-      end
-
-      result = task.execute
-      unless result
-        puts 'Failed to build iOS TwitterUtils Framework.'
-        exit(1)
-      end
-    end
-  end
-
-  namespace :parseui do
-    task :framework do
-      task = XCTask::BuildFrameworkTask.new do |t|
-        t.directory = script_folder
-        t.build_directory = File.join(build_folder, 'iOS')
-        t.framework_type = XCTask::FrameworkType::IOS
-        t.framework_name = 'ParseUI.framework'
-        t.workspace = 'Parse.xcworkspace'
-        t.scheme = 'ParseUI'
-        t.configuration = 'Release'
-      end
-
-      result = task.execute
-      unless result
-        puts 'Failed to build ParseUI'
-        exit(1)
-      end
-    end
-
-    task :demo_objc do
-      task = XCTask::BuildTask.new do |t|
-        t.directory = script_folder
-        t.workspace = 'Parse.xcworkspace'
-
-        t.scheme = 'ParseUIDemo'
-        t.sdk = 'iphonesimulator'
-        t.destinations = [ios_simulator]
-        t.configuration = 'Debug'
-        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
-                                 "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
-
-        t.actions = build_action
-        t.formatter = XCTask::BuildFormatter::XCPRETTY
-      end
-
-      result = task.execute
-      unless result
-        puts 'Failed to build ParseUI Demo.'
-        exit(1)
-      end
-    end
-
-    task :demo_swift do
-      task = XCTask::BuildTask.new do |t|
-        t.directory = script_folder
-        t.workspace = 'Parse.xcworkspace'
-
-        t.scheme = 'ParseUIDemo-Swift'
-        t.sdk = 'iphonesimulator'
-        t.destinations = [ios_simulator]
-        t.configuration = 'Debug'
-        t.additional_options = { "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS" => "YES",
-                                 "GCC_GENERATE_TEST_COVERAGE_FILES" => "YES" }
-
-        t.actions = build_action
-        t.formatter = XCTask::BuildFormatter::XCPRETTY
-      end
-
-      result = task.execute
-      unless result
-        puts 'Failed to build iOS ParseUI Swift Demo.'
-        exit(1)
-      end
-    end
-  end
-
   namespace :ios_starters do
     task :all do
       Rake::Task['build:ios_starters:objc'].invoke
@@ -500,169 +165,18 @@ namespace :build do
   end
 end
 
-namespace :package do
-  package_ios_name = 'Parse-iOS.zip'
-  package_macos_name = 'Parse-macOS.zip'
-  package_tvos_name = 'Parse-tvOS.zip'
-  package_watchos_name = 'Parse-watchOS.zip'
-  package_starter_ios_name = 'ParseStarterProject-iOS.zip'
-  package_starter_osx_name = 'ParseStarterProject-OSX.zip'
-  package_starter_tvos_name = 'ParseStarterProject-tvOS.zip'
-  package_starter_watchos_name = 'ParseStarterProject-watchOS.zip'
-  package_parseui_name = 'ParseUI.zip'
-
-  task :prepare do
-    `rm -rf #{build_folder} && mkdir -p #{build_folder}`
-    `#{bolts_folder}/scripts/build_framework.sh -n -c Release --with-watchos --with-tvos`
-  end
-
-  task :set_version, [:version] do |_, args|
-    version = args[:version] || Constants.current_version
-    Constants.update_version(version)
-  end
-
-  desc 'Build all frameworks and starters'
-  task :release do |_|
-    Rake::Task['package:frameworks'].invoke
-  end
-
-  desc 'Build and package all frameworks for the release'
-  task :frameworks, [:version] => :prepare do |_, args|
-    version = args[:version] || Constants.current_version
-    Constants.update_version(version)
-
-    ## Build macOS Framework
-    Rake::Task['build:macos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'osx', 'Bolts.framework')
-    osx_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [osx_framework_path, bolts_path],
-                 package_macos_name)
-
-    ## Build iOS Framework
-    Rake::Task['build:ios'].invoke
-    bolts_path = File.join(bolts_build_folder, 'ios', 'Bolts.framework')
-    ios_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [ios_framework_path, bolts_path],
-                 package_ios_name)
-
-    ## Build tvOS Framework
-    Rake::Task['build:tvos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'tvOS', 'Bolts.framework')
-    tvos_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                  [tvos_framework_path, bolts_path],
-                  package_tvos_name)
-
-    ## Build watchOS Framework
-    Rake::Task['build:watchos'].invoke
-    bolts_path = File.join(bolts_build_folder, 'watchOS', 'Bolts.framework')
-    watchos_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [watchos_framework_path, bolts_path],
-                 package_watchos_name)
-
-    Rake::Task['build:facebook_utils:ios'].invoke
-    ios_fb_utils_framework_path = File.join(build_folder, 'iOS', 'ParseFacebookUtilsV4.framework')
-    make_package(release_folder, [ios_fb_utils_framework_path], 'ParseFacebookUtils-iOS.zip')
-
-    Rake::Task['build:twitter_utils:ios'].invoke
-    ios_tw_utils_framework_path = File.join(build_folder, 'iOS', 'ParseTwitterUtils.framework')
-    make_package(release_folder, [ios_tw_utils_framework_path], 'ParseTwitterUtils-iOS.zip')
-
-    Rake::Task['build:facebook_utils:tvos'].invoke
-    tvos_fb_utils_framework_path = File.join(build_folder, 'tvOS', 'ParseFacebookUtilsV4.framework')
-    make_package(release_folder, [tvos_fb_utils_framework_path], 'ParseFacebookUtils-tvOS.zip')
-
-    Rake::Task['build:parseui:framework'].invoke
-    parseui_framework_path = File.join(build_folder, 'iOS', 'ParseUI.framework')
-    make_package(release_folder,
-                [parseui_framework_path],
-                package_parseui_name)
-    
-    Rake::Task['build:parse_live_query:ios'].invoke
-    ios_lq_framework_path = File.join(build_folder, 'iOS', 'ParseLiveQuery.framework')
-    make_package(release_folder, [ios_lq_framework_path], 'ParseLiveQuery-iOS.zip')
-
-    Rake::Task['build:parse_live_query:watchos'].invoke
-    watchos_lq_fb_utils_framework_path = File.join(build_folder, 'watchOS', 'ParseLiveQuery_watchOS.framework')
-    make_package(release_folder, [watchos_lq_fb_utils_framework_path], 'ParseLiveQuery-watchOS.zip')
-
-    Rake::Task['build:parse_live_query:tvos'].invoke
-    tvos_lq_framework_path = File.join(build_folder, 'tvOS', 'ParseLiveQuery_tvOS.framework')
-    make_package(release_folder, [tvos_lq_framework_path], 'ParseLiveQuery-tvOS.zip')
-
-    Rake::Task['build:parse_live_query:macos'].invoke
-    macos_lq_utils_framework_path = File.join(build_folder, 'macOS', 'ParseLiveQuery.framework')
-    make_package(release_folder, [macos_lq_utils_framework_path], 'ParseLiveQuery-OSX.zip')
-  end
-
-  def make_package(target_path, items, archive_name)
-    temp_folder = File.join(target_path, 'tmp')
-    `mkdir -p #{temp_folder}`
-
-    item_list = ''
-    items.each do |item|
-      `cp -R #{item} #{temp_folder}`
-
-      file_name = File.basename(item)
-      item_list << " #{file_name}"
-    end
-
-    archive_path = File.join(target_path, archive_name)
-    `cd #{temp_folder}; zip -r --symlinks #{archive_path} #{item_list}`
-    `rm -rf #{temp_folder}`
-    puts "Release archive created: #{File.join(target_path, archive_name)}"
-  end
-
-  def make_starter_package(target_path, starter_projects, framework_archive, archive_name)
-    starter_projects.each do |project_path|
-      `git clean -xfd #{project_path}`
-      `cd #{project_path} && unzip -o #{framework_archive}`
-
-      xcodeproj_path = Dir.glob(File.join(project_path, '*.xcodeproj'))[0]
-      prepare_xcodeproj(xcodeproj_path)
-    end
-    make_package(target_path, starter_projects, archive_name)
-
-    starter_projects.each do |project_path|
-      `git clean -xfd #{project_path}`
-      `git checkout #{project_path}`
-    end
-  end
-
-  def prepare_xcodeproj(path)
-    project = Xcodeproj::Project.open(path)
-    project.targets.each do |target|
-      if target.name == 'Bootstrap'
-        target.remove_from_project
-      else
-        target.dependencies.each do |dependency|
-          dependency.remove_from_project if dependency.display_name == 'Bootstrap'
-        end
-      end
-    end
-    project.save
-
-    `rm -rf #{File.join(path, 'xcshareddata', 'xcschemes', '*')}`
-  end
-end
-
 namespace :test do
   desc 'Run iOS Tests'
   task :ios do |_, args|
     task = XCTask::BuildTask.new do |t|
       t.directory = script_folder
       t.workspace = 'Parse.xcworkspace'
-
       t.scheme = 'Parse-iOS'
       t.sdk = 'iphonesimulator'
       t.destinations = [ios_simulator]
       t.configuration = 'Debug -enableCodeCoverage YES'
-
       t.actions = [XCTask::BuildAction::TEST]
-      t.formatter = XCTask::BuildFormatter::XCODEBUILD
+      t.formatter = XCTask::BuildFormatter::XCPRETTY
     end
     unless task.execute
       puts 'iOS Tests Failed!'
@@ -675,13 +189,11 @@ namespace :test do
     task = XCTask::BuildTask.new do |t|
       t.directory = script_folder
       t.workspace = 'Parse.xcworkspace'
-
       t.scheme = 'Parse-macOS'
       t.sdk = 'macosx'
       t.configuration = 'Debug -enableCodeCoverage YES'
-
       t.actions = [XCTask::BuildAction::TEST]
-      t.formatter = XCTask::BuildFormatter::XCODEBUILD
+      t.formatter = XCTask::BuildFormatter::XCPRETTY
     end
     unless task.execute
       puts 'macOS Tests Failed!'
@@ -695,18 +207,14 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseFacebookUtilsV4-iOS'
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug -enableCodeCoverage YES'
-
         t.actions = [XCTask::BuildAction::TEST]
-        t.formatter = XCTask::BuildFormatter::XCODEBUILD
+        t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build iOS FacebookUtils Framework.'
         exit(1)
       end
@@ -719,18 +227,14 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseTwitterUtils-iOS'
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug -enableCodeCoverage YES'
-
         t.actions = [XCTask::BuildAction::TEST]
-        t.formatter = XCTask::BuildFormatter::XCODEBUILD
+        t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build iOS TwitterUtils Framework.'
         exit(1)
       end
@@ -747,18 +251,14 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseUI'
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug -enableCodeCoverage YES'
-
         t.actions = [XCTask::BuildAction::TEST]
-        t.formatter = XCTask::BuildFormatter::XCODEBUILD
+        t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build ParseUI'
         exit(1)
       end
@@ -768,18 +268,14 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseUIDemo'
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-
         t.actions = build_action
         t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build ParseUI Demo.'
         exit(1)
       end
@@ -789,18 +285,14 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseUIDemo-Swift'
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-
         t.actions = build_action
         t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build iOS ParseUI Swift Demo.'
         exit(1)
       end
@@ -819,18 +311,14 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseLiveQuery-iOS'
         t.sdk = 'iphonesimulator'
         t.destinations = [ios_simulator]
         t.configuration = 'Debug'
-
         t.actions = build_action
         t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build ParseLiveQuery'
         exit(1)
       end
@@ -840,18 +328,13 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseLiveQuery-tvOS'
         t.destinations = [tvos_simulator]
         t.configuration = 'Debug'
-        
-
         t.actions = build_action
         t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build ParseLiveQuery-tvOS.'
         exit(1)
       end
@@ -861,18 +344,13 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseLiveQuery-watchOS'
         t.destinations = [watchos_simulator]
         t.configuration = 'Debug'
-        
-
         t.actions = build_action
         t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build ParseLiveQuery-watchOS.'
         exit(1)
       end
@@ -882,17 +360,12 @@ namespace :test do
       task = XCTask::BuildTask.new do |t|
         t.directory = script_folder
         t.workspace = 'Parse.xcworkspace'
-
         t.scheme = 'ParseLiveQuery-OSX'
         t.configuration = 'Debug'
-    
-
         t.actions = build_action
         t.formatter = XCTask::BuildFormatter::XCPRETTY
       end
-
-      result = task.execute
-      unless result
+      unless task.execute
         puts 'Failed to build ParseLiveQuery-OSX.'
         exit(1)
       end


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
xctoolchain framework builder doesn't work for release configuration builds on Xcode 14+. 

Closes: N/A

### Approach
<!-- Add a description of the approach in this PR. -->
Eventually we would want to create xcframework assets for publishing. We can use [swift-create-xcframework](https://github.com/unsignedapps/swift-create-xcframework) or this [Makefile](https://github.com/dplewis/Parse-SDK-iOS-OSX/blob/xcframework/Makefile) that I'm testing. They far are simpler solutions than working with xctoolchain.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
