### PR TITLE
fix: Automatic loading of `PFObject` subclasses not working on Xcode 16

### DIFF
--- a/Parse/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
+++ b/Parse/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
@@ -381,6 +381,14 @@ static NSNumber *PFNumberCreateSafe(const char *typeEncoding, const void *bytes)
         unsigned bundleClassCount = 0;
 
         for (int i = 0; i < sizeof(potentialPaths) / sizeof(*potentialPaths); i++) {
+            #ifdef DEBUG
+                const char *debugSuffix = ".debug.dylib";
+                if (strlen(potentialPaths[i]) + strlen(debugSuffix) < sizeof(potentialPaths[i])) {
+                    strcat(potentialPaths[i], debugSuffix);
+                } else {
+                    printf("Error: Not enough space to append the suffix.\n");
+                }
+            #endif
             classNames = objc_copyClassNamesForImage(potentialPaths[i], &bundleClassCount);
             if (bundleClassCount) {
                 break;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1792).

### Issue Description
Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1792

Xcode 16 changes the default setting for [Enable Debug Dylib Support](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support) to `YES` which adds a suffix of `.debug.dylib` to the target at runtime meaning the standard call of `objc_copyClassNamesForImage` with the image name will not find anything while the scheme is running in Debug mode. 

### Approach
Adding the suffix based on the scheme build configuration fixes the issue to find the target at runtime and makes `objc_copyClassNamesForImage` work as expected.

