### PR TITLE
feat: Add support for login with additional auth data

### DIFF
--- a/Parse/Parse/Internal/Commands/PFRESTUserCommand.h
+++ b/Parse/Parse/Internal/Commands/PFRESTUserCommand.h
@@ -23,6 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
                                     password:(NSString *)password
                             revocableSession:(BOOL)revocableSessionEnabled
                                        error:(NSError **)error;
++ (instancetype)logInUserCommandWithUsername:(NSString *)username
+                                    password:(NSString *)password
+                                    authData:(NSDictionary *)authData
+                            revocableSession:(BOOL)revocableSessionEnabled
+                                       error:(NSError **)error;
 + (instancetype)serviceLoginUserCommandWithAuthenticationType:(NSString *)authenticationType
                                            authenticationData:(NSDictionary *)authenticationData
                                              revocableSession:(BOOL)revocableSessionEnabled

--- a/Parse/Parse/Internal/Commands/PFRESTUserCommand.m
+++ b/Parse/Parse/Internal/Commands/PFRESTUserCommand.m
@@ -65,6 +65,26 @@ static NSString *const PFRESTUserCommandRevocableSessionHeaderEnabledValue = @"1
                                 error:error];
 }
 
++ (instancetype)logInUserCommandWithUsername:(NSString *)username
+                                    password:(NSString *)password
+                            authData:(NSDictionary *)authData
+                            revocableSession:(BOOL)revocableSessionEnabled
+                                       error:(NSError **) error {
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
+        @"username" : username,
+        @"password" : password,
+        @"authData" : authData
+    }];
+    
+    return [self _commandWithHTTPPath:@"login"
+                           httpMethod:PFHTTPRequestMethodGET
+                           parameters:parameters
+                         sessionToken:nil
+                     revocableSession:revocableSessionEnabled
+                                error:error];
+}
+
+
 + (instancetype)serviceLoginUserCommandWithAuthenticationType:(NSString *)authenticationType
                                            authenticationData:(NSDictionary *)authenticationData
                                              revocableSession:(BOOL)revocableSessionEnabled

--- a/Parse/Parse/Internal/User/Controller/PFUserController.h
+++ b/Parse/Parse/Internal/User/Controller/PFUserController.h
@@ -38,6 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)logInCurrentUserAsyncWithUsername:(NSString *)username
                                      password:(NSString *)password
                              revocableSession:(BOOL)revocableSession;
+- (BFTask *)logInCurrentUserAsyncWithUsername:(NSString *)username
+                                     password:(NSString *)password
+                             authData:(NSDictionary *)authData
+                             revocableSession:(BOOL)revocableSession;
 
 //TODO: (nlutsenko) Move this method into PFUserAuthenticationController after PFUser is decoupled further.
 - (BFTask *)logInCurrentUserAsyncWithAuthType:(NSString *)authType

--- a/Parse/Parse/Source/PFUser.h
+++ b/Parse/Parse/Source/PFUser.h
@@ -167,6 +167,39 @@ typedef void(^PFUserLogoutResultBlock)(NSError *_Nullable error);
  */
 + (void)logInWithUsernameInBackground:(NSString *)username password:(NSString *)password block:(nullable PFUserResultBlock)block;
 
+/**
+ Makes an *asynchronous* request to login a user with specified credentials and additional data.
+
+ Returns an instance of the successfully logged in `PFUser`.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
+
+ @param username The username of the user.
+ @param password The password of the user.
+ @param authData Additional data to be sent with the login request.
+
+ @return The task, that encapsulates the work being done.
+ */
++ (BFTask<__kindof PFUser *> *)logInWithUsernameInBackground:(NSString *)username
+                                                    password:(NSString *)password
+                                              authData:(NSDictionary *)authData;
+
+/**
+ Makes an *asynchronous* request to log in a user with specified credentials and additional data.
+
+ Returns an instance of the successfully logged in `PFUser`.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
+
+ @param username The username of the user.
+ @param password The password of the user.
+ @param authData Additional data to be sent with the login request.
+ @param block The block to execute.
+ It should have the following argument signature: `^(PFUser *user, NSError *error)`.
+ */
++ (void)logInWithUsernameInBackground:(NSString *)username
+                          password:(NSString *)password
+                            authData:(NSDictionary *)authData
+                                    block:(nullable PFUserResultBlock)block;
+
 ///--------------------------------------
 #pragma mark - Becoming a User
 ///--------------------------------------

--- a/Parse/Tests/Unit/UserCommandTests.m
+++ b/Parse/Tests/Unit/UserCommandTests.m
@@ -41,6 +41,35 @@
     XCTAssertFalse(command.revocableSessionEnabled);
 }
 
+- (void)testLogInCommandWithAuthData {
+    NSDictionary *authData = @{ @"mfa" : @{ @"token" : @"000000" } };
+    PFRESTUserCommand *command = [PFRESTUserCommand logInUserCommandWithUsername:@"a"
+                                                                        password:@"b"
+                                                                        authData:authData
+                                                                revocableSession:YES
+                                                                           error:nil];
+    XCTAssertNotNil(command);
+    XCTAssertEqualObjects(command.httpPath, @"login");
+    XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodGET);
+    XCTAssertNotNil(command.parameters);
+    XCTAssertNotNil(command.parameters[@"username"]);
+    XCTAssertNotNil(command.parameters[@"password"]);
+    XCTAssertNotNil(command.parameters[@"authData"]);
+    XCTAssertEqualObjects(command.parameters[@"authData"], authData);
+    XCTAssertEqual(command.additionalRequestHeaders.count, 1);
+    XCTAssertTrue(command.revocableSessionEnabled);
+    XCTAssertNil(command.sessionToken);
+
+    command = [PFRESTUserCommand logInUserCommandWithUsername:@"a"
+                                                     password:@"b"
+                                                     authData:authData
+                                             revocableSession:NO
+                                                        error:nil];
+    XCTAssertNotNil(command);
+    XCTAssertEqual(command.additionalRequestHeaders.count, 0);
+    XCTAssertFalse(command.revocableSessionEnabled);
+}
+
 - (void)testServiceLoginCommandWithAuthTypeData {
     PFRESTUserCommand *command = [PFRESTUserCommand serviceLoginUserCommandWithAuthenticationType:@"a"
                                                                                authenticationData:@{ @"b" : @"c" }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
Login with additional `authData` to allow multi-factor authentication (MFA).

Closes: #1839

### Approach
A `logInWithUsernameInBackground` function is added that takes additional `authData`.  

In order to prevent the SDK from passing the `mfa` object when saving the user the `_convertToDictionaryForSaving` function was updated to exclude the `mfa` object.

The login function can be called like this: 

`PFUser.logInWithUsername(inBackground: username, password: password, authData: ["mfa": ["token": authCode]])`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
