### PR TITLE
refactor: Bump OCMock to 3.9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 env:
   CI_XCODE_14: /Applications/Xcode_14.2.app/Contents/Developer
   CI_XCODE_15: /Applications/Xcode_15.4.0.app/Contents/Developer
-  CI_XCODE_16: /Applications/Xcode_16.1.app/Contents/Developer
+  CI_XCODE_16: /Applications/Xcode_16.0.app/Contents/Developer
 jobs:
   tests:
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 env:
   CI_XCODE_14: /Applications/Xcode_14.2.app/Contents/Developer
   CI_XCODE_15: /Applications/Xcode_15.4.0.app/Contents/Developer
-  CI_XCODE_16: /Applications/Xcode_16.0.app/Contents/Developer
+  CI_XCODE_16: /Applications/Xcode_16.1.app/Contents/Developer
 jobs:
   tests:
     env:

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/erikdoe/ocmock.git",
         "state": {
           "branch": null,
-          "revision": "67bb9602f0a7541f24dc2d6d0d7389ca3e4c2c89",
-          "version": null
+          "revision": "2c0bfd373289f4a7716db5d6db471640f91a6507",
+          "version": "3.9.4"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -25,7 +25,7 @@
         "state": {
           "branch": null,
           "revision": "2c0bfd373289f4a7716db5d6db471640f91a6507",
-          "version": "3.9.4"
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/parse-community/Bolts-ObjC.git", from: "1.10.0"),
         .package(url: "https://github.com/BoltsFramework/Bolts-Swift.git", from: "1.5.0"),
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.8"),
-        .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock.git", .revision("67bb9602f0a7541f24dc2d6d0d7389ca3e4c2c89"))
+        .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock.git", from: "3.9.4")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/parse-community/Bolts-ObjC.git", from: "1.10.0"),
         .package(url: "https://github.com/BoltsFramework/Bolts-Swift.git", from: "1.5.0"),
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.8"),
-        .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock.git", from: "3.9.4")
+        .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock.git", .revision("2c0bfd373289f4a7716db5d6db471640f91a6507"))
     ],
     targets: [
         .target(

--- a/Parse.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Parse.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/erikdoe/ocmock",
         "state": {
           "branch": null,
-          "revision": "67bb9602f0a7541f24dc2d6d0d7389ca3e4c2c89",
-          "version": null
+          "revision": "2c0bfd373289f4a7716db5d6db471640f91a6507",
+          "version": "3.9.4"
         }
       },
       {

--- a/Parse.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Parse.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -25,7 +25,7 @@
         "state": {
           "branch": null,
           "revision": "2c0bfd373289f4a7716db5d6db471640f91a6507",
-          "version": "3.9.4"
+          "version": null
         }
       },
       {

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -8907,8 +8907,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/erikdoe/ocmock";
 			requirement = {
-				kind = exactVersion;
-				version = 3.9.4;
+				kind = revision;
+				revision = 2c0bfd373289f4a7716db5d6db471640f91a6507;
 			};
 		};
 		39E24A0B2AD214540014357C /* XCRemoteSwiftPackageReference "Bolts-ObjC" */ = {

--- a/Parse/Parse.xcodeproj/project.pbxproj
+++ b/Parse/Parse.xcodeproj/project.pbxproj
@@ -8907,8 +8907,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/erikdoe/ocmock";
 			requirement = {
-				kind = revision;
-				revision = 67bb9602f0a7541f24dc2d6d0d7389ca3e4c2c89;
+				kind = exactVersion;
+				version = 3.9.4;
 			};
 		};
 		39E24A0B2AD214540014357C /* XCRemoteSwiftPackageReference "Bolts-ObjC" */ = {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Fixes issue when running test on Xcode 16.1 RC / beta. Previously 3.9.2
```
xxx/NSObject+OCMAdditions.m:49:14: Incompatible function pointer types returning 'void (id _Nonnull, SEL _Nonnull, ...)' from a function with result type 'IMP' (aka 'id  _Nullable (*)(id _Nonnull, SEL _Nonnull, ...)')
```

https://github.com/erikdoe/ocmock/releases/tag/v3.9.4