### PR TITLE
fix: App crashes on launch and SwiftUI preview when built with Xcode 16 due to unregistered Parse subclasses

### DIFF
--- a/Parse/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
+++ b/Parse/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
@@ -357,7 +357,18 @@ static NSNumber *PFNumberCreateSafe(const char *typeEncoding, const void *bytes)
 - (void)_registerSubclassesInBundle:(NSBundle *)bundle {
     PFConsistencyAssert(bundle.loaded, @"Cannot register subclasses in an unloaded bundle: %@", bundle);
 
-    const char *executablePath = bundle.executablePath.UTF8String;
+    [self _registerSubclassesInExecutablePath:bundle.executablePath];
+    
+#if defined(DEBUG) && DEBUG
+    if (bundle == [NSBundle mainBundle]) {
+        NSString *executablePath = [NSString stringWithFormat:@"%@.debug.dylib", bundle.executablePath];
+        [self _registerSubclassesInExecutablePath:executablePath];
+    }
+#endif
+}
+
+- (void)_registerSubclassesInExecutablePath:(NSString *)exePath {
+    const char *executablePath = exePath.UTF8String;
     if (executablePath == NULL) {
         return;
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1792).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
App crashes on app startup when built with Xcode 16:

> The class PFPin must be registered with registerSubclass before using Parse

Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1792

### Approach
<!-- Add a description of the approach in this PR. -->
Starting Xcode 16, Apple adds this new build setting in Xcode: ENABLE_DEBUG_DYLIB, enabled by default.

Per Apple's [doc](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support): 
> If enabled, debug builds of app and app extension targets on supported platforms and SDKs will be built with the main binary code in a separate “NAME.debug.dylib”. 

When getting class names from a binary, we should check on the "NAME.debug.dylib" binary file as well, instead of assuming the "NAME" binary file.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
