### PR TITLE
ci: Fix CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   tests:
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         script:


### PR DESCRIPTION
Fixes Ci timeout, see for ex: https://github.com/parse-community/Parse-SDK-iOS-OSX/actions/runs/10906352787/job/30538838978?pr=1808

