### PR TITLE
ci: Fix failing CI by pinning bundler version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   tests:
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       matrix:
         script:
@@ -94,6 +94,7 @@ jobs:
           xcode_archive_path: ${{ env.TEST_RESULTS }}
   docs:
     runs-on: macos-13
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Submodules
         run: |
           git submodule update --init --recursive
-          sudo gem install bundler
+          sudo gem install bundler -v 2.4.22
           bundle config set path 'vendor/bundle'
       - name: Bundle Install
         if: steps.cache-gems.outputs.cache-hit != 'true'
@@ -109,7 +109,7 @@ jobs:
       - name: Submodules
         run: |
           git submodule update --init --recursive
-          sudo gem install bundler
+          sudo gem install bundler -v 2.4.22
           bundle config path vendor/bundle
       - name: Bundle Install
         if: steps.cache-gems.outputs.cache-hit != 'true'

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Submodules and Bundle Install
         run: |
           git submodule update --init --recursive
-          sudo gem install bundler
+          sudo gem install bundler -v 2.4.22
           bundle config set path 'vendor/bundle'
           bundle install
       - run: npm ci
@@ -64,7 +64,7 @@ jobs:
       - name: Submodules
         run: |
           git submodule update --init --recursive
-          sudo gem install bundler
+          sudo gem install bundler -v 2.4.22
           bundle config path vendor/bundle
       - name: Bundle Install
         if: steps.cache-gems.outputs.cache-hit != 'true'

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Submodules
         run: |
           git submodule update --init --recursive
-          sudo gem install bundler
+          sudo gem install bundler -v 2.4.22
           bundle config path vendor/bundle
       - name: Bundle Install
         if: steps.cache-gems.outputs.cache-hit != 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ For analyzing bugs, creating bug fixes and features we recommend to clone this r
    Install all dependencies:
    ```
    git submodule update --init --recursive
-   gem install bundler
+   gem install bundler -v 2.4.22
    bundle install
    ```
    Run the tests:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description

Closes: #1777 

### Approach

Pin bundler version to not use latest version that requires ruby >= 3

