### PR TITLE
Add SecureEncoder support to PFFileObject

### DIFF
--- a/Parse/Parse/Source/PFFileObject.h
+++ b/Parse/Parse/Source/PFFileObject.h
@@ -31,7 +31,14 @@ __attribute__((unavailable("PFFile was renamed to PFFileObject. Please use it in
  `PFFileObject` representes a file of binary data stored on the Parse servers.
  This can be a image, video, or anything else that an application needs to reference in a non-relational way.
  */
-@interface PFFileObject : NSObject
+@interface PFFileObject : NSObject <NSSecureCoding>
+
+/**
+ Class property required for NSSecureCoding: also it must return YES
+
+ @return Whether the class supports NSSecureCoding..
+ */
++ (BOOL)supportsSecureCoding;
 
 ///--------------------------------------
 #pragma mark - Creating a PFFileObject

--- a/Parse/Parse/Source/PFFileObject.m
+++ b/Parse/Parse/Source/PFFileObject.m
@@ -51,6 +51,8 @@
 
 @synthesize stagedFilePath = _stagedFilePath;
 
++ (BOOL)supportsSecureCoding { return YES; }
+
 ///--------------------------------------
 #pragma mark - Public
 ///--------------------------------------
@@ -501,6 +503,24 @@
 
 + (PFFileController *)fileController {
     return [Parse _currentManager].coreManager.fileController;
+}
+
+#pragma mark - NSSecureCoding
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    PFEncoder *encoder = [PFEncoder objectEncoder];
+    __autoreleasing NSError *error;
+    NSDictionary *dict = [encoder encodeObject:self error:&error];
+    if (dict && error == nil) {
+        [coder encodeObject:dict];
+    }
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
+    NSDictionary *dict = [coder decodeObject];
+    PFDecoder *decoder = [PFDecoder objectDecoder];
+    PFFileObject *fileObject = [decoder decodeObject:dict];
+    return (fileObject.name && fileObject.url) ? fileObject : nil;
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [X ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [X ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1736).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

PFFileObjects can be used outside of a PFObject subclass. When archiving them and other objects using the NSSecureEncoder, the encoder now fails with an error that PFFileObjects are not secure coding compliant.

Fine - in Objective-C, I create a class extension to add it. Works fine. However, when I go to change that extension to Swift, the compilation fails with the error that NSSecureCoding cannot be added in a class extension (but must be done by the original class).

Closes: n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add NSSecureCoding to PFFileObject:
- return YES from the class method `supportsSecureCoding`
- encode the object using the existing `PFEncoder objectEncoder`
- decode the object using `PFDecoder objectDecoder`
-
### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
