### PR TITLE
feat: Add support for Xcode 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-[![Build Status CI](https://github.com/parse-community/Parse-SDK-iOS-OSX/workflows/ci/badge.svg?branch=master)](https://github.com/parse-community/Parse-SDK-iOS-OSX/actions?query=workflow%3Aci+branch%3Amaster)
+[![Build Status CI](https://github.com/parse-community/Parse-SDK-iOS-OSX/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/parse-community/Parse-SDK-iOS-OSX/actions?query=workflow%3Aci+branch%3Amaster)
 [![Build Status Release](https://github.com/parse-community/Parse-SDK-iOS-OSX/actions/workflows/release-automated.yml/badge.svg)](https://github.com/parse-community/Parse-SDK-iOS-OSX/actions?query=workflow%3Arelease-automated)
 [![Snyk Badge](https://snyk.io/test/github/parse-community/Parse-SDK-iOS-OSX/badge.svg)](https://snyk.io/test/github/parse-community/Parse-SDK-iOS-OSX)
 [![Coverage](https://img.shields.io/codecov/c/github/parse-community/Parse-SDK-iOS-OSX/master.svg)](https://codecov.io/github/parse-community/Parse-SDK-iOS-OSX?branch=master)


### PR DESCRIPTION
The purpose of this PR is to trigger a release. The changes for Xcode 16 support have been done in https://github.com/parse-community/Parse-SDK-iOS-OSX/pull/1818, which was merged as `ci` instead of `feat` and hence did not trigger a release.