### PR TITLE
fix: `Parse.setServer` doesn't properly validate URL

### DIFF
--- a/Parse/Parse.xcodeproj/xcshareddata/xcschemes/Parse-iOS.xcscheme
+++ b/Parse/Parse.xcodeproj/xcshareddata/xcschemes/Parse-iOS.xcscheme
@@ -96,9 +96,6 @@
                <Test
                   Identifier = "ParseClientConfigurationTests/testExtensionDataSharing">
                </Test>
-               <Test
-                  Identifier = "ParseClientConfigurationTests/testServerValidation">
-               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Parse/Parse/Source/ParseClientConfiguration.m
+++ b/Parse/Parse/Source/ParseClientConfiguration.m
@@ -69,8 +69,9 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 }
 
 - (void)setServer:(NSString *)server {
+    NSURL *url = [NSURL URLWithString:server];
     PFParameterAssert(server.length, @"Server should not be `nil`.");
-    PFParameterAssert([NSURL URLWithString:server], @"Server should be a valid URL.");
+    PFParameterAssert(url && url.scheme && url.host, @"Server should be a valid URL.");
     _server = [server copy];
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
ParseClientConfigurationTests.testServerValidation test is broken and was excluded from the test suite.

Closes: https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1837

### Approach
<!-- Add a description of the approach in this PR. -->
Improve url validation, we could also remove this check and leave it to the developer

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
