### PR TITLE
docs: Add compatibility table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Parse Apple SDK is compatible with the following versions of Parse Server.
 
 The Parse Apple SDK is continuously tested with the most recent releases of Xcode to ensure compatibility. We follow the annual release schedule of Xcode to support the current and previous major Xcode version.
 
-| Xcode Version | iOS Version | macOS Version | Release Date   | End-of-Support Date | Parse Apple SDK Support |
-|---------------|-------------|---------------|----------------|---------------------|-------------------------|
-| Xcode 13      | iOS 15      | macOS 12      | September 2021 | October 2022        | >= 1.19.3 <2.7.2        |
-| Xcode 14      | iOS 16      | macOS 13      | September 2022 | October 2023        | >= 2.7.2                |
-| Xcode 15      | iOS 17      | macOS 14      | September 2023 | October 2024        | >= 3.0.0                |
-| Xcode 16      | iOS 18      | macOS 15      | September 2024 | tbd                 | >= 4.2.0                |
-| Xcode 17      | iOS 19      | macOS 16      | tbd            | tbd                 | tbd                     |
+| Xcode Version | iOS Version | macOS Version | macOS Version | Release Date   | End-of-Support Date | Parse Apple SDK Support |
+|---------------|-------------|---------------|---------------|----------------|---------------------|-------------------------|
+| Xcode 13      | iOS 15      | macOS 12      | watchOS 8     | September 2021 | October 2022        | >= 1.19.3 <2.7.2        |
+| Xcode 14      | iOS 16      | macOS 13      | watchOS 9     | September 2022 | October 2023        | >= 2.7.2                |
+| Xcode 15      | iOS 17      | macOS 14      | watchOS 10    | September 2023 | October 2024        | >= 3.0.0                |
+| Xcode 16      | iOS 18      | macOS 15      | watchOS 11    | September 2024 | tbd                 | >= 4.2.0                |
+| Xcode 17      | iOS 19      | macOS 16      | watchOS 12    | tbd            | tbd                 | tbd                     |
 
 ## How Do I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A library that gives you access to the powerful Parse Server backend from your i
 - [Getting Started](#getting-started)
 - [Compatibility](#compatibility)
   - [Parse Server](#parse-server)
-  - [Xcode](#xcode)
+  - [Xcode, iOS, macOS](#xcode-ios-macos)
 - [How Do I Contribute?](#how-do-i-contribute)
 - [Dependencies](#dependencies)
 
@@ -62,17 +62,17 @@ Parse Apple SDK is compatible with the following versions of Parse Server.
 |-----------------|--------------|
 | 1.0.0           | >= 1.0.0     |
 
-### Xcode
+### Xcode, iOS, macOS
 
 The Parse Apple SDK is continuously tested with the most recent releases of Xcode to ensure compatibility. We follow the annual release schedule of Xcode to support the current and previous major Xcode version.
 
-| Xcode Version | iOS Version | Release Date   | End-of-Support Date | Parse Apple SDK Support |
-|---------------|-------------|----------------|---------------------|-------------------------|
-| Xcode 13      | iOS 15      | September 2021 | October 2022        | >= 1.19.3 <2.7.2        |
-| Xcode 14      | iOS 16      | September 2022 | October 2023        | >= 2.7.2                |
-| Xcode 15      | iOS 17      | September 2023 | October 2024        | >= 3.0.0                |
-| Xcode 16      | iOS 18      | September 2024 | tbd                 | >= 4.2.0                |
-| Xcode 17      | iOS 19      | tbd            | tbd                 | tbd                     |
+| Xcode Version | iOS Version | macOS Version | Release Date   | End-of-Support Date | Parse Apple SDK Support |
+|---------------|-------------|---------------|----------------|---------------------|-------------------------|
+| Xcode 13      | iOS 15      | macOS 12      | September 2021 | October 2022        | >= 1.19.3 <2.7.2        |
+| Xcode 14      | iOS 16      | macOS 13      | September 2022 | October 2023        | >= 2.7.2                |
+| Xcode 15      | iOS 17      | macOS 14      | September 2023 | October 2024        | >= 3.0.0                |
+| Xcode 16      | iOS 18      | macOS 15      | September 2024 | tbd                 | >= 4.2.0                |
+| Xcode 17      | iOS 19      | macOS 16      | tbd            | tbd                 | tbd                     |
 
 ## How Do I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ Parse Apple SDK is compatible with the following versions of Parse Server.
 
 The Parse Apple SDK is continuously tested with the most recent releases of Xcode to ensure compatibility. We follow the annual release schedule of Xcode to support the current and previous major Xcode version.
 
-| Version  | Minimum Version | End-of-Life  | Parse Apple SDK Support |
-|----------|-----------------|--------------|-------------------------|
-| Xcode 13 | 13.1            | October 2022 | >= 1.19.3 <2.7.2        |
-| Xcode 14 | 14.2            | October 2023 | >= 2.7.2                |
-| Xcode 15 | 15.4            | October 2024 | >= 3.0.0                |
-| Xcode 16 | 16.0            | October 2025 | >= 4.2.0                |
+| Xcode Version | iOS Version | Release Date   | End-of-Support Date | Parse Apple SDK Support |
+|---------------|-------------|----------------|---------------------|-------------------------|
+| Xcode 13      | iOS 15      | September 2021 | October 2022        | >= 1.19.3 <2.7.2        |
+| Xcode 14      | iOS 16      | September 2022 | October 2023        | >= 2.7.2                |
+| Xcode 15      | iOS 17      | September 2023 | October 2024        | >= 3.0.0                |
+| Xcode 16      | iOS 18      | September 2024 | tbd                 | >= 4.2.0                |
+| Xcode 17      | iOS 19      | tbd            | tbd                 | tbd                     |
 
 ## How Do I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ A library that gives you access to the powerful Parse Server backend from your i
 ---
 
 - [Getting Started](#getting-started)
+- [Compatibility](#compatibility)
+  - [Parse Server](#parse-server)
+  - [Xcode](#xcode)
 - [How Do I Contribute?](#how-do-i-contribute)
 - [Dependencies](#dependencies)
 
@@ -48,6 +51,27 @@ The easiest way to install the SDK is via Swift Package Manager.
 4. Choose the submodules you want to install
 
 Take a look at the public [documentation][docs] & [API][api] and start building.
+
+## Compatibility
+
+### Parse Server
+
+Parse Apple SDK is compatible with the following versions of Parse Server.
+
+| Parse Apple SDK | Parse Server |
+|-----------------|--------------|
+| 1.0.0           | >= 1.0.0     |
+
+### Xcode
+
+The Parse Apple SDK is continuously tested with the most recent releases of Xcode to ensure compatibility. We follow the annual release schedule of Xcode to support the current and previous major Xcode version.
+
+| Version  | Minimum Version | End-of-Life  | Parse Apple SDK Support |
+|----------|-----------------|--------------|-------------------------|
+| Xcode 13 | 13.1            | October 2022 | >= 1.19.3 <2.7.2        |
+| Xcode 14 | 14.2            | October 2023 | >= 2.7.2                |
+| Xcode 15 | 15.4            | October 2024 | >= 3.0.0                |
+| Xcode 16 | 16.0            | October 2025 | >= 4.2.0                |
 
 ## How Do I Contribute?
 


### PR DESCRIPTION
Did some git research to find out which releases added official testing in the CI for a specific Xcode version. I attempted to infer the iOS, macOS, watchOS support dates from the Xcode support policy.

Closes: #1836 