### PR TITLE
test: [DO NOT MERGE] Run ParseUI Swift Demo without Dynamic Targets

### DIFF
--- a/ParseUI/ParseUI.xcodeproj/project.pbxproj
+++ b/ParseUI/ParseUI.xcodeproj/project.pbxproj
@@ -184,19 +184,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4A0ECCAC200DA7D100BA84A3 /* PBXContainerItemProxy */ = {
+		39D1F8932AD1AA7D0011B331 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 4A9A9496200D0329005D8F4B;
 			remoteInfo = ParseUI;
 		};
-		4A0ECCB0200DA8DC00BA84A3 /* PBXContainerItemProxy */ = {
+		4A0ECCAC200DA7D100BA84A3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4A0ECBE4200D8C0200BA84A3;
-			remoteInfo = "ParseUI-Dynamic";
+			remoteGlobalIDString = 4A9A9496200D0329005D8F4B;
+			remoteInfo = ParseUI;
 		};
 		7C77D138292A50BF00C4D90E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1272,7 +1272,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				4A0ECCB1200DA8DC00BA84A3 /* PBXTargetDependency */,
+				39D1F8942AD1AA7D0011B331 /* PBXTargetDependency */,
 			);
 			name = "ParseUIDemo-Swift";
 			productName = ParseUIDemo;
@@ -1745,15 +1745,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		39D1F8942AD1AA7D0011B331 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4A9A9496200D0329005D8F4B /* ParseUI */;
+			targetProxy = 39D1F8932AD1AA7D0011B331 /* PBXContainerItemProxy */;
+		};
 		4A0ECCAD200DA7D100BA84A3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4A9A9496200D0329005D8F4B /* ParseUI */;
 			targetProxy = 4A0ECCAC200DA7D100BA84A3 /* PBXContainerItemProxy */;
-		};
-		4A0ECCB1200DA8DC00BA84A3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 4A0ECBE4200D8C0200BA84A3 /* ParseUI-Dynamic */;
-			targetProxy = 4A0ECCB0200DA8DC00BA84A3 /* PBXContainerItemProxy */;
 		};
 		7C77D14F292A50F600C4D90E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Rakefile
+++ b/Rakefile
@@ -245,6 +245,7 @@ namespace :test do
     task :all do
       Rake::Task['test:parseui:framework'].invoke
       Rake::Task['test:parseui:demo_objc'].invoke
+      Rake::Task['test:parseui:demo_swift'].invoke
     end
 
     task :framework do


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The only way to remove Bolts from Carthage is to remove all Dynamic Targets. ParseUI Swift Demo is the only target using it. I'm wondering why its not included in the CI build. If this test fails then we will have to remove the ParseUI swift support from the Repo unless we want to keep Bolts Carthage.

Looks like Bolts Carthage has already started failing in other Jobs

https://github.com/parse-community/Parse-SDK-iOS-OSX/actions/runs/6441796016/job/17491943259?pr=1756
https://github.com/parse-community/Parse-SDK-iOS-OSX/actions/runs/6440880523/job/17490133303
