### PR TITLE
feat: Add `PFObject.fromDictionary` to create an object from dictionary

### DIFF
--- a/Parse/Parse/Source/PFObject.h
+++ b/Parse/Parse/Source/PFObject.h
@@ -890,8 +890,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param dictionary Undecoded dictionary.
  @param defaultClassName The className of the resulting object if none is given by the dictionary.
  */
-+ (id)objectFromDictionary:(NSDictionary *)dictionary
-          defaultClassName:(NSString *)defaultClassName;
++ (id)fromDictionary:(NSDictionary *)dictionary
+    defaultClassName:(NSString *)defaultClassName;
 
 @end
 

--- a/Parse/Parse/Source/PFObject.h
+++ b/Parse/Parse/Source/PFObject.h
@@ -880,6 +880,19 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                     withName:(NSString *)name
                        block:(nullable PFBooleanResultBlock)block;
 
+///--------------------------------------
+#pragma mark - Serialization
+///--------------------------------------
+
+/**
+ Creates a PFObject from a dictionary object.
+
+ @param dictionary Undecoded dictionary.
+ @param defaultClassName The className of the resulting object if none is given by the dictionary.
+ */
++ (id)objectFromDictionary:(NSDictionary *)dictionary
+          defaultClassName:(NSString *)defaultClassName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Parse/Parse/Source/PFObject.m
+++ b/Parse/Parse/Source/PFObject.m
@@ -809,8 +809,8 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return YES;
 }
 
-+ (id)objectFromDictionary:(NSDictionary *)dictionary
-           defaultClassName:(NSString *)defaultClassName {
++ (id)fromDictionary:(NSDictionary *)dictionary
+    defaultClassName:(NSString *)defaultClassName {
     return [self _objectFromDictionary:dictionary
                       defaultClassName:defaultClassName
                           completeData:YES];

--- a/Parse/Parse/Source/PFObject.m
+++ b/Parse/Parse/Source/PFObject.m
@@ -809,6 +809,13 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return YES;
 }
 
++ (id)objectFromDictionary:(NSDictionary *)dictionary
+           defaultClassName:(NSString *)defaultClassName {
+    return [self _objectFromDictionary:dictionary
+                      defaultClassName:defaultClassName
+                          completeData:YES];
+}
+
 + (id)_objectFromDictionary:(NSDictionary *)dictionary
            defaultClassName:(NSString *)defaultClassName
                completeData:(BOOL)completeData {

--- a/Parse/Tests/Unit/ObjectUnitTests.m
+++ b/Parse/Tests/Unit/ObjectUnitTests.m
@@ -361,10 +361,10 @@
     XCTAssertNil(error);
 }
 
-- (void)testObjectFromDictionary {
+- (void)testFromDictionary {
     NSDictionary *dict = @{ @"objectId": @"XYZ", @"score" : @1.0 };
-    PFObject *object = [PFObject objectFromDictionary:dict
-                                      defaultClassName:@"Test"];
+    PFObject *object = [PFObject fromDictionary:dict
+                               defaultClassName:@"Test"];
 
     XCTAssertEqualObjects(dict[@"objectId"], object.objectId);
     XCTAssertEqualObjects(dict[@"score"], object[@"score"]);

--- a/Parse/Tests/Unit/ObjectUnitTests.m
+++ b/Parse/Tests/Unit/ObjectUnitTests.m
@@ -361,4 +361,13 @@
     XCTAssertNil(error);
 }
 
+- (void)testObjectFromDictionary {
+    NSDictionary *dict = @{ @"objectId": @"XYZ", @"score" : @1.0 };
+    PFObject *object = [PFObject objectFromDictionary:dict
+                                      defaultClassName:@"Test"];
+
+    XCTAssertEqualObjects(dict[@"objectId"], object.objectId);
+    XCTAssertEqualObjects(dict[@"score"], object[@"score"]);
+}
+
 @end

--- a/Rakefile
+++ b/Rakefile
@@ -12,9 +12,9 @@ require_relative 'Vendor/xctoolchain/Scripts/xctask/build_task'
 SCRIPT_PATH = File.expand_path(File.dirname(__FILE__))
 starters_path = File.join(SCRIPT_PATH, 'ParseStarterProject')
 
-ios_simulator = 'platform="iOS Simulator",name="iPhone 15"'
+ios_simulator = 'platform="iOS Simulator",name="iPhone 14"'
 tvos_simulator = 'platform="tvOS Simulator",name="Apple TV"'
-watchos_simulator = 'platform="watchOS Simulator",name="Apple Watch Series 7 (45mm)"'
+watchos_simulator = 'platform="watchOS Simulator",name="Apple Watch Series 8 (45mm)"'
 
 build_action = [XCTask::BuildAction::CLEAN, XCTask::BuildAction::BUILD];
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ require_relative 'Vendor/xctoolchain/Scripts/xctask/build_task'
 SCRIPT_PATH = File.expand_path(File.dirname(__FILE__))
 starters_path = File.join(SCRIPT_PATH, 'ParseStarterProject')
 
-ios_simulator = 'platform="iOS Simulator",name="iPhone 14"'
+ios_simulator = 'platform="iOS Simulator",name="iPhone 15"'
 tvos_simulator = 'platform="tvOS Simulator",name="Apple TV"'
 watchos_simulator = 'platform="watchOS Simulator",name="Apple Watch Series 7 (45mm)"'
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ starters_path = File.join(SCRIPT_PATH, 'ParseStarterProject')
 
 ios_simulator = 'platform="iOS Simulator",name="iPhone 14"'
 tvos_simulator = 'platform="tvOS Simulator",name="Apple TV"'
-watchos_simulator = 'platform="watchOS Simulator",name="Apple Watch Series 8 (45mm)"'
+watchos_simulator = 'platform="watchOS Simulator",name="Apple Watch Series 7 (45mm)"'
 
 build_action = [XCTask::BuildAction::CLEAN, XCTask::BuildAction::BUILD];
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
There is no way easy way to convert a dictionary to a PFObject. This is useful if you return a json server side and want to decode it client side. Analogous to `Parse.Object.fromJSON` in the JS SDK

### Approach
<!-- Add a description of the approach in this PR. -->
Add a wrapper around the private method `_objectFromDictionary`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
